### PR TITLE
fix(docker): raise nginx client_max_body_size to 100M for PDF/CAD uploads

### DIFF
--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -25,6 +25,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Allow large uploads (PDF/CAD takeoff drawings, BIM models). The nginx
+    # default is 1m, which rejects even a modest construction PDF with a bare
+    # "413 Request Entity Too Large" before the request ever reaches the
+    # backend. The backend enforces its own per-feature cap (e.g.
+    # OE_TAKEOFF_MAX_UPLOAD_MB), so this just lifts the proxy-layer ceiling.
+    client_max_body_size 100M;
+
     # Gzip compression
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;


### PR DESCRIPTION
**Title:** fix(docker): raise nginx client_max_body_size to 100M for PDF/CAD uploads

## Problem
The frontend image's `deploy/docker/nginx.conf` never set
`client_max_body_size`, so nginx's 1 MB default rejected any construction PDF
> 1 MB with a bare `413 Request Entity Too Large` **before the request reached
the backend** (no POST ever logged by uvicorn).

## Fix
Add `client_max_body_size 100M;` to the server block. The backend still
enforces its own per-feature cap (e.g. `OE_TAKEOFF_MAX_UPLOAD_MB`); this only
lifts the proxy-layer ceiling.

## Verification
Live: a 1.2 MB PDF takeoff upload that previously returned 413 (nginx/1.31.1)
now returns **201** from `POST /api/v1/takeoff/documents/upload/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)