### PR TITLE
fix(docker): serve .mjs workers as application/javascript (fixes PDF viewer)

### DIFF
--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -30,6 +30,20 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
     gzip_min_length 256;
 
+    # Serve ES-module workers (.mjs) with the correct MIME type. nginx's
+    # bundled mime.types has no .mjs mapping, so it falls back to
+    # application/octet-stream — and browsers then REFUSE to execute the
+    # module (strict MIME checks for module scripts/workers). That silently
+    # breaks the PDF takeoff viewer: pdf.js ships its worker as pdf.worker.mjs,
+    # the worker never starts, getDocument() hangs, and the canvas never
+    # renders (no error surfaced to the user). Regex locations take precedence
+    # over the /assets/ prefix, so re-assert the cache headers here too.
+    location ~ \.mjs$ {
+        default_type application/javascript;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
     # Cache static assets
     location /assets/ {
         expires 1y;


### PR DESCRIPTION
**Title:** fix(docker): serve .mjs workers as application/javascript (fixes PDF viewer)

## Problem
nginx's bundled `mime.types` has no `.mjs` mapping, so the frontend image
served pdf.js's worker (`pdf.worker.min-*.mjs`) as `application/octet-stream`.
Browsers refuse to execute a module worker with a non-JS MIME type, so the
worker never started, `getDocument()` never resolved, and the **PDF takeoff
viewer canvas never rendered** — silently, for every PDF.

## Fix
Add a regex location that serves `.mjs` with `default_type
application/javascript` (re-asserting the immutable cache headers, since regex
locations take precedence over the `/assets/` prefix).

## Verification
Live: `assets/pdf.worker.min-*.mjs` now returns `content-type:
application/javascript`; the viewer mounts and renders a real 1.2 MB
architectural drawing (verified the worker 200 + canvas ink + screenshot).

## Note
Both nginx fixes (#03, #04) touch `deploy/docker/nginx.conf`. They can be
submitted as one PR if preferred — the hunks don't conflict.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)