### PR TITLE
fix(bim): COLLADA namespace prefix crashes viewer + degraded model status

### DIFF
--- a/backend/app/modules/bim_hub/ifc_processor.py
+++ b/backend/app/modules/bim_hub/ifc_processor.py
@@ -3197,6 +3197,17 @@ def _patch_collada_node_names(dae_path: Path) -> int:
 
     if patched > 0:
         ET.indent(tree, space="  ")
+        # Register COLLADA namespace as the default (empty prefix) so
+        # tree.write() emits <COLLADA xmlns="..."> instead of
+        # <ns0:COLLADA xmlns:ns0="...">.  Python ET emits the ns0: form when
+        # the namespace is not in the global prefix registry, which causes the
+        # frontend's literal "<COLLADA" text-scan to reject the file with
+        # "Not a COLLADA document".
+        # NOTE: default_namespace= cannot be used here — Python ET rejects it
+        # whenever any element or attribute carries a non-qualified name
+        # (e.g. the `version` attribute on <COLLADA>): ValueError "cannot use
+        # non-qualified names with default_namespace option".
+        ET.register_namespace("", _COLLADA_NS)
         tree.write(str(dae_path), xml_declaration=True, encoding="utf-8")
         logger.info(
             "Patched %d COLLADA node name attributes to match id in %s",

--- a/frontend/src/features/bim/BIMPage.tsx
+++ b/frontend/src/features/bim/BIMPage.tsx
@@ -273,21 +273,25 @@ function ModelCard({ model, isActive, onClick, onDelete }: {
 
   const statusDot = model.status === 'ready'
     ? 'bg-emerald-500'
-    : isProcessing
-      ? 'bg-amber-400 animate-pulse'
-      : isError
-        ? 'bg-red-400'
-        : 'bg-gray-400';
+    : model.status === 'degraded'
+      ? 'bg-amber-500'
+      : isProcessing
+        ? 'bg-amber-400 animate-pulse'
+        : isError
+          ? 'bg-red-400'
+          : 'bg-gray-400';
 
   const statusLabel = model.status === 'ready'
     ? t('bim.status_ready', { defaultValue: 'Ready' })
-    : model.status === 'needs_converter'
-      ? t('bim.status_needs_converter', { defaultValue: 'Needs Converter' })
-      : model.status === 'processing'
-        ? t('bim.status_processing', { defaultValue: 'Processing' })
-        : model.status === 'error'
-          ? t('bim.status_error', { defaultValue: 'Error' })
-          : model.status;
+    : model.status === 'degraded'
+      ? t('bim.status_degraded', { defaultValue: 'Imported (no quantities)' })
+      : model.status === 'needs_converter'
+        ? t('bim.status_needs_converter', { defaultValue: 'Needs Converter' })
+        : model.status === 'processing'
+          ? t('bim.status_processing', { defaultValue: 'Processing' })
+          : model.status === 'error'
+            ? t('bim.status_error', { defaultValue: 'Error' })
+            : model.status;
 
   // The card itself acts as a button (click selects the model). We render
   // it as a <div role="button"> so the inner delete button can stay a real
@@ -1565,9 +1569,10 @@ function LandingPage({ projectId, onUploadComplete: _onUploadComplete, breadcrum
             {(landingModels ?? []).map((m) => {
               const fmt = (m.model_format || m.format || '').toUpperCase();
               const isReady = m.status === 'ready';
+              const isDegraded = m.status === 'degraded';
               const isProcessing = m.status === 'processing';
               const isError = m.status === 'error' || m.status === 'needs_converter';
-              const statusDot = isReady ? 'bg-emerald-500' : isProcessing ? 'bg-amber-400 animate-pulse' : isError ? 'bg-red-400' : 'bg-gray-400';
+              const statusDot = isReady ? 'bg-emerald-500' : isDegraded ? 'bg-amber-500' : isProcessing ? 'bg-amber-400 animate-pulse' : isError ? 'bg-red-400' : 'bg-gray-400';
 
               return (
                 <button
@@ -1597,7 +1602,7 @@ function LandingPage({ projectId, onUploadComplete: _onUploadComplete, breadcrum
                     <div className="flex items-center gap-2 text-[10px] text-content-quaternary">
                       <span className="flex items-center gap-1">
                         <span className={`w-1.5 h-1.5 rounded-full ${statusDot}`} />
-                        {isReady ? t('bim.status_ready', { defaultValue: 'Ready' }) : isProcessing ? t('bim.status_processing', { defaultValue: 'Processing' }) : m.status}
+                        {isReady ? t('bim.status_ready', { defaultValue: 'Ready' }) : isDegraded ? t('bim.status_degraded', { defaultValue: 'Imported (no quantities)' }) : isProcessing ? t('bim.status_processing', { defaultValue: 'Processing' }) : m.status}
                       </span>
                       {(m.element_count ?? 0) > 0 && (
                         <>
@@ -1950,7 +1955,10 @@ export function BIMPage() {
     // an upload) used to surface a misleading "Failed to load model elements"
     // toast — the inline NonReadyOverlay now drives the UI for non-ready
     // states and the elements query waits its turn.
-    enabled: !!activeModelId && activeModel?.status === 'ready',
+    // 'degraded' models have geometry + elements in the DB (imported but DDC
+    // converter absent or no quantities extracted) — show them in the viewer
+    // with the existing converter-absent warning banner.
+    enabled: !!activeModelId && (activeModel?.status === 'ready' || activeModel?.status === 'degraded'),
   });
   const elements: BIMElementData[] = elementsQuery.data?.items ?? [];
   const elementsTotal: number = elementsQuery.data?.total ?? 0;
@@ -2066,9 +2074,11 @@ export function BIMPage() {
   // The ?token= param authenticates the request (Three.js can't set headers).
   // Cache-bust with model updated_at to ensure fresh geometry after re-upload.
   const geometryUrl = useMemo(() => {
+    const modelIsViewable =
+      activeModel?.status === 'ready' || activeModel?.status === 'degraded';
     if (
       !activeModelId ||
-      activeModel?.status !== 'ready' ||
+      !modelIsViewable ||
       ((activeModel?.element_count ?? 0) === 0 && !elements.some((el) => !!el.mesh_ref))
     ) {
       return null;

--- a/frontend/src/shared/ui/BIMViewer/ElementManager.ts
+++ b/frontend/src/shared/ui/BIMViewer/ElementManager.ts
@@ -34,8 +34,10 @@ const inFlightGeometryFetches = new Map<
  *
  * - GLB: bytes 0..3 == ASCII 'glTF' (0x67 0x6c 0x54 0x46)
  * - DAE: first 4 KiB (after optional UTF-8 BOM + XML decl) contains
- *   ``<COLLADA`` somewhere; case-insensitive because some exporters
- *   write ``<Collada``.
+ *   a ``<COLLADA`` root tag; case-insensitive and namespace-prefix-tolerant
+ *   (matches ``<ns0:COLLADA`` as well as the bare ``<COLLADA`` form).
+ *   Python ElementTree without ET.register_namespace() serialises the
+ *   namespace-prefixed form; both are valid COLLADA.
  */
 function detectGeometryKind(buffer: ArrayBuffer): 'glb' | 'dae' | null {
   if (buffer.byteLength < 12) return null;
@@ -50,7 +52,9 @@ function detectGeometryKind(buffer: ArrayBuffer): 'glb' | 'dae' | null {
   );
   // Strip BOM for the check.
   const stripped = head.charCodeAt(0) === 0xfeff ? head.slice(1) : head;
-  if (/<COLLADA[\s>]/i.test(stripped)) return 'dae';
+  // Match bare <COLLADA and namespace-prefixed <ns0:COLLADA (Python ET
+  // without register_namespace() serialises the latter).
+  if (/<(?:[A-Za-z0-9_-]+:)?COLLADA[\s>]/i.test(stripped)) return 'dae';
   return null;
 }
 
@@ -1047,7 +1051,9 @@ export class ElementManager {
         // walker explodes with the unhelpful "reading 'getAttribute'"
         // error somewhere inside the parser instead of telling us it's
         // not COLLADA. Bail out early with a clear message.
-        if (!/<COLLADA[\s>]/i.test(text.slice(0, 4096))) {
+        // The regex also accepts namespace-prefixed forms such as
+        // "<ns0:COLLADA" (produced by Python ET without register_namespace()).
+        if (!/<(?:[A-Za-z0-9_-]+:)?COLLADA[\s>]/i.test(text.slice(0, 4096))) {
           reject(new Error('Not a COLLADA document — <COLLADA> root tag not found in first 4096 chars'));
           return;
         }


### PR DESCRIPTION
## Context

Three bugs left the BIM viewer blank or misleading after a successful CAD
conversion. All three are independent of the DDC CLI compatibility work
already merged — they affect the geometry serialisation and the frontend
rendering layer.

---

## Bug 1 — Python ElementTree writes `<ns0:COLLADA>` prefix, viewer rejects the file

**File:** `backend/app/modules/bim_hub/ifc_processor.py`

**Problem:**
`_patch_collada_node_names()` calls `ET.write()` without registering a
default namespace. Python ElementTree then serialises the root element as
`<ns0:COLLADA xmlns:ns0="...">` instead of `<COLLADA xmlns="...">`.
The frontend's literal `<COLLADA` text-scan (in both `detectGeometryKind`
and `parseDAEBuffer`) rejected the file with *"Not a COLLADA document"*,
leaving the viewer blank even when the DAE file was fully valid.

**Fix:**
Added `ET.register_namespace("", _COLLADA_NS)` before `tree.write()` in
`_patch_collada_node_names()` so the output always carries the bare root tag.

> **Note:** `default_namespace=` cannot be used — Python ET raises
> `ValueError: cannot use non-qualified names with default_namespace option`
> when any element carries a non-qualified attribute (e.g. `version` on
> `<COLLADA>`).

---

## Bug 2 — Frontend COLLADA regex does not match namespace-prefixed root tag

**File:** `frontend/src/shared/ui/BIMViewer/ElementManager.ts`

**Problem:**
Two places used `/<COLLADA[\s>]/i`:
- `detectGeometryKind()` — decides whether the buffer is DAE or GLB
- `parseDAEBuffer()` — structural pre-check before ColladaLoader

Neither matches `<ns0:COLLADA`, so any DAE produced by Python ET without
`register_namespace` was silently rejected on the frontend side.

**Fix:**
Updated both regexes to `/<(?:[A-Za-z0-9_-]+:)?COLLADA[\s>]/i` — accepts
both the canonical and namespace-prefixed forms as a defence-in-depth
measure.

---

## Bug 3 — `degraded` model status not handled in the BIM viewer UI

**File:** `frontend/src/features/bim/BIMPage.tsx`

**Problem:**
Models with `status = "degraded"` (geometry imported, quantity extraction
failed) were not recognised as viewable:
- Elements React Query disabled → blank panel
- `geometryUrl` resolved to `null` → viewer never loaded geometry
- Status indicators fell through to grey dot + raw string `"degraded"`

**Fix:**
- Elements query enabled for `ready || degraded`
- `geometryUrl` computed for both statuses via `modelIsViewable` boolean
- Status dot: solid amber `bg-amber-500` (distinct from pulsing amber of
  in-progress and green of ready)
- Status label: *"Imported (no quantities)"* (i18n key `bim.status_degraded`)
- Applied in both `ModelCard` and `LandingPage`

---

## Test plan

- [ ] Upload RVT/IFC with DDC converter → geometry loads in viewer (Bug 1+2)
- [ ] Inspect DAE on disk → root element is `<COLLADA xmlns="...">` without prefix
- [ ] Set a model to `status = degraded` → amber dot + "Imported (no quantities)", geometry loads
- [ ] Verify `status = ready` models unaffected
