### PR TITLE
Fix/user access management

### DIFF
--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -413,12 +413,16 @@ async def verify_project_access(
     user_id: str,
     session: AsyncSession,
 ) -> None:
-    """Verify user owns or has admin access to the project.
+    """Verify user has access to the project: owner, admin, or team member.
 
-    Raises HTTP 404 on both "project missing" and "access denied" to avoid
-    leaking the existence of UUIDs the caller is not allowed to see.
+    Raises HTTP 404 on "project missing" and HTTP 403 on "access denied".
+    Team membership (added via add_project_member) grants the same read/write
+    access as ownership within the caller's RBAC role.
     """
+    from sqlalchemy import select as _select
+
     from app.modules.projects.repository import ProjectRepository
+    from app.modules.teams.models import Team, TeamMembership
     from app.modules.users.repository import UserRepository
 
     proj_repo = ProjectRepository(session)
@@ -438,11 +442,32 @@ async def verify_project_access(
     except Exception:
         logger.exception("Admin-role lookup failed during project access check")
 
-    if str(getattr(project, "owner_id", "")) != str(user_id):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Project not found",
-        )
+    # Owner has full access.
+    if str(getattr(project, "owner_id", "")) == str(user_id):
+        return
+
+    # Team-member check — any TeamMembership row for this project grants access.
+    try:
+        member_row = (
+            await session.execute(
+                _select(TeamMembership.id)
+                .join(Team, Team.id == TeamMembership.team_id)
+                .where(
+                    Team.project_id == project_id,
+                    TeamMembership.user_id == _uuid.UUID(str(user_id)),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if member_row is not None:
+            return
+    except Exception:
+        logger.exception("Team-membership lookup failed during project access check")
+
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="You do not have access to this project",
+    )
 
 
 # ── Locale resolution (per-request, for HTTPException i18n) ────────────────

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -413,16 +413,16 @@ async def verify_project_access(
     user_id: str,
     session: AsyncSession,
 ) -> None:
-    """Verify user has access to the project: owner, admin, or team member.
+    """Verify user owns or has admin / team-member access to the project.
 
-    Raises HTTP 404 on "project missing" and HTTP 403 on "access denied".
+    Raises HTTP 404 on both "project missing" and "access denied" to avoid
+    leaking the existence of UUIDs the caller is not allowed to see (IDOR
+    defence — same policy as all downstream modules that call this helper).
     Team membership (added via add_project_member) grants the same read/write
     access as ownership within the caller's RBAC role.
     """
-    from sqlalchemy import select as _select
-
     from app.modules.projects.repository import ProjectRepository
-    from app.modules.teams.models import Team, TeamMembership
+    from app.modules.teams.access import is_project_member
     from app.modules.users.repository import UserRepository
 
     proj_repo = ProjectRepository(session)
@@ -448,25 +448,18 @@ async def verify_project_access(
 
     # Team-member check — any TeamMembership row for this project grants access.
     try:
-        member_row = (
-            await session.execute(
-                _select(TeamMembership.id)
-                .join(Team, Team.id == TeamMembership.team_id)
-                .where(
-                    Team.project_id == project_id,
-                    TeamMembership.user_id == _uuid.UUID(str(user_id)),
-                )
-                .limit(1)
-            )
-        ).scalar_one_or_none()
-        if member_row is not None:
+        if await is_project_member(session, project_id, _uuid.UUID(str(user_id))):
             return
+    except (ValueError, TypeError):
+        pass  # malformed user_id — fall through to 404
     except Exception:
         logger.exception("Team-membership lookup failed during project access check")
 
+    # 404 (not 403) — keeps "resource missing" and "access denied"
+    # indistinguishable, preventing UUID-existence oracle attacks.
     raise HTTPException(
-        status_code=status.HTTP_403_FORBIDDEN,
-        detail="You do not have access to this project",
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Project not found",
     )
 
 

--- a/backend/app/modules/boq/router.py
+++ b/backend/app/modules/boq/router.py
@@ -185,15 +185,37 @@ def _get_service(session: SessionDep) -> BOQService:
     return BOQService(session)
 
 
+async def _is_project_member(session: SessionDep, project_id: uuid.UUID, user_id: str) -> bool:
+    """Return True if user_id has a TeamMembership row for the given project."""
+    from sqlalchemy import select
+
+    from app.modules.teams.models import Team, TeamMembership
+
+    row = (
+        await session.execute(
+            select(TeamMembership.id)
+            .join(Team, Team.id == TeamMembership.team_id)
+            .where(
+                Team.project_id == project_id,
+                TeamMembership.user_id == uuid.UUID(user_id),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    return row is not None
+
+
 async def _verify_boq_owner(
     session: SessionDep,
     boq_id: uuid.UUID,
     user_id: str,
     payload: dict | None = None,
 ) -> None:
-    """‌⁠‍Load a BOQ, then its project, and verify ownership.
+    """‌⁠‍Load a BOQ, then its project, and verify the user has access.
 
-    Admins bypass the check. Raises 403 if the user is not the project owner.
+    Admins bypass the check. Grants access to the project owner and to
+    any user who is a team member of the project (added via add_project_member).
+    Raises 403 if none of those conditions are met.
     """
     if payload and payload.get("role") == "admin":
         return
@@ -207,14 +229,15 @@ async def _verify_boq_owner(
     project_repo = ProjectRepository(session)
     project = await project_repo.get_by_id(boq.project_id)
     if project is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail=translate("errors.project_not_found", locale=get_locale())
-        )
-    if str(project.owner_id) != user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have access to this BOQ",
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=translate("errors.project_not_found", locale=get_locale()))
+    if str(project.owner_id) == user_id:
+        return
+    if await _is_project_member(session, boq.project_id, user_id):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="You do not have access to this BOQ",
+    )
 
 
 async def _verify_project_owner_for_boq(
@@ -223,8 +246,9 @@ async def _verify_project_owner_for_boq(
     user_id: str,
     payload: dict | None = None,
 ) -> None:
-    """‌⁠‍Verify the current user owns the given project. Admins bypass.
+    """‌⁠‍Verify the current user has access to the given project.
 
+    Grants access to: admins, the project owner, and team members.
     Treats archived (soft-deleted) projects as 404 — no operations on
     archived projects are permitted via this gateway.
     """
@@ -239,11 +263,14 @@ async def _verify_project_owner_for_boq(
         )
     if is_admin:
         return
-    if str(project.owner_id) != user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have access to this project",
-        )
+    if str(project.owner_id) == user_id:
+        return
+    if await _is_project_member(session, project_id, user_id):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="You do not have access to this project",
+    )
 
 
 async def _log_activity(

--- a/backend/app/modules/boq/router.py
+++ b/backend/app/modules/boq/router.py
@@ -5281,7 +5281,7 @@ async def import_boq_gaeb(
 
 async def _persist_imported_boq(
     boq_id: uuid.UUID,
-    imported: "ImportedBOQ",
+    imported: "ImportedBOQ",  # noqa: F821 — imported inside function body at call site
     *,
     file_name: str,
     service: BOQService,

--- a/backend/app/modules/boq/router.py
+++ b/backend/app/modules/boq/router.py
@@ -185,26 +185,6 @@ def _get_service(session: SessionDep) -> BOQService:
     return BOQService(session)
 
 
-async def _is_project_member(session: SessionDep, project_id: uuid.UUID, user_id: str) -> bool:
-    """Return True if user_id has a TeamMembership row for the given project."""
-    from sqlalchemy import select
-
-    from app.modules.teams.models import Team, TeamMembership
-
-    row = (
-        await session.execute(
-            select(TeamMembership.id)
-            .join(Team, Team.id == TeamMembership.team_id)
-            .where(
-                Team.project_id == project_id,
-                TeamMembership.user_id == uuid.UUID(user_id),
-            )
-            .limit(1)
-        )
-    ).scalar_one_or_none()
-    return row is not None
-
-
 async def _verify_boq_owner(
     session: SessionDep,
     boq_id: uuid.UUID,
@@ -232,7 +212,13 @@ async def _verify_boq_owner(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=translate("errors.project_not_found", locale=get_locale()))
     if str(project.owner_id) == user_id:
         return
-    if await _is_project_member(session, boq.project_id, user_id):
+    from app.modules.teams.access import is_project_member
+
+    try:
+        uid = uuid.UUID(str(user_id))
+    except (ValueError, TypeError):
+        uid = None
+    if uid is not None and await is_project_member(session, boq.project_id, uid):
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,
@@ -265,7 +251,13 @@ async def _verify_project_owner_for_boq(
         return
     if str(project.owner_id) == user_id:
         return
-    if await _is_project_member(session, project_id, user_id):
+    from app.modules.teams.access import is_project_member
+
+    try:
+        uid = uuid.UUID(str(user_id))
+    except (ValueError, TypeError):
+        uid = None
+    if uid is not None and await is_project_member(session, project_id, uid):
         return
     raise HTTPException(
         status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/app/modules/projects/repository.py
+++ b/backend/app/modules/projects/repository.py
@@ -41,19 +41,13 @@ class ProjectRepository:
         Archived (soft-deleted) projects are excluded by default; pass an
         explicit `status` to override.
         """
-        from app.modules.teams.models import Team, TeamMembership
+        from app.modules.teams.access import member_project_ids_subquery
 
         base = select(Project)
         if not is_admin:
-            # Subquery: project_ids where user is a team member
-            member_project_ids = (
-                select(Team.project_id)
-                .join(TeamMembership, TeamMembership.team_id == Team.id)
-                .where(TeamMembership.user_id == owner_id)
-                .scalar_subquery()
-            )
             base = base.where(
-                (Project.owner_id == owner_id) | (Project.id.in_(member_project_ids))
+                (Project.owner_id == owner_id)
+                | (Project.id.in_(member_project_ids_subquery(owner_id)))
             )
         if status is not None:
             base = base.where(Project.status == status)

--- a/backend/app/modules/projects/repository.py
+++ b/backend/app/modules/projects/repository.py
@@ -36,13 +36,25 @@ class ProjectRepository:
     ) -> tuple[list[Project], int]:
         """List projects for a user with pagination. Returns (projects, total_count).
 
-        Admins see all projects; regular users see only their own.
+        Admins see all projects; regular users see projects they own OR
+        where they are a team member (added via add_project_member).
         Archived (soft-deleted) projects are excluded by default; pass an
         explicit `status` to override.
         """
+        from app.modules.teams.models import Team, TeamMembership
+
         base = select(Project)
         if not is_admin:
-            base = base.where(Project.owner_id == owner_id)
+            # Subquery: project_ids where user is a team member
+            member_project_ids = (
+                select(Team.project_id)
+                .join(TeamMembership, TeamMembership.team_id == Team.id)
+                .where(TeamMembership.user_id == owner_id)
+                .scalar_subquery()
+            )
+            base = base.where(
+                (Project.owner_id == owner_id) | (Project.id.in_(member_project_ids))
+            )
         if status is not None:
             base = base.where(Project.status == status)
         elif exclude_archived:

--- a/backend/app/modules/projects/router.py
+++ b/backend/app/modules/projects/router.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from fastapi import APIRouter, Body, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import Response
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import CurrentUserId, CurrentUserPayload, SessionDep, SettingsDep
 from app.modules.projects import profile_service
@@ -125,7 +126,7 @@ async def _verify_project_access(
     service: ProjectService,
     project_id: uuid.UUID,
     user_id: str,
-    session: object,
+    session: AsyncSession,
     payload: dict | None = None,
 ) -> object:
     """‌⁠‍Load a project and verify the current user has read access.
@@ -133,8 +134,11 @@ async def _verify_project_access(
     Grants access to: admins, the project owner, and any team member
     added via add_project_member (i.e. a TeamMembership row exists).
     Used for read operations (get, dashboard, list members, etc.).
+
+    Raises 404 (not 403) on denial to keep "missing" and "denied"
+    indistinguishable — same IDOR policy as verify_project_access.
     """
-    from app.modules.teams.models import Team, TeamMembership
+    from app.modules.teams.access import is_project_member
 
     project = await service.get_project(project_id)
 
@@ -146,25 +150,20 @@ async def _verify_project_access(
     if str(project.owner_id) == user_id:
         return project
 
-    # Team-member check — any membership row for this project grants read access
-    member_row = (
-        await session.execute(
-            select(TeamMembership.id)
-            .join(Team, Team.id == TeamMembership.team_id)
-            .where(
-                Team.project_id == project_id,
-                TeamMembership.user_id == uuid.UUID(user_id),
-            )
-            .limit(1)
-        )
-    ).scalar_one_or_none()
+    # Team-member check — any membership row for this project grants read access.
+    # Wrap UUID conversion so a malformed user_id yields 404, not 500.
+    try:
+        uid = uuid.UUID(str(user_id))
+    except (ValueError, TypeError):
+        uid = None
 
-    if member_row is None:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="You do not have access to this project",
-        )
-    return project
+    if uid is not None and await is_project_member(session, project_id, uid):
+        return project
+
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Project not found",
+    )
 
 
 # ── Create ────────────────────────────────────────────────────────────────
@@ -1455,18 +1454,16 @@ async def dashboard_cards(
             select(Project).where(Project.status != "archived").order_by(Project.updated_at.desc())
         )
     else:
-        from app.modules.teams.models import Team, TeamMembership
+        from app.modules.teams.access import member_project_ids_subquery
 
-        member_project_ids = (
-            select(Team.project_id)
-            .join(TeamMembership, TeamMembership.team_id == Team.id)
-            .where(TeamMembership.user_id == uuid.UUID(user_id))
-            .scalar_subquery()
-        )
+        try:
+            uid = uuid.UUID(user_id)
+        except (ValueError, TypeError):
+            return []
         proj_result = await session.execute(
             select(Project)
             .where(
-                (Project.owner_id == uuid.UUID(user_id)) | (Project.id.in_(member_project_ids)),
+                (Project.owner_id == uid) | (Project.id.in_(member_project_ids_subquery(uid))),
                 Project.status != "archived",
             )
             .order_by(Project.updated_at.desc())
@@ -1688,16 +1685,14 @@ async def analytics_overview(
     # Per-project summary — owner + team-member projects for non-admins
     proj_stmt = select(Project).order_by(Project.name)
     if not is_admin:
-        from app.modules.teams.models import Team, TeamMembership
+        from app.modules.teams.access import member_project_ids_subquery
 
-        member_project_ids = (
-            select(Team.project_id)
-            .join(TeamMembership, TeamMembership.team_id == Team.id)
-            .where(TeamMembership.user_id == uuid.UUID(_user_id))
-            .scalar_subquery()
-        )
+        try:
+            _uid = uuid.UUID(_user_id)
+        except (ValueError, TypeError):
+            return {}
         proj_stmt = proj_stmt.where(
-            (Project.owner_id == _user_id) | (Project.id.in_(member_project_ids))
+            (Project.owner_id == _uid) | (Project.id.in_(member_project_ids_subquery(_uid)))
         )
     proj_result = await session.execute(proj_stmt)
     all_projects = list(proj_result.scalars().all())

--- a/backend/app/modules/projects/router.py
+++ b/backend/app/modules/projects/router.py
@@ -107,12 +107,59 @@ async def _verify_project_owner(
 
     Admins (role=admin in JWT payload) bypass the ownership check.
     Returns the project object on success, raises 403 if not owner.
+    Used for write operations (update, delete, add/remove member, etc.).
     """
     project = await service.get_project(project_id)
     # Admin bypass
     if payload and payload.get("role") == "admin":
         return project
     if str(project.owner_id) != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have access to this project",
+        )
+    return project
+
+
+async def _verify_project_access(
+    service: ProjectService,
+    project_id: uuid.UUID,
+    user_id: str,
+    session: object,
+    payload: dict | None = None,
+) -> object:
+    """‌⁠‍Load a project and verify the current user has read access.
+
+    Grants access to: admins, the project owner, and any team member
+    added via add_project_member (i.e. a TeamMembership row exists).
+    Used for read operations (get, dashboard, list members, etc.).
+    """
+    from app.modules.teams.models import Team, TeamMembership
+
+    project = await service.get_project(project_id)
+
+    # Admin bypass
+    if payload and payload.get("role") == "admin":
+        return project
+
+    # Owner has full access
+    if str(project.owner_id) == user_id:
+        return project
+
+    # Team-member check — any membership row for this project grants read access
+    member_row = (
+        await session.execute(
+            select(TeamMembership.id)
+            .join(Team, Team.id == TeamMembership.team_id)
+            .where(
+                Team.project_id == project_id,
+                TeamMembership.user_id == uuid.UUID(user_id),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if member_row is None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="You do not have access to this project",
@@ -196,10 +243,11 @@ async def get_project(
     project_id: uuid.UUID,
     user_id: CurrentUserId,
     payload: CurrentUserPayload,
+    session: SessionDep,
     service: ProjectService = Depends(_get_service),
 ) -> ProjectResponse:
-    """Get project by ID. Verifies ownership."""
-    project = await _verify_project_owner(service, project_id, user_id, payload)
+    """Get project by ID. Accessible by owner, admin, or project team member."""
+    project = await _verify_project_access(service, project_id, user_id, session, payload)
     return ProjectResponse.model_validate(project)
 
 
@@ -372,8 +420,8 @@ async def list_project_members_endpoint(
     session: SessionDep,
     service: ProjectService = Depends(_get_service),
 ) -> list[ProjectMemberResponse]:
-    """List members of a project. Owner / admin only — 403 otherwise."""
-    await _verify_project_owner(service, project_id, user_id, payload)
+    """List members of a project. Accessible by owner, admin, or any team member."""
+    await _verify_project_access(service, project_id, user_id, session, payload)
     from app.modules.projects.member_service import list_project_members
 
     return await list_project_members(session, project_id)
@@ -617,8 +665,8 @@ async def project_dashboard(
     from sqlalchemy import Float, func, literal_column, select, union_all
     from sqlalchemy.sql.expression import cast
 
-    # Verify ownership / admin access
-    project = await _verify_project_owner(service, project_id, user_id, payload)
+    # Verify read access — owner, admin, or team member
+    project = await _verify_project_access(service, project_id, user_id, session, payload)
 
     # ── Helper: safe query wrapper ──────────────────────────────
     async def _safe(coro, default=None):  # noqa: ANN001, ANN202
@@ -1400,16 +1448,27 @@ async def dashboard_cards(
 
     from app.modules.projects.models import Project
 
-    # Fetch all projects (admin sees all, regular user sees own)
+    # Fetch all projects (admin sees all, regular user sees owned + member projects)
     is_admin = payload.get("role") == "admin"
     if is_admin:
         proj_result = await session.execute(
             select(Project).where(Project.status != "archived").order_by(Project.updated_at.desc())
         )
     else:
+        from app.modules.teams.models import Team, TeamMembership
+
+        member_project_ids = (
+            select(Team.project_id)
+            .join(TeamMembership, TeamMembership.team_id == Team.id)
+            .where(TeamMembership.user_id == uuid.UUID(user_id))
+            .scalar_subquery()
+        )
         proj_result = await session.execute(
             select(Project)
-            .where(Project.owner_id == uuid.UUID(user_id), Project.status != "archived")
+            .where(
+                (Project.owner_id == uuid.UUID(user_id)) | (Project.id.in_(member_project_ids)),
+                Project.status != "archived",
+            )
             .order_by(Project.updated_at.desc())
         )
     all_projects = proj_result.scalars().all()
@@ -1626,10 +1685,20 @@ async def analytics_overview(
 
     is_admin = bool(payload and payload.get("role") == "admin")
 
-    # Per-project summary — owner-scoped for non-admins
+    # Per-project summary — owner + team-member projects for non-admins
     proj_stmt = select(Project).order_by(Project.name)
     if not is_admin:
-        proj_stmt = proj_stmt.where(Project.owner_id == _user_id)
+        from app.modules.teams.models import Team, TeamMembership
+
+        member_project_ids = (
+            select(Team.project_id)
+            .join(TeamMembership, TeamMembership.team_id == Team.id)
+            .where(TeamMembership.user_id == uuid.UUID(_user_id))
+            .scalar_subquery()
+        )
+        proj_stmt = proj_stmt.where(
+            (Project.owner_id == _user_id) | (Project.id.in_(member_project_ids))
+        )
     proj_result = await session.execute(proj_stmt)
     all_projects = list(proj_result.scalars().all())
 

--- a/backend/app/modules/teams/access.py
+++ b/backend/app/modules/teams/access.py
@@ -1,0 +1,67 @@
+"""Reusable project-membership access helpers.
+
+Every module that needs to gate access behind team membership (projects,
+BOQ, HSE, Carbon, Variations, …) should route through these helpers rather
+than inlining a fresh copy of the TeamMembership query.
+
+Two helpers are provided:
+
+* :func:`is_project_member` — async boolean check used in route guards.
+* :func:`member_project_ids_subquery` — synchronous scalar subquery used
+  in ORM ``WHERE … IN (…)`` clauses for list/aggregate endpoints.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def is_project_member(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Return ``True`` if *user_id* has a :class:`TeamMembership` row for *project_id*.
+
+    Failures (DB errors, bad UUIDs that slipped through) are caught and
+    treated as *not a member* so callers never see an unexpected 500.
+    """
+    from app.modules.teams.models import Team, TeamMembership
+
+    try:
+        row = (
+            await session.execute(
+                select(TeamMembership.id)
+                .join(Team, Team.id == TeamMembership.team_id)
+                .where(
+                    Team.project_id == project_id,
+                    TeamMembership.user_id == user_id,
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        return row is not None
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def member_project_ids_subquery(user_id: uuid.UUID):
+    """Return a SQLAlchemy scalar subquery of project_ids where *user_id* is a member.
+
+    Intended for use in ORM ``WHERE`` clauses::
+
+        Project.id.in_(member_project_ids_subquery(user_id))
+
+    This is a *synchronous* factory — it returns a subquery object, not a
+    coroutine.  The actual DB round-trip happens when the parent query executes.
+    """
+    from app.modules.teams.models import Team, TeamMembership
+
+    return (
+        select(Team.project_id)
+        .join(TeamMembership, TeamMembership.team_id == Team.id)
+        .where(TeamMembership.user_id == user_id)
+        .scalar_subquery()
+    )

--- a/backend/tests/integration/test_team_member_project_access.py
+++ b/backend/tests/integration/test_team_member_project_access.py
@@ -1,0 +1,213 @@
+"""Team-member project access regression suite.
+
+Pins the access policy introduced in fix/user-access-management:
+users added via ``add_project_member`` must be able to read the
+projects and BOQs they were invited to, while uninvited users must
+still receive 404 (not 403 — IDOR defence: keep "missing" and "denied"
+indistinguishable, matching the ``verify_project_access`` convention).
+
+Test scaffolding mirrors ``test_erp_chat_idor.py``: a per-module temp
+SQLite file is wired up before ``app.database`` is imported so the
+production ``backend/openestimate.db`` is never touched.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import uuid
+from pathlib import Path
+
+# ── Per-module SQLite isolation (must run BEFORE app imports) ──────────────
+_TMP_DIR = Path(tempfile.mkdtemp(prefix="oe-team-access-"))
+_TMP_DB = _TMP_DIR / "team_access.db"
+os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{_TMP_DB.as_posix()}"
+os.environ["DATABASE_SYNC_URL"] = f"sqlite:///{_TMP_DB.as_posix()}"
+
+import pytest  # noqa: E402
+import pytest_asyncio  # noqa: E402
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+# ── App fixture ────────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_instance():
+    """Boot the FastAPI app once for the whole module."""
+    from app.config import get_settings
+
+    get_settings.cache_clear()
+
+    from app.main import create_app
+
+    app = create_app()
+
+    async with app.router.lifespan_context(app):
+        from app.database import Base, engine
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        yield app
+
+
+@pytest_asyncio.fixture(scope="module")
+async def http_client(app_instance):
+    transport = ASGITransport(app=app_instance)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+async def _activate_user(email: str) -> None:
+    """Force is_active=True so login works under admin-approve mode."""
+    from sqlalchemy import update
+
+    from app.database import async_session_factory
+    from app.modules.users.models import User
+
+    async with async_session_factory() as s:
+        await s.execute(
+            update(User).where(User.email == email.lower()).values(is_active=True)
+        )
+        await s.commit()
+
+
+async def _register_and_login(client: AsyncClient, suffix: str) -> tuple[str, dict[str, str]]:
+    """Register a fresh user, activate, login. Returns (user_id, auth_headers)."""
+    email = f"user-{suffix}-{uuid.uuid4().hex[:6]}@team-access.test"
+    password = f"TeamAccess{uuid.uuid4().hex[:6]}9!"
+
+    reg = await client.post(
+        "/api/v1/users/auth/register",
+        json={"email": email, "password": password, "full_name": f"User {suffix}"},
+    )
+    assert reg.status_code in (200, 201), f"register failed: {reg.text}"
+    user_id = reg.json()["id"]
+
+    await _activate_user(email)
+
+    login = await client.post(
+        "/api/v1/users/auth/login",
+        json={"email": email, "password": password},
+    )
+    assert login.status_code == 200, f"login failed: {login.text}"
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    return user_id, headers
+
+
+# ── Shared fixture: A owns a project + BOQ, B is invited, C is not ─────────
+
+
+@pytest_asyncio.fixture(scope="module")
+async def scenario(http_client):
+    """
+    A creates a project and a BOQ.
+    A adds B as a project member.
+    C is a separate user with no connection to the project.
+    """
+    a_id, a_headers = await _register_and_login(http_client, "A")
+    b_id, b_headers = await _register_and_login(http_client, "B")
+    _, c_headers = await _register_and_login(http_client, "C")
+
+    # A creates a project
+    proj_resp = await http_client.post(
+        "/api/v1/projects/",
+        json={"name": "Test Project", "currency": "EUR"},
+        headers=a_headers,
+    )
+    assert proj_resp.status_code in (200, 201), f"create project failed: {proj_resp.text}"
+    project_id = proj_resp.json()["id"]
+
+    # A adds B as a team member
+    add_resp = await http_client.post(
+        f"/api/v1/projects/{project_id}/members/",
+        json={"user_id": b_id, "role": "viewer"},
+        headers=a_headers,
+    )
+    assert add_resp.status_code in (200, 201), f"add member failed: {add_resp.text}"
+
+    # A creates a BOQ in the project
+    boq_resp = await http_client.post(
+        "/api/v1/boq/",
+        json={"project_id": project_id, "name": "Main BOQ"},
+        headers=a_headers,
+    )
+    assert boq_resp.status_code in (200, 201), f"create BOQ failed: {boq_resp.text}"
+    boq_id = boq_resp.json()["id"]
+
+    return {
+        "project_id": project_id,
+        "boq_id": boq_id,
+        "a_headers": a_headers,
+        "b_headers": b_headers,
+        "c_headers": c_headers,
+    }
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_team_member_can_list_project(http_client, scenario):
+    """B (team member) must see the project in GET /projects/."""
+    resp = await http_client.get("/api/v1/projects/", headers=scenario["b_headers"])
+    assert resp.status_code == 200
+    ids = [p["id"] for p in resp.json().get("projects", resp.json())]
+    assert scenario["project_id"] in ids, "team member's project missing from listing"
+
+
+@pytest.mark.asyncio
+async def test_team_member_can_get_project(http_client, scenario):
+    """B can call GET /projects/{id}, /dashboard, /members/ without 4xx."""
+    pid = scenario["project_id"]
+    headers = scenario["b_headers"]
+
+    get_resp = await http_client.get(f"/api/v1/projects/{pid}", headers=headers)
+    assert get_resp.status_code == 200, f"GET project: {get_resp.text}"
+
+    members_resp = await http_client.get(f"/api/v1/projects/{pid}/members/", headers=headers)
+    assert members_resp.status_code == 200, f"GET members: {members_resp.text}"
+
+    dash_resp = await http_client.get(f"/api/v1/projects/{pid}/dashboard", headers=headers)
+    assert dash_resp.status_code == 200, f"GET dashboard: {dash_resp.text}"
+
+
+@pytest.mark.asyncio
+async def test_team_member_can_access_boq(http_client, scenario):
+    """B can read BOQs under the project."""
+    boq_id = scenario["boq_id"]
+    headers = scenario["b_headers"]
+
+    list_resp = await http_client.get(
+        f"/api/v1/boq/?project_id={scenario['project_id']}", headers=headers
+    )
+    assert list_resp.status_code == 200, f"list BOQs: {list_resp.text}"
+
+    get_resp = await http_client.get(f"/api/v1/boq/{boq_id}", headers=headers)
+    assert get_resp.status_code == 200, f"GET BOQ: {get_resp.text}"
+
+
+@pytest.mark.asyncio
+async def test_uninvolved_user_still_404_via_verify_project_access(http_client, scenario):
+    """C (no membership) must receive 404 — not 403 — to prevent UUID-oracle attacks."""
+    pid = scenario["project_id"]
+    headers = scenario["c_headers"]
+
+    get_resp = await http_client.get(f"/api/v1/projects/{pid}", headers=headers)
+    assert get_resp.status_code == 404, (
+        f"Expected 404 for uninvolved user (IDOR defence), got {get_resp.status_code}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_member_dashboard_cards_includes_member_projects(http_client, scenario):
+    """B's dashboard_cards response must include the project A invited them to."""
+    resp = await http_client.get("/api/v1/projects/dashboard-cards", headers=scenario["b_headers"])
+    assert resp.status_code == 200, f"dashboard-cards failed: {resp.text}"
+    ids = [p.get("id") or p.get("project_id") for p in resp.json()]
+    assert scenario["project_id"] in ids, (
+        "invited project missing from team member's dashboard cards"
+    )


### PR DESCRIPTION
## Bugs fixed

### 🐛 Bug 1 — Silent failure when saving user module access preferences

**File:** `backend/app/modules/users/router.py`

**Root cause:** `set_user_module_access` was calling `service.update_profile(user_id, metadata=metadata)` but the correct parameter name is `metadata_`. Python silently discarded the argument, so module access preferences were never persisted to the database — the endpoint returned 200 but nothing was saved.

**Fix:** Renamed the keyword argument from `metadata=` to `metadata_=`.

---

### 🐛 Bug 2 — Team members blocked from accessing projects and BOQs they were invited to

**Files:** `backend/app/dependencies.py`, `backend/app/modules/projects/repository.py`, `backend/app/modules/projects/router.py`, `backend/app/modules/boq/router.py`

**Root cause:** Every access check was gating on `owner_id` only. Users added via `add_project_member` (i.e. with a `TeamMembership` row) received a 403/404 on all project-related endpoints.

Affected endpoints:
- `GET /projects/` — team-member projects not included in listing
- `GET /projects/{id}` — 403 for team members
- `GET /projects/{id}/dashboard` — 403 for team members
- `GET /projects/{id}/members` — 403 for team members
- `GET /boq/`, `GET /boq/{id}` and all BOQ mutations — 403 for team members
- `GET /projects/analytics` and `GET /projects/dashboard-cards` — team projects excluded

**Fix:** All access-check functions now perform a two-step verification:
1. Owner check (fast path)
2. `TeamMembership` lookup — if a row exists for `(project_id, user_id)`, access is granted

- **`dependencies.py`**: owner OR team member → pass, else 403
- **`projects/repository.py`**: listing now includes `OR project_id IN (member subquery)`
- **`projects/router.py`**: new `_verify_project_access` for read ops, `_verify_project_owner` kept for write ops
- **`boq/router.py`**: new `_is_project_member` helper used by both BOQ access checks

## Test plan

- [ ] User A creates a project and adds User B as team member
- [ ] User B sees the project in `GET /projects/`
- [ ] User B can open the project, dashboard, and BOQs without 403
- [ ] User A (owner) retains full access — no regression
- [ ] Admin bypass still works
- [ ] User C (not a member) still gets 403