### PR TITLE
fix(docker): install backend with source + [server] extra so the image actually works

### DIFF
--- a/deploy/docker/Dockerfile.backend
+++ b/deploy/docker/Dockerfile.backend
@@ -8,14 +8,20 @@ RUN groupadd -r oe && useradd -r -g oe -d /app -s /sbin/nologin oe
 
 WORKDIR /app
 
-COPY backend/pyproject.toml backend/
-RUN pip install --no-cache-dir ./backend && \
-    pip install --no-cache-dir "ezdxf>=0.18.0" || true
-
+# Copy the FULL backend source BEFORE installing. hatchling (packages=["app"])
+# needs app/ present to build the package, and the runtime needs the alembic/
+# data/ locales/ siblings. The previous layout copied only pyproject.toml then
+# ran `pip install ./backend ... || true` — the install failed (no source yet)
+# but `|| true` masked it, so the image shipped with NO dependencies and no
+# uvicorn (container crashed: "exec: uvicorn: not found"). The [server] extra
+# pulls asyncpg/psycopg2 required by the PostgreSQL DATABASE_URL.
 COPY backend/ backend/
+RUN pip install --no-cache-dir -e "./backend[server]"
 
 RUN chown -R oe:oe /app
 USER oe
+
+WORKDIR /app/backend
 
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
**Title:** fix(docker): install backend with source + [server] extra so the image actually works

## Problem
`deploy/docker/Dockerfile.backend` copied only `pyproject.toml` and ran
`pip install ./backend ... || true`. Because the `app/` source wasn't present
yet, the install failed — and `|| true` masked the failure, so the image
shipped with **no dependencies and no uvicorn**. The backend container could
not start.

## Fix
Copy the backend source first, then `pip install --no-cache-dir -e
"./backend[server]"` (the `[server]` extra pulls asyncpg/psycopg2, required
because production runs `postgresql+asyncpg`). Removed the `|| true` mask so a
failed install fails the build.

## Verification
Built and ran live on a Docker + PostgreSQL deployment (oce.tendix.io) — the
backend starts with all deps present.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)