### PR TITLE
fix(docker): proxy WebSocket upgrades so real-time notifications work

### DIFF
--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -41,6 +41,33 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # WebSocket endpoints — real-time notification push
+    # (/api/v1/notifications/ws/) and collaboration presence
+    # (/api/v1/collaboration_locks/presence/).
+    #
+    # Without this, nginx proxies these as plain HTTP/1.0 and drops the
+    # Upgrade/Connection headers, so the WS handshake never completes — the
+    # browser reports "Unexpected response code: 404 during WebSocket
+    # handshake" and real-time notifications silently fall back to polling.
+    # A dedicated regex location keeps the upgrade dance off the REST /api/
+    # path (which must NOT force Connection: upgrade). Regex locations take
+    # precedence over the /api/ prefix, and a regex location cannot carry a
+    # URI in proxy_pass, so the full original request URI is forwarded as-is.
+    # New WebSocket endpoints must be added to this alternation.
+    location ~ ^/api/v1/(notifications/ws|collaboration_locks/presence)/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # Keep idle sockets open (1h) instead of the 120s REST cutoff.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+
     # Proxy API requests to backend
     location /api/ {
         proxy_pass http://backend:8000/api/;


### PR DESCRIPTION
**Title:** fix(docker): proxy WebSocket upgrades so real-time notifications work

## Problem
The frontend image's `deploy/docker/nginx.conf` proxied `/api/` as plain
HTTP/1.0 and never set the `Upgrade`/`Connection` headers. The two WebSocket
endpoints —
- `/api/v1/notifications/ws/` (real-time notification push), and
- `/api/v1/collaboration_locks/presence/` (collaboration presence) —

failed the handshake. The browser logged **"Unexpected response code: 404
during WebSocket handshake"** and the app silently fell back to polling
`/notifications/unread-count/`, so notifications never arrived in real time.

## Fix
A dedicated regex `location` for those endpoints with the standard upgrade
dance (`proxy_http_version 1.1` + `Upgrade $http_upgrade` + `Connection
"upgrade"`) and a 1 h read/send timeout so idle sockets aren't cut at the 120 s
REST limit. Kept off the REST `/api/` prefix so ordinary requests aren't forced
to `Connection: upgrade`. (Regex locations can't carry a URI in `proxy_pass`, so
the full original request URI is forwarded as-is.)

## Verification
Config syntax checked (brace-balanced; canonical nginx WS pattern). End-to-end
verification needs a deploy — the browser console "404 during WebSocket
handshake" should disappear and the notifications WS should hold open.

## Note (reverse-proxy chains)
Any *additional* proxy in front (a host nginx, Traefik, etc.) needs the same
upgrade headers on the path it forwards to this container. Cloudflare proxies
WebSockets automatically.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)