### PR TITLE
fix(takeoff): open documents in the in-app viewer instead of a broken download nav

### DIFF
--- a/frontend/src/features/takeoff/TakeoffPage.tsx
+++ b/frontend/src/features/takeoff/TakeoffPage.tsx
@@ -340,6 +340,7 @@ function DocumentCard({
   doc,
   onAnalyze,
   onExtractTables,
+  onView,
   onRemove,
   onToggleElement,
   onSelectAll,
@@ -350,6 +351,7 @@ function DocumentCard({
   doc: UploadedDocument;
   onAnalyze: (id: string) => void;
   onExtractTables: (id: string) => void;
+  onView: (doc: UploadedDocument) => void;
   onRemove: (id: string) => void;
   onToggleElement: (docId: string, elementId: string) => void;
   onSelectAll: (docId: string) => void;
@@ -470,14 +472,7 @@ function DocumentCard({
             defaultValue: 'View {{name}}',
             name: doc.filename,
           })}
-          onClick={() => {
-            // Open in a new tab; fall back to same-tab nav if the browser
-            // blocks `window.open` (popup blocker) so the user still sees
-            // their document instead of a no-op click.
-            const url = `/api/v1/takeoff/documents/${doc.id}/download`;
-            const w = window.open(url, '_blank', 'noopener,noreferrer');
-            if (!w) window.location.href = url;
-          }}
+          onClick={() => onView(doc)}
         >
           {t('takeoff.view', 'View')}
         </Button>
@@ -1551,6 +1546,25 @@ export function TakeoffPage() {
     [extractTablesMutation],
   );
 
+  /* ── View a document ──────────────────────────────────────────────────
+   * Open the document in the in-app pdf.js viewer (Measurements tab) rather
+   * than navigating the whole tab to the raw `/download` API URL. That URL
+   * (a) is auth-gated — a top-level browser navigation can't send the Bearer
+   * token, so it 401s — and (b) 404s without the trailing slash. The viewer
+   * fetches the PDF with the auth header (see TakeoffViewerModule), so this
+   * reuses the proven, working path. */
+  const handleViewDocument = useCallback(
+    (doc: UploadedDocument) => {
+      setActiveDocId(doc.id);
+      setViewerDoc({
+        url: `/api/v1/takeoff/documents/${doc.id}/download/`,
+        name: doc.filename,
+      });
+      setActiveTab('measurements');
+    },
+    [],
+  );
+
   const handleToggleElement = useCallback((docId: string, elementId: string) => {
     setDocuments((prev) =>
       prev.map((d) => {
@@ -1974,6 +1988,7 @@ export function TakeoffPage() {
                     doc={doc}
                     onAnalyze={handleAnalyze}
                     onExtractTables={handleExtractTables}
+                    onView={handleViewDocument}
                     onRemove={handleRemoveDocument}
                     onToggleElement={handleToggleElement}
                     onSelectAll={handleSelectAll}


### PR DESCRIPTION
**Title:** fix(takeoff): open documents in the in-app viewer instead of a broken download nav

## Problem
The "View" button on the Documents & AI tab navigated the whole tab to
`/api/v1/takeoff/documents/{id}/download` (no trailing slash). That breaks two
ways for a top-level browser navigation:
1. **404** — the route is `…/download/` (trailing slash); `…/download` returns
   `{"detail":"Not Found"}`.
2. **Auth-gated** — a plain `window.open`/location nav can't send the
   `Authorization: Bearer` token, so even the correct path 401s.

Net effect: clicking "View" replaced the app with a raw JSON error page — which
reads as "the PDF viewer is broken".

## Fix
Route "View" through the existing in-app pdf.js viewer (Measurements tab) via
`setViewerDoc` + `setActiveTab('measurements')`. `TakeoffViewerModule` already
fetches the PDF **with** the auth header and feeds the bytes to pdf.js, so this
reuses the proven path and unifies the two tabs. Added an `onView` prop to
`DocumentCard`.

## Verification
`tsc --noEmit` clean. (Local eslint/vitest couldn't run — no node_modules on
the dev machine; upstream CI covers it.) The change mirrors the existing,
working `?doc=…&tab=measurements` restore effect exactly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)