### PR TITLE
feat(bim): add resumable CAD uploads

### DIFF
--- a/backend/app/modules/bim_hub/resumable_uploads.py
+++ b/backend/app/modules/bim_hub/resumable_uploads.py
@@ -1,0 +1,117 @@
+"""Helpers for resumable BIM CAD uploads.
+
+The resumable upload flow stores multipart session state in BIMModel.metadata_
+so the upload can be resumed from the model record without a separate table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from typing import Any
+
+from app.core.storage import MultipartSession, PartInfo
+from app.modules.bim_hub.models import BIMModel
+
+UPLOAD_METADATA_KEY = "resumable_upload"
+DEFAULT_CHUNK_SIZE_BYTES = 8 * 1024 * 1024
+
+
+def _model_metadata(model: BIMModel) -> dict[str, Any]:
+    return dict(model.metadata_ or {})
+
+
+def get_manifest(model: BIMModel) -> dict[str, Any] | None:
+    manifest = _model_metadata(model).get(UPLOAD_METADATA_KEY)
+    return dict(manifest) if isinstance(manifest, dict) else None
+
+
+def set_manifest(model: BIMModel, manifest: dict[str, Any] | None) -> None:
+    metadata = _model_metadata(model)
+    if manifest is None:
+        metadata.pop(UPLOAD_METADATA_KEY, None)
+    else:
+        metadata[UPLOAD_METADATA_KEY] = manifest
+    model.metadata_ = metadata
+
+
+def create_manifest(*, upload_id: str, key: str, filename: str, file_size: int, chunk_size_bytes: int, content_type: str | None = None, model_format: str | None = None, project_id: str | None = None, model_id: str | None = None, name: str | None = None, discipline: str | None = None, conversion_depth: str | None = None) -> dict[str, Any]:
+    return {
+        "upload_id": upload_id,
+        "key": key,
+        "filename": filename,
+        "file_size": file_size,
+        "chunk_size_bytes": chunk_size_bytes,
+        "content_type": content_type or "application/octet-stream",
+        "model_format": model_format,
+        "project_id": project_id,
+        "model_id": model_id,
+        "name": name,
+        "discipline": discipline,
+        "conversion_depth": conversion_depth,
+        "started_at": datetime.now(UTC).isoformat(),
+        "parts": {},
+    }
+
+
+def session_from_manifest(manifest: dict[str, Any]) -> MultipartSession:
+    return MultipartSession(
+        upload_id=str(manifest["upload_id"]),
+        key=str(manifest["key"]),
+        backend=str(manifest.get("backend") or "local"),
+        started_at=datetime.now(UTC),
+        metadata={
+            k: v
+            for k, v in manifest.items()
+            if k not in {"upload_id", "key", "started_at", "parts"}
+        },
+    )
+
+
+def parts_from_manifest(manifest: dict[str, Any]) -> list[PartInfo]:
+    raw_parts = manifest.get("parts") or {}
+    if not isinstance(raw_parts, dict):
+        return []
+    parts: list[PartInfo] = []
+    for key, value in raw_parts.items():
+        try:
+            part_number = int(key)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(value, dict):
+            continue
+        etag = str(value.get("etag") or "")
+        if not etag:
+            continue
+        try:
+            size_bytes = int(value.get("size_bytes") or 0)
+        except (TypeError, ValueError):
+            size_bytes = 0
+        parts.append(PartInfo(part_number=part_number, etag=etag, size_bytes=size_bytes))
+    parts.sort(key=lambda p: p.part_number)
+    return parts
+
+
+def uploaded_bytes(parts: Iterable[PartInfo]) -> int:
+    return sum(part.size_bytes for part in parts)
+
+
+def next_part_number(parts: Iterable[PartInfo]) -> int:
+    max_seen = 0
+    for part in parts:
+        if part.part_number > max_seen:
+            max_seen = part.part_number
+    return max_seen + 1
+
+
+def remember_part(manifest: dict[str, Any], part: PartInfo) -> dict[str, Any]:
+    parts = manifest.setdefault("parts", {})
+    if not isinstance(parts, dict):
+        parts = {}
+        manifest["parts"] = parts
+    parts[str(part.part_number)] = {
+        "etag": part.etag,
+        "size_bytes": part.size_bytes,
+        "uploaded_at": datetime.now(UTC).isoformat(),
+    }
+    return manifest

--- a/backend/app/modules/bim_hub/router.py
+++ b/backend/app/modules/bim_hub/router.py
@@ -61,9 +61,10 @@ import json
 import logging
 import pathlib
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, Depends, File, Header, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, BackgroundTasks, Depends, File, Header, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -72,8 +73,20 @@ from app.core.http_headers import content_disposition_attachment
 from app.core.i18n import get_locale
 from app.core.rate_limiter import upload_limiter
 from app.core.validation.messages import translate
+from app.core.storage import get_storage_backend
 from app.dependencies import CurrentUserId, RequirePermission, SessionDep
 from app.modules.bim_hub import file_storage as bim_file_storage
+from app.modules.bim_hub.resumable_uploads import (
+    DEFAULT_CHUNK_SIZE_BYTES,
+    create_manifest,
+    get_manifest,
+    next_part_number,
+    parts_from_manifest,
+    remember_part,
+    session_from_manifest,
+    set_manifest,
+    uploaded_bytes,
+)
 from app.modules.bim_hub.schemas import (
     AssetInfoUpdateRequest,
     AssetListResponse,
@@ -95,6 +108,9 @@ from app.modules.bim_hub.schemas import (
     BIMQuantityMapListResponse,
     BIMQuantityMapResponse,
     BIMQuantityMapUpdate,
+    BIMResumableUploadInitRequest,
+    BIMResumableUploadPartResponse,
+    BIMResumableUploadStatusResponse,
     BOQElementLinkBrief,
     BOQElementLinkCreate,
     BOQElementLinkListResponse,
@@ -1279,12 +1295,13 @@ async def _process_cad_in_background(
             logger.exception("RVT converter pre-flight check failed for %s", model_id)
 
     try:
-        content = await get_storage_backend().get(cad_storage_key)
-
         with tempfile.TemporaryDirectory(prefix="oe-bim-bg-") as _tmp_str:
             _tmp_dir = _Path(_tmp_str)
             _tmp_cad_path = _tmp_dir / f"original{ext}"
-            await asyncio.to_thread(_tmp_cad_path.write_bytes, content)
+            with _tmp_cad_path.open("wb") as out:
+                async for chunk in bim_file_storage.open_geometry_stream(cad_storage_key):
+                    if chunk:
+                        out.write(chunk)
 
             result = await asyncio.to_thread(process_ifc_file, _tmp_cad_path, _tmp_dir, conversion_depth)
             element_count = result["element_count"]
@@ -1689,12 +1706,13 @@ async def _generate_pdf_in_background(
         return
 
     try:
-        content = await get_storage_backend().get(cad_storage_key)
-
         with tempfile.TemporaryDirectory(prefix="oe-bim-pdf-") as _tmp_str:
             _tmp_dir = _Path(_tmp_str)
             _tmp_cad_path = _tmp_dir / f"original{ext}"
-            await asyncio.to_thread(_tmp_cad_path.write_bytes, content)
+            with _tmp_cad_path.open("wb") as out:
+                async for chunk in bim_file_storage.open_geometry_stream(cad_storage_key):
+                    if chunk:
+                        out.write(chunk)
 
             pdf_target = (_tmp_dir / "sheets.pdf").resolve()
 
@@ -1762,6 +1780,386 @@ async def _generate_pdf_in_background(
 
     except Exception as exc:
         logger.exception("PDF generation failed for model %s: %s", model_id, exc)
+
+
+def _resumable_parts_response(model_id: uuid.UUID, manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    parts = parts_from_manifest(manifest)
+    uploaded = uploaded_bytes(parts)
+    return [
+        {
+            "model_id": str(model_id),
+            "part_number": part.part_number,
+            "etag": part.etag,
+            "size_bytes": part.size_bytes,
+            "uploaded_bytes": uploaded,
+            "next_part_number": next_part_number(parts),
+            "complete": False,
+        }
+        for part in parts
+    ]
+
+
+def _resumable_status_payload(model: Any, manifest: dict[str, Any]) -> dict[str, Any]:
+    parts = parts_from_manifest(manifest)
+    uploaded = uploaded_bytes(parts)
+    ext = pathlib.Path(str(manifest.get("filename") or model.name or "")).suffix.lower().lstrip(".")
+    return {
+        "model_id": str(model.id),
+        "project_id": str(model.project_id),
+        "upload_id": str(manifest.get("upload_id") or ""),
+        "key": str(manifest.get("key") or ""),
+        "filename": str(manifest.get("filename") or model.name or ""),
+        "file_size": int(manifest.get("file_size") or 0),
+        "chunk_size_bytes": int(manifest.get("chunk_size_bytes") or DEFAULT_CHUNK_SIZE_BYTES),
+        "model_format": ext,
+        "name": str(manifest.get("name") or model.name or ""),
+        "discipline": manifest.get("discipline"),
+        "conversion_depth": manifest.get("conversion_depth"),
+        "status": str(model.status),
+        "uploaded_bytes": uploaded,
+        "next_part_number": next_part_number(parts),
+        "uploaded_parts": [
+            {
+                "model_id": str(model.id),
+                "part_number": part.part_number,
+                "etag": part.etag,
+                "size_bytes": part.size_bytes,
+                "uploaded_bytes": uploaded,
+                "next_part_number": next_part_number(parts),
+                "complete": False,
+            }
+            for part in parts
+        ],
+    }
+
+
+@router.post("/upload-cad/resumable/", status_code=201)
+async def initiate_resumable_upload(
+    payload: BIMResumableUploadInitRequest,
+    user_id: CurrentUserId = None,  # type: ignore[assignment]
+    _perm: None = Depends(RequirePermission("bim.create")),
+    service: BIMHubService = Depends(_get_service),
+) -> dict[str, Any]:
+    """Start a resumable BIM CAD upload session."""
+
+    try:
+        project_uuid = uuid.UUID(str(payload.project_id))
+    except (ValueError, TypeError) as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Invalid project_id: {exc}") from exc
+
+    await _verify_project_access(service.session, project_uuid, user_id or "")
+
+    allowed, _ = upload_limiter.is_allowed(str(user_id or "anon"))
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many uploads. Please wait a moment and try again.",
+            headers={"Retry-After": "60"},
+        )
+
+    filename = payload.filename.strip()
+    if not filename:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No filename provided.")
+
+    ext = pathlib.Path(filename).suffix.lower()
+    if ext not in _ALLOWED_CAD_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(f"Unsupported file type '{ext}'. Accepted: {', '.join(sorted(_ALLOWED_CAD_EXTENSIONS))}"),
+        )
+
+    if ext in _NEEDS_CONVERTER_EXTS:
+        from app.modules.boq.cad_import import find_converter
+
+        if find_converter(ext.lstrip(".")) is None:
+            install_endpoint = f"/api/v1/takeoff/converters/{ext.lstrip('.')}/install/"
+            return JSONResponse(
+                status_code=status.HTTP_202_ACCEPTED,
+                content={
+                    "status": "converter_required",
+                    "format": ext.lstrip("."),
+                    "converter_id": ext.lstrip("."),
+                    "message": (
+                        f"{ext.upper().lstrip('.')} files require the {ext.upper().lstrip('.')} converter, "
+                        "which is not installed on this server. Install the converter before uploading."
+                    ),
+                    "install_endpoint": install_endpoint,
+                    "model_id": None,
+                    "name": None,
+                    "file_size": 0,
+                    "element_count": 0,
+                    "error_message": None,
+                },
+                headers={
+                    "Retry-After": "60",
+                    "Link": f'<{install_endpoint}>; rel="install-converter"',
+                },
+            )
+
+    from app.modules.bim_hub.models import BIMModel
+
+    model_name = (payload.name or pathlib.Path(filename).stem).strip() or filename
+    model_format = ext.lstrip(".")
+    model = BIMModel(
+        project_id=project_uuid,
+        name=model_name,
+        discipline=payload.discipline,
+        model_format=model_format,
+        status="uploading",
+        metadata_={},
+        created_by=uuid.UUID(str(user_id)) if user_id else None,
+    )
+    service.session.add(model)
+    await service.session.flush()
+
+    key = bim_file_storage.original_cad_key(project_uuid, model.id, ext)
+    storage_backend = get_storage_backend()
+    session = await storage_backend.initiate_multipart(key, content_type="application/octet-stream")
+
+    manifest = create_manifest(
+        upload_id=session.upload_id,
+        key=key,
+        filename=filename,
+        file_size=payload.file_size,
+        chunk_size_bytes=payload.chunk_size_bytes or DEFAULT_CHUNK_SIZE_BYTES,
+        content_type="application/octet-stream",
+        model_format=model_format,
+        project_id=str(project_uuid),
+        model_id=str(model.id),
+        name=model_name,
+        discipline=payload.discipline,
+        conversion_depth=payload.conversion_depth,
+    )
+    manifest["backend"] = session.backend
+    set_manifest(model, manifest)
+    await service.session.commit()
+
+    logger.info(
+        "Resumable BIM upload initiated: model=%s key=%s size=%d chunk=%d",
+        model.id,
+        key,
+        payload.file_size,
+        payload.chunk_size_bytes,
+    )
+    return {
+        "model_id": str(model.id),
+        "project_id": str(project_uuid),
+        "upload_id": session.upload_id,
+        "key": key,
+        "filename": filename,
+        "file_size": payload.file_size,
+        "chunk_size_bytes": payload.chunk_size_bytes or DEFAULT_CHUNK_SIZE_BYTES,
+        "model_format": model_format,
+        "name": model_name,
+        "discipline": payload.discipline,
+        "conversion_depth": payload.conversion_depth,
+        "status": "uploading",
+        "uploaded_bytes": 0,
+        "next_part_number": 1,
+        "uploaded_parts": [],
+    }
+
+
+@router.get("/models/{model_id}/upload/", status_code=200)
+async def get_resumable_upload_status(
+    model_id: uuid.UUID,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("bim.create")),
+    service: BIMHubService = Depends(_get_service),
+) -> dict[str, Any]:
+    model = await _verify_model_access(service, model_id, user_id or "")
+    manifest = get_manifest(model)
+    if not manifest:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No resumable upload is associated with this model.")
+    return _resumable_status_payload(model, manifest)
+
+
+@router.put("/models/{model_id}/upload/parts/{part_number}/", status_code=200)
+async def upload_resumable_part(
+    model_id: uuid.UUID,
+    part_number: int,
+    request: Request,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("bim.create")),
+    service: BIMHubService = Depends(_get_service),
+) -> BIMResumableUploadPartResponse:
+    model = await _verify_model_access(service, model_id, user_id or "")
+    manifest = get_manifest(model)
+    if not manifest:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No resumable upload is associated with this model.")
+
+    body = await request.body()
+    if not body:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Chunk body is empty.")
+
+    session = session_from_manifest(manifest)
+    try:
+        part = await get_storage_backend().upload_part(session, part_number, body)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    remember_part(manifest, part)
+    set_manifest(model, manifest)
+    model.status = "uploading"
+    await service.session.commit()
+
+    parts = parts_from_manifest(manifest)
+    total_uploaded = uploaded_bytes(parts)
+    next_part = next_part_number(parts)
+    logger.info(
+        "Resumable BIM upload part stored: model=%s part=%d size=%d uploaded=%d",
+        model_id,
+        part_number,
+        part.size_bytes,
+        total_uploaded,
+    )
+    return BIMResumableUploadPartResponse(
+        model_id=model_id,
+        part_number=part_number,
+        etag=part.etag,
+        size_bytes=part.size_bytes,
+        uploaded_bytes=total_uploaded,
+        next_part_number=next_part,
+        complete=False,
+    )
+
+
+@router.post("/models/{model_id}/upload/complete/", status_code=202)
+async def complete_resumable_upload(
+    model_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("bim.create")),
+    service: BIMHubService = Depends(_get_service),
+) -> dict[str, Any]:
+    model = await _verify_model_access(service, model_id, user_id or "")
+    manifest = get_manifest(model)
+    if not manifest:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No resumable upload is associated with this model.")
+
+    parts = parts_from_manifest(manifest)
+    if not parts:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Upload has no parts yet.")
+
+    session = session_from_manifest(manifest)
+    storage_backend = get_storage_backend()
+    try:
+        stored = await storage_backend.complete_multipart(session, parts)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    filename = str(manifest.get("filename") or model.name or f"model.{(model.model_format or 'ifc')}")
+    ext = pathlib.Path(filename).suffix.lower()
+    model_format = ext.lstrip(".") or (model.model_format or "ifc")
+    model_name = str(manifest.get("name") or model.name or pathlib.Path(filename).stem or filename)
+    conversion_depth = str(manifest.get("conversion_depth") or "standard")
+    saved_cad_key = stored.key
+
+    # Clear resumable upload metadata now that the blob is safely in storage.
+    metadata = dict(model.metadata_ or {})
+    metadata.pop("resumable_upload", None)
+    metadata["original_file_name"] = filename
+    metadata["original_file_size"] = stored.size_bytes
+    metadata["upload_completed_at"] = datetime.now(UTC).isoformat()
+    model.metadata_ = metadata
+    model.canonical_file_path = saved_cad_key
+    model.model_format = model_format
+    model.name = model_name
+    model.discipline = str(manifest.get("discipline") or model.discipline or "architecture")
+    model.status = "processing"
+    model.error_message = None
+    model.element_count = 0
+
+    # Reuse the existing preflight logic for converter-gated formats.
+    if ext in _NEEDS_CONVERTER_EXTS:
+        from app.modules.boq.cad_import import find_converter
+
+        if find_converter(ext.lstrip(".")) is None:
+            model.status = "needs_converter"
+            model.error_message = (
+                f"{ext.upper().lstrip('.')} converter not installed - install it from the BIM converter banner, "
+                f"then click Re-process on this model."
+            )
+            await service.session.commit()
+            install_endpoint = f"/api/v1/takeoff/converters/{ext.lstrip('.')}/install/"
+            return JSONResponse(
+                status_code=status.HTTP_202_ACCEPTED,
+                content={
+                    "status": "converter_required",
+                    "format": ext.lstrip("."),
+                    "converter_id": ext.lstrip("."),
+                    "message": (
+                        f"{ext.upper().lstrip('.')} files require the {ext.upper().lstrip('.')} converter, which is not installed on this server. "
+                        "Your file has been saved - install the converter and click Re-process on the model card to finish the upload."
+                    ),
+                    "install_endpoint": install_endpoint,
+                    "model_id": str(model.id),
+                    "name": model_name,
+                    "file_size": stored.size_bytes,
+                    "element_count": 0,
+                    "error_message": None,
+                },
+                headers={
+                    "Retry-After": "60",
+                    "Link": (
+                        f'<{install_endpoint}>; rel="install-converter", '
+                        f"</api/v1/bim_hub/{model.id}/retry/>; rel=\"reprocess-model\""
+                    ),
+                },
+            )
+
+    await service.session.commit()
+
+    processable = ext in (".ifc", ".rvt")
+    if processable:
+        background_tasks.add_task(
+            _process_cad_in_background,
+            project_id=str(model.project_id),
+            model_id=str(model.id),
+            cad_storage_key=saved_cad_key,
+            ext=ext,
+            conversion_depth=conversion_depth,
+        )
+    else:
+        model.status = "needs_converter"
+        model.error_message = (
+            f"{ext.upper().lstrip('.')} files require an external converter. Convert to IFC first, then re-upload."
+        )
+        await service.session.flush()
+        await service.session.commit()
+
+    return {
+        "model_id": str(model.id),
+        "name": model_name,
+        "format": model_format,
+        "file_size": stored.size_bytes,
+        "status": "processing" if processable else "needs_converter",
+        "element_count": 0,
+        "error_message": model.error_message,
+        "geometry_type": (model.metadata_ or {}).get("geometry_type", "unknown"),
+        "converter_id": ext.lstrip(".") if not processable else None,
+        "install_endpoint": (
+            f"/api/v1/takeoff/converters/{ext.lstrip('.')}/install/" if not processable else None
+        ),
+    }
+
+
+@router.delete("/models/{model_id}/upload/", status_code=204)
+async def abort_resumable_upload(
+    model_id: uuid.UUID,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("bim.create")),
+    service: BIMHubService = Depends(_get_service),
+) -> None:
+    model = await _verify_model_access(service, model_id, user_id or "")
+    manifest = get_manifest(model)
+    if manifest:
+        try:
+            await get_storage_backend().abort_multipart(session_from_manifest(manifest))
+        except Exception as exc:  # noqa: BLE001 - best effort cleanup
+            logger.warning("Failed to abort multipart upload for model %s: %s", model_id, exc)
+    model.status = "cancelled"
+    await service.session.commit()
 
 
 @router.post("/upload-cad/", status_code=201)

--- a/backend/app/modules/bim_hub/schemas.py
+++ b/backend/app/modules/bim_hub/schemas.py
@@ -185,6 +185,52 @@ class BIMModelUpdate(BaseModel):
     metadata: dict[str, Any] | None = None
 
 
+class BIMResumableUploadInitRequest(BaseModel):
+    """Start a chunked BIM upload session."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    project_id: UUID
+    name: str = Field(..., min_length=1, max_length=255)
+    discipline: str = Field(default="architecture", max_length=50)
+    filename: str = Field(..., min_length=1, max_length=255)
+    file_size: int = Field(..., ge=1)
+    chunk_size_bytes: int = Field(default=8 * 1024 * 1024, ge=1, le=50 * 1024 * 1024)
+    conversion_depth: str = Field(default="standard", max_length=20)
+
+
+class BIMResumableUploadPartResponse(BaseModel):
+    """Response for a single uploaded chunk."""
+
+    model_id: UUID
+    part_number: int
+    etag: str
+    size_bytes: int
+    uploaded_bytes: int
+    next_part_number: int
+    complete: bool = False
+
+
+class BIMResumableUploadStatusResponse(BaseModel):
+    """Current state of a resumable BIM upload session."""
+
+    model_id: UUID
+    project_id: UUID
+    upload_id: str
+    key: str
+    filename: str
+    file_size: int
+    chunk_size_bytes: int
+    model_format: str
+    name: str
+    discipline: str | None = None
+    conversion_depth: str | None = None
+    status: str
+    uploaded_bytes: int
+    next_part_number: int
+    uploaded_parts: list[BIMResumableUploadPartResponse] = Field(default_factory=list)
+
+
 class BIMModelResponse(BaseModel):
     """BIM model returned from the API."""
 

--- a/backend/tests/integration/test_bim_resumable_upload.py
+++ b/backend/tests/integration/test_bim_resumable_upload.py
@@ -1,0 +1,175 @@
+"""Integration tests for the resumable BIM CAD upload flow.
+
+The goal is to prove that large files can move through the app in small
+chunks, update resumable session state, and finalise into the normal BIM
+upload response without relying on a single large multipart body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+
+
+@pytest_asyncio.fixture(scope="module")
+async def resumable_client():
+    app = create_app()
+
+    from app.modules.bim_hub import router as bim_router
+
+    async def _noop_process_cad_in_background(*_args, **_kwargs):
+        return None
+
+    patcher = pytest.MonkeyPatch()
+    patcher.setattr(bim_router, "_process_cad_in_background", _noop_process_cad_in_background)
+
+    @asynccontextmanager
+    async def lifespan_ctx():
+        async with app.router.lifespan_context(app):
+            yield
+
+    async with lifespan_ctx():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+    patcher.undo()
+
+
+@pytest_asyncio.fixture(scope="module")
+async def resumable_auth(resumable_client: AsyncClient) -> dict[str, str]:
+    unique = uuid.uuid4().hex[:8]
+    email = f"bimresumable-{unique}@test.io"
+    password = f"BimResumable{unique}9"
+
+    reg = await resumable_client.post(
+        "/api/v1/users/auth/register",
+        json={
+            "email": email,
+            "password": password,
+            "full_name": "BIM Resumable Tester",
+            "role": "admin",
+        },
+    )
+    assert reg.status_code == 201, f"Registration failed: {reg.text}"
+
+    from tests.integration._auth_helpers import promote_to_admin
+
+    await promote_to_admin(email)
+
+    token = ""
+    data: dict[str, str] = {}
+    for attempt in range(3):
+        resp = await resumable_client.post(
+            "/api/v1/users/auth/login",
+            json={"email": email, "password": password},
+        )
+        data = resp.json()
+        token = data.get("access_token", "")
+        if token:
+            break
+        if "Too many login attempts" in data.get("detail", ""):
+            await asyncio.sleep(5 * (attempt + 1))
+            continue
+        break
+    assert token, f"Login failed: {data}"
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest_asyncio.fixture(scope="module")
+async def resumable_project(resumable_client: AsyncClient, resumable_auth: dict[str, str]) -> str:
+    resp = await resumable_client.post(
+        "/api/v1/projects/",
+        json={
+            "name": f"BIMResumable Project {uuid.uuid4().hex[:6]}",
+            "description": "BIM resumable upload test project",
+            "region": "DACH",
+            "classification_standard": "din276",
+            "currency": "EUR",
+        },
+        headers=resumable_auth,
+    )
+    assert resp.status_code == 201, f"Project create failed: {resp.text}"
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_resumable_upload_init_chunk_status_and_complete(
+    resumable_client: AsyncClient,
+    resumable_auth: dict[str, str],
+    resumable_project: str,
+):
+    file_size = 9 * 1024 * 1024 + 1
+    first_chunk = 8 * 1024 * 1024
+    second_chunk = file_size - first_chunk
+
+    init_resp = await resumable_client.post(
+        "/api/v1/bim_hub/upload-cad/resumable/",
+        json={
+            "project_id": resumable_project,
+            "name": "Big model",
+            "discipline": "architecture",
+            "filename": "big.ifc",
+            "file_size": file_size,
+            "chunk_size_bytes": first_chunk,
+            "conversion_depth": "standard",
+        },
+        headers=resumable_auth,
+    )
+    assert init_resp.status_code == 201, init_resp.text
+    init = init_resp.json()
+    assert init["status"] == "uploading"
+    assert init["model_id"]
+    assert init["upload_id"]
+    assert init["next_part_number"] == 1
+
+    model_id = init["model_id"]
+
+    part1 = await resumable_client.put(
+        f"/api/v1/bim_hub/models/{model_id}/upload/parts/1/",
+        content=b"a" * first_chunk,
+        headers=resumable_auth,
+    )
+    assert part1.status_code == 200, part1.text
+    part1_data = part1.json()
+    assert part1_data["part_number"] == 1
+    assert part1_data["next_part_number"] == 2
+    assert part1_data["uploaded_bytes"] == first_chunk
+
+    part2 = await resumable_client.put(
+        f"/api/v1/bim_hub/models/{model_id}/upload/parts/2/",
+        content=b"b" * second_chunk,
+        headers=resumable_auth,
+    )
+    assert part2.status_code == 200, part2.text
+    part2_data = part2.json()
+    assert part2_data["part_number"] == 2
+    assert part2_data["uploaded_bytes"] == file_size
+    assert part2_data["next_part_number"] == 3
+
+    status_resp = await resumable_client.get(
+        f"/api/v1/bim_hub/models/{model_id}/upload/",
+        headers=resumable_auth,
+    )
+    assert status_resp.status_code == 200, status_resp.text
+    status = status_resp.json()
+    assert status["uploaded_bytes"] == file_size
+    assert status["next_part_number"] == 3
+    assert len(status["uploaded_parts"]) == 2
+
+    complete_resp = await resumable_client.post(
+        f"/api/v1/bim_hub/models/{model_id}/upload/complete/",
+        headers=resumable_auth,
+    )
+    assert complete_resp.status_code == 202, complete_resp.text
+    complete = complete_resp.json()
+    assert complete["model_id"] == model_id
+    assert complete["status"] == "processing"
+    assert complete["file_size"] == file_size
+    assert complete["element_count"] == 0

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -46,7 +46,7 @@ putting a different proxy (Caddy, Traefik, a cloud load balancer) in front of
 the app:
 
 - Upload size. Drawings and BIM files are large, so the body limit is raised to
-  `100M`. The nginx default of `1M` rejects most takeoff and CAD uploads with a
+  `2G`. The nginx default of `1M` rejects most takeoff and CAD uploads with a
   413 before the request ever reaches FastAPI.
 - `.mjs` module workers. The PDF takeoff viewer loads pdf.js as an ES module
   worker. nginx-alpine has no MIME mapping for `.mjs` and would serve it as

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -27,7 +27,8 @@ server {
 
     # Allow large uploads (PDF drawings, CAD files). The nginx default of 1M
     # rejects most takeoff/BIM payloads with a 413 before they reach FastAPI.
-    client_max_body_size 100M;
+    # Raise this to 2 GB so large IFC/RVT payloads can pass through.
+    client_max_body_size 2G;
 
     # Gzip compression
     gzip on;

--- a/frontend/src/app/locales/__tests__/en.test.ts
+++ b/frontend/src/app/locales/__tests__/en.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import en from '../en';
+
+describe('BIM empty-state copy', () => {
+  it('uses clearer text for empty BIM models', () => {
+    expect(en.translation['bim.no_elements']).toBe('No BIM elements found');
+  });
+});

--- a/frontend/src/app/locales/__tests__/en.test.ts
+++ b/frontend/src/app/locales/__tests__/en.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import en from '../en';
 
-describe('BIM empty-state copy', () => {
+describe('BIM copy', () => {
   it('uses clearer text for empty BIM models', () => {
     expect(en.translation['bim.no_elements']).toBe('No BIM elements found');
+  });
+
+  it('shows the 2 GB upload limit in the BIM hint text', () => {
+    expect(en.translation['bim.upload_size_hint']).toBe('Revit (.rvt), IFC (.ifc) · Max 2 GB');
   });
 });

--- a/frontend/src/app/locales/ar.ts
+++ b/frontend/src/app/locales/ar.ts
@@ -1464,7 +1464,7 @@ const resource = {
     "bim.upload_result": "نتيجة الرفع",
     "bim.upload_rvt_note": "ملاحظة: ملفات RVT تتطلب DDC cad2data. يُنصح باستخدام IFC.",
     "bim.upload_simple_mode_toggle": "التبديل إلى الوضع البسيط",
-    "bim.upload_size_hint": "Revit (.rvt)، IFC (.ifc) · الحد الأقصى 500 ميغابايت",
+    "bim.upload_size_hint": "Revit (.rvt)، IFC (.ifc) · الحد الأقصى 2 جيجابايت",
     "bim.upload_storeys": "الطوابق:",
     "bim.upload_success": "تم رفع بيانات BIM",
     "bim.upload_success_desc": "تم رفع النموذج بنجاح.",

--- a/frontend/src/app/locales/bg.ts
+++ b/frontend/src/app/locales/bg.ts
@@ -4935,7 +4935,7 @@ const resource = {
     "bim.upload_remove_file": "Премахване",
     "bim.upload_rvt_note": "Забележка: RVT файловете изискват DDC cad2data. Обмислете IFC.",
     "bim.upload_simple_mode_toggle": "Превключване към опростен режим",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Макс 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Макс 2 GB",
     "bim.upload_success_desc": "Моделът е качен успешно.",
     "bim.upload_title": "Качване на BIM данни",
     "bim.upload_unsupported_format": "Неподдържан формат.",

--- a/frontend/src/app/locales/da.ts
+++ b/frontend/src/app/locales/da.ts
@@ -6864,7 +6864,7 @@ const resource = {
     "bim.upload_remove_file": "Fjern",
     "bim.upload_rvt_note": "Bemærk: RVT-filer kræver DDC cad2data. Overvej IFC.",
     "bim.upload_simple_mode_toggle": "Skift til simpel tilstand",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 2 GB",
     "bim.upload_success_desc": "Model uploadet.",
     "bim.upload_title": "Upload BIM-data",
     "bim.upload_unsupported_format": "Ikke-understøttet format.",

--- a/frontend/src/app/locales/en.ts
+++ b/frontend/src/app/locales/en.ts
@@ -6511,7 +6511,7 @@ const resource = {
     "bim.upload_remove_file": "Remove",
     "bim.upload_rvt_note": "Note: RVT files require DDC cad2data. Consider IFC.",
     "bim.upload_simple_mode_toggle": "Switch to simple mode",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc)",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Max 2 GB",
     "bim.upload_success_desc": "Model uploaded successfully.",
     "bim.upload_title": "Upload BIM Data",
     "bim.upload_unsupported_format": "Unsupported format.",

--- a/frontend/src/app/locales/en.ts
+++ b/frontend/src/app/locales/en.ts
@@ -2727,7 +2727,7 @@ const resource = {
     "bim.models": "Models",
     "bim.element_tree": "Element Tree",
     "bim.loading_model": "Loading model...",
-    "bim.no_elements": "No elements to display",
+    "bim.no_elements": "No BIM elements found",
     "bim.geometry_load_failed": "Could not load 3D geometry",
     "bim.geometry_retry": "Retry",
     "bim.geometry_dismiss": "Dismiss",

--- a/frontend/src/app/locales/fi.ts
+++ b/frontend/src/app/locales/fi.ts
@@ -4935,7 +4935,7 @@ const resource = {
     "bim.upload_remove_file": "Poista",
     "bim.upload_rvt_note": "Huom.: RVT-tiedostot edellyttävät DDC cad2data -palvelua. Harkitse IFC-muotoa.",
     "bim.upload_simple_mode_toggle": "Vaihda yksinkertaiseen tilaan",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · enintään 500 Mt",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · enintään 2 Gt",
     "bim.upload_success_desc": "Malli ladattu onnistuneesti.",
     "bim.upload_title": "Lataa BIM-data",
     "bim.upload_unsupported_format": "Ei tuettu muoto.",

--- a/frontend/src/app/locales/hi.ts
+++ b/frontend/src/app/locales/hi.ts
@@ -4936,7 +4936,7 @@ const resource = {
     "bim.upload_remove_file": "हटाएँ",
     "bim.upload_rvt_note": "नोट: RVT फ़ाइलों के लिए DDC cad2data आवश्यक है। IFC पर विचार करें।",
     "bim.upload_simple_mode_toggle": "सरल मोड पर स्विच करें",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · अधिकतम 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · अधिकतम 2 GB",
     "bim.upload_success_desc": "मॉडल सफलतापूर्वक अपलोड हुआ।",
     "bim.upload_title": "BIM डेटा अपलोड करें",
     "bim.upload_unsupported_format": "असमर्थित प्रारूप।",

--- a/frontend/src/app/locales/id.ts
+++ b/frontend/src/app/locales/id.ts
@@ -4938,7 +4938,7 @@ const resource = {
     "bim.upload_remove_file": "Hapus",
     "bim.upload_rvt_note": "Catatan: File RVT memerlukan DDC cad2data. Pertimbangkan IFC.",
     "bim.upload_simple_mode_toggle": "Beralih ke mode sederhana",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 2 GB",
     "bim.upload_success_desc": "Model berhasil diunggah.",
     "bim.upload_title": "Unggah Data BIM",
     "bim.upload_unsupported_format": "Format tidak didukung.",

--- a/frontend/src/app/locales/ja.ts
+++ b/frontend/src/app/locales/ja.ts
@@ -4936,7 +4936,7 @@ const resource = {
     "bim.upload_remove_file": "削除",
     "bim.upload_rvt_note": "注: RVTファイルにはDDC cad2dataが必要です。IFCの使用をご検討ください。",
     "bim.upload_simple_mode_toggle": "シンプルモードに切り替え",
-    "bim.upload_size_hint": "Revit (.rvt)、IFC (.ifc) · 最大500MB",
+    "bim.upload_size_hint": "Revit (.rvt)、IFC (.ifc) · 最大2GB",
     "bim.upload_success_desc": "モデルのアップロードに成功しました。",
     "bim.upload_title": "BIMデータをアップロード",
     "bim.upload_unsupported_format": "サポートされていない形式。",

--- a/frontend/src/app/locales/ko.ts
+++ b/frontend/src/app/locales/ko.ts
@@ -4935,7 +4935,7 @@ const resource = {
     "bim.upload_remove_file": "제거",
     "bim.upload_rvt_note": "참고: RVT 파일은 DDC cad2data가 필요합니다. IFC 사용을 고려하세요.",
     "bim.upload_simple_mode_toggle": "단순 모드로 전환",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · 최대 500MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · 최대 2GB",
     "bim.upload_success_desc": "모델을 성공적으로 업로드했습니다.",
     "bim.upload_title": "BIM 데이터 업로드",
     "bim.upload_unsupported_format": "지원되지 않는 형식입니다.",

--- a/frontend/src/app/locales/no.ts
+++ b/frontend/src/app/locales/no.ts
@@ -6864,7 +6864,7 @@ const resource = {
     "bim.upload_remove_file": "Fjern",
     "bim.upload_rvt_note": "Merk: RVT-filer krever DDC cad2data. Vurder IFC.",
     "bim.upload_simple_mode_toggle": "Bytt til enkel modus",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 2 GB",
     "bim.upload_success_desc": "Modell lastet opp.",
     "bim.upload_title": "Last opp BIM-data",
     "bim.upload_unsupported_format": "Format som ikke støttes.",

--- a/frontend/src/app/locales/pl.ts
+++ b/frontend/src/app/locales/pl.ts
@@ -4935,7 +4935,7 @@ const resource = {
     "bim.upload_remove_file": "Usuń",
     "bim.upload_rvt_note": "Uwaga: Pliki RVT wymagają DDC cad2data. Proszę rozważyć IFC.",
     "bim.upload_simple_mode_toggle": "Przełącz na tryb prosty",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks. 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks. 2 GB",
     "bim.upload_success_desc": "Model przesłany pomyślnie.",
     "bim.upload_title": "Prześlij dane BIM",
     "bim.upload_unsupported_format": "Nieobsługiwany format.",

--- a/frontend/src/app/locales/ru.ts
+++ b/frontend/src/app/locales/ru.ts
@@ -5553,7 +5553,7 @@ const resource = {
     "bim.upload_remove_file": "Удалить",
     "bim.upload_rvt_note": "Примечание: для RVT-файлов требуется DDC cad2data. Рекомендуется IFC.",
     "bim.upload_simple_mode_toggle": "Перейти в простой режим",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Макс. 500 МБ",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Макс. 2 ГБ",
     "bim.upload_unsupported_format": "Неподдерживаемый формат.",
     "match_elements.title": "Сопоставление элементов",
     "match_elements.subtitle": "Сопоставить элементы BIM → позиции CWICR. BIM активен; DWG / PDF / Фото добавим в следующих фазах.",

--- a/frontend/src/app/locales/th.ts
+++ b/frontend/src/app/locales/th.ts
@@ -4938,7 +4938,7 @@ const resource = {
     "bim.upload_remove_file": "ลบ",
     "bim.upload_rvt_note": "หมายเหตุ: ไฟล์ RVT ต้องใช้ DDC cad2data พิจารณาใช้ IFC",
     "bim.upload_simple_mode_toggle": "เปลี่ยนเป็นโหมดเรียบง่าย",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · สูงสุด 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · สูงสุด 2 GB",
     "bim.upload_success_desc": "อัปโหลดแบบจำลองสำเร็จ",
     "bim.upload_title": "อัปโหลดข้อมูล BIM",
     "bim.upload_unsupported_format": "รูปแบบไม่รองรับ",

--- a/frontend/src/app/locales/tr.ts
+++ b/frontend/src/app/locales/tr.ts
@@ -4935,7 +4935,7 @@ const resource = {
     "bim.upload_remove_file": "Kaldır",
     "bim.upload_rvt_note": "Not: RVT dosyaları DDC cad2data gerektirir. IFC kullanmayı düşünün.",
     "bim.upload_simple_mode_toggle": "Basit moda geç",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Maks 2 GB",
     "bim.upload_success_desc": "Model başarıyla yüklendi.",
     "bim.upload_title": "BIM Verisi Yükle",
     "bim.upload_unsupported_format": "Desteklenmeyen format.",

--- a/frontend/src/app/locales/vi.ts
+++ b/frontend/src/app/locales/vi.ts
@@ -4938,7 +4938,7 @@ const resource = {
     "bim.upload_remove_file": "Xóa",
     "bim.upload_rvt_note": "Lưu ý: Tệp RVT yêu cầu DDC cad2data. Hãy cân nhắc dùng IFC.",
     "bim.upload_simple_mode_toggle": "Chuyển sang chế độ đơn giản",
-    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Tối đa 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt), IFC (.ifc) · Tối đa 2 GB",
     "bim.upload_success_desc": "Đã tải lên mô hình thành công.",
     "bim.upload_title": "Tải lên dữ liệu BIM",
     "bim.upload_unsupported_format": "Định dạng không được hỗ trợ.",

--- a/frontend/src/app/locales/zh.ts
+++ b/frontend/src/app/locales/zh.ts
@@ -4936,7 +4936,7 @@ const resource = {
     "bim.upload_remove_file": "移除",
     "bim.upload_rvt_note": "注意：RVT 文件需要 DDC cad2data，建议使用 IFC。",
     "bim.upload_simple_mode_toggle": "切换至简洁模式",
-    "bim.upload_size_hint": "Revit (.rvt)、IFC (.ifc) · 最大 500 MB",
+    "bim.upload_size_hint": "Revit (.rvt)、IFC (.ifc) · 最大 2 GB",
     "bim.upload_success_desc": "模型上传成功。",
     "bim.upload_title": "上传 BIM 数据",
     "bim.upload_unsupported_format": "不支持的格式。",

--- a/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
+++ b/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
@@ -25,6 +25,89 @@ describe('uploadCADFile', () => {
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
+  it('uploads large BIM files as resumable chunks', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch');
+    const fileSize = 9 * 1024 * 1024 + 1;
+    const initResponse = {
+      model_id: 'model-1',
+      project_id: 'project-1',
+      upload_id: 'upload-1',
+      key: 'projects/project-1/models/model-1/original.ifc',
+      filename: 'big.ifc',
+      file_size: fileSize,
+      chunk_size_bytes: 8 * 1024 * 1024,
+      model_format: 'ifc',
+      name: 'Big model',
+      discipline: 'architecture',
+      conversion_depth: 'standard',
+      status: 'uploading',
+      uploaded_bytes: 0,
+      next_part_number: 1,
+      uploaded_parts: [],
+    };
+    const firstChunk = 8 * 1024 * 1024;
+    const finalResponse = {
+      model_id: 'model-1',
+      name: 'Big model',
+      format: 'ifc',
+      file_size: fileSize,
+      status: 'processing',
+      element_count: 0,
+    };
+
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(initResponse), {
+          status: 201,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            model_id: 'model-1',
+            part_number: 1,
+            etag: 'etag-1',
+            size_bytes: firstChunk,
+            uploaded_bytes: firstChunk,
+            next_part_number: 2,
+            complete: false,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            model_id: 'model-1',
+            part_number: 2,
+            etag: 'etag-2',
+            size_bytes: fileSize - firstChunk,
+            uploaded_bytes: fileSize,
+            next_part_number: 3,
+            complete: false,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(finalResponse), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+
+    const file = new File([new Uint8Array(fileSize)], 'big.ifc');
+    const result = await uploadCADFile('project-1', 'Big model', 'architecture', file);
+
+    expect(result).toEqual(finalResponse);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(String(fetchMock.mock.calls[0][0])).toContain('/upload-cad/resumable/');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('/upload/parts/1/');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('/upload/parts/2/');
+    expect(String(fetchMock.mock.calls[3][0])).toContain('/upload/complete/');
+  });
+
   it('explains that a network-style failure may be a proxy body-size block', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
 

--- a/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
+++ b/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({ accessToken: 'test-token' }),
+  },
+}));
+
+import { uploadCADFile } from '../api';
+
+describe('uploadCADFile', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows a clearer message when the upload is rejected with HTTP 413', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 413, statusText: 'Payload Too Large' }),
+    );
+
+    await expect(
+      uploadCADFile('project-1', 'Model', 'architecture', new File(['ifc'], 'model.ifc')),
+    ).rejects.toThrow('The file is too large. Please try a smaller one.');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
+++ b/frontend/src/features/bim/__tests__/uploadCADFile.test.ts
@@ -24,4 +24,14 @@ describe('uploadCADFile', () => {
 
     expect(fetchMock).toHaveBeenCalledOnce();
   });
+
+  it('explains that a network-style failure may be a proxy body-size block', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('Failed to fetch'));
+
+    await expect(
+      uploadCADFile('project-1', 'Model', 'architecture', new File(['ifc'], 'model.ifc')),
+    ).rejects.toThrow(
+      'Upload failed before it reached the server. If this is a very large file, a proxy in front of the app may be blocking it.',
+    );
+  });
 });

--- a/frontend/src/features/bim/api.ts
+++ b/frontend/src/features/bim/api.ts
@@ -152,6 +152,217 @@ export interface BIMCadUploadResponse {
   message?: string | null;
 }
 
+interface BIMResumableUploadInitResponse {
+  model_id: string | null;
+  project_id: string;
+  upload_id: string | null;
+  key: string | null;
+  filename: string | null;
+  file_size: number;
+  chunk_size_bytes: number;
+  model_format: string;
+  name: string | null;
+  discipline?: string | null;
+  conversion_depth?: string | null;
+  status: string;
+  uploaded_bytes: number;
+  next_part_number: number;
+  uploaded_parts: Array<{
+    model_id: string;
+    part_number: number;
+    etag: string;
+    size_bytes: number;
+    uploaded_bytes: number;
+    next_part_number: number;
+    complete: boolean;
+  }>;
+  message?: string | null;
+  converter_id?: string | null;
+  install_endpoint?: string | null;
+  error_message?: string | null;
+}
+
+interface BIMResumableUploadPartResponse {
+  model_id: string;
+  part_number: number;
+  etag: string;
+  size_bytes: number;
+  uploaded_bytes: number;
+  next_part_number: number;
+  complete: boolean;
+}
+
+const BIM_RESUMABLE_UPLOAD_THRESHOLD_BYTES = 8 * 1024 * 1024;
+const BIM_RESUMABLE_UPLOAD_MAX_RETRIES = 3;
+
+async function parseBIMUploadError(response: Response, fallback: string): Promise<string> {
+  let detail = fallback;
+  try {
+    const body = await response.json();
+    detail = extractErrorMessageFromBody(body) ?? detail;
+  } catch {
+    // ignore parse errors
+  }
+  return detail;
+}
+
+async function initiateResumableCADUpload(
+  projectId: string,
+  name: string,
+  discipline: string,
+  file: File,
+  conversionDepth?: 'standard' | 'medium' | 'complete',
+): Promise<BIMResumableUploadInitResponse> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'X-DDC-Client': 'OE/1.0',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch('/api/v1/bim_hub/upload-cad/resumable/', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      project_id: projectId,
+      name,
+      discipline,
+      filename: file.name,
+      file_size: file.size,
+      chunk_size_bytes: BIM_RESUMABLE_UPLOAD_THRESHOLD_BYTES,
+      conversion_depth: conversionDepth,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await parseBIMUploadError(
+      response,
+      response.status === 413
+        ? 'The file is too large. Please try a smaller one.'
+        : `Upload failed (HTTP ${response.status})`,
+    );
+    throw new Error(detail);
+  }
+
+  return response.json();
+}
+
+async function uploadBIMResumablePart(
+  modelId: string,
+  partNumber: number,
+  chunk: Blob,
+  signal?: AbortSignal,
+): Promise<BIMResumableUploadPartResponse> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/octet-stream',
+    'X-DDC-Client': 'OE/1.0',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(
+    `/api/v1/bim_hub/models/${encodeURIComponent(modelId)}/upload/parts/${partNumber}/`,
+    {
+      method: 'PUT',
+      headers,
+      body: chunk,
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    const detail = await parseBIMUploadError(
+      response,
+      response.status === 413
+        ? 'The file is too large. Please try a smaller one.'
+        : `Upload failed (HTTP ${response.status})`,
+    );
+    throw new Error(detail);
+  }
+
+  return response.json();
+}
+
+async function completeBIMResumableUpload(modelId: string, signal?: AbortSignal): Promise<BIMCadUploadResponse> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'X-DDC-Client': 'OE/1.0',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(`/api/v1/bim_hub/models/${encodeURIComponent(modelId)}/upload/complete/`, {
+    method: 'POST',
+    headers,
+    body: '{}',
+    signal,
+  });
+
+  if (!response.ok) {
+    const detail = await parseBIMUploadError(
+      response,
+      response.status === 413
+        ? 'The file is too large. Please try a smaller one.'
+        : `Upload failed (HTTP ${response.status})`,
+    );
+    throw new Error(detail);
+  }
+
+  return response.json();
+}
+
+async function uploadCADFileResumable(
+  projectId: string,
+  name: string,
+  discipline: string,
+  file: File,
+  signal?: AbortSignal,
+  conversionDepth?: 'standard' | 'medium' | 'complete',
+): Promise<BIMCadUploadResponse> {
+  const init = await initiateResumableCADUpload(projectId, name, discipline, file, conversionDepth);
+  if (init.status !== 'uploading' || !init.model_id) {
+    return init as unknown as BIMCadUploadResponse;
+  }
+
+  const chunkSize = Math.max(1, init.chunk_size_bytes || BIM_RESUMABLE_UPLOAD_THRESHOLD_BYTES);
+  let offset = 0;
+  let partNumber = init.next_part_number || 1;
+
+  while (offset < file.size) {
+    const chunk = file.slice(offset, Math.min(offset + chunkSize, file.size));
+    let lastErr: unknown;
+
+    for (let attempt = 1; attempt <= BIM_RESUMABLE_UPLOAD_MAX_RETRIES; attempt += 1) {
+      try {
+        await uploadBIMResumablePart(init.model_id, partNumber, chunk, signal);
+        lastErr = undefined;
+        break;
+      } catch (err) {
+        lastErr = err;
+        if (err instanceof DOMException && err.name === 'AbortError') throw err;
+        if (attempt < BIM_RESUMABLE_UPLOAD_MAX_RETRIES) {
+          await new Promise((resolve) => setTimeout(resolve, attempt * 500));
+          continue;
+        }
+      }
+    }
+
+    if (lastErr) {
+      throw lastErr instanceof Error
+        ? lastErr
+        : new Error('Upload failed before it reached the server. If this is a very large file, a proxy in front of the app may be blocking it.');
+    }
+
+    offset += chunk.size;
+    partNumber += 1;
+  }
+
+  return completeBIMResumableUpload(init.model_id, signal);
+}
+
 /* ── Converter Management (BIM preflight + auto-install) ─────────────── */
 
 /** Health states surfaced by the backend smoke test:
@@ -1297,6 +1508,10 @@ export async function uploadCADFile(
   signal?: AbortSignal,
   conversionDepth?: 'standard' | 'medium' | 'complete',
 ): Promise<BIMCadUploadResponse> {
+  if (file.size > BIM_RESUMABLE_UPLOAD_THRESHOLD_BYTES) {
+    return uploadCADFileResumable(projectId, name, discipline, file, signal, conversionDepth);
+  }
+
   const formData = new FormData();
   formData.append('file', file);
 

--- a/frontend/src/features/bim/api.ts
+++ b/frontend/src/features/bim/api.ts
@@ -704,7 +704,7 @@ export async function uploadBIMData(
     // Re-throw AbortError as-is so callers can distinguish cancellation
     if (networkErr instanceof DOMException && networkErr.name === 'AbortError') throw networkErr;
     throw new Error(
-      'Cannot connect to server. Please check that the backend is running and try again.',
+      'Upload failed before it reached the server. If this is a very large file, a proxy in front of the app may be blocking it.',
     );
   }
 
@@ -1325,7 +1325,7 @@ export async function uploadCADFile(
     // Re-throw AbortError as-is so callers can distinguish cancellation
     if (networkErr instanceof DOMException && networkErr.name === 'AbortError') throw networkErr;
     throw new Error(
-      'Cannot connect to server. Please check that the backend is running and try again.',
+      'Upload failed before it reached the server. If this is a very large file, a proxy in front of the app may be blocking it.',
     );
   }
 

--- a/frontend/src/features/bim/api.ts
+++ b/frontend/src/features/bim/api.ts
@@ -709,7 +709,10 @@ export async function uploadBIMData(
   }
 
   if (!response.ok) {
-    let detail = `Upload failed (HTTP ${response.status})`;
+    let detail =
+      response.status === 413
+        ? 'The file is too large. Please try a smaller one.'
+        : `Upload failed (HTTP ${response.status})`;
     try {
       const body = await response.json();
       detail = extractErrorMessageFromBody(body) ?? detail;
@@ -1327,7 +1330,10 @@ export async function uploadCADFile(
   }
 
   if (!response.ok) {
-    let detail = `Upload failed (HTTP ${response.status})`;
+    let detail =
+      response.status === 413
+        ? 'The file is too large. Please try a smaller one.'
+        : `Upload failed (HTTP ${response.status})`;
     try {
       const body = await response.json();
       detail = extractErrorMessageFromBody(body) ?? detail;

--- a/frontend/src/shared/ui/BIMViewer/BIMViewer.tsx
+++ b/frontend/src/shared/ui/BIMViewer/BIMViewer.tsx
@@ -3349,7 +3349,7 @@ export function BIMViewer({
           <div className="flex flex-col items-center gap-2 text-center">
             <Box size={40} className="text-content-tertiary" />
             <span className="text-sm text-content-tertiary">
-              {t('bim.no_elements', { defaultValue: 'No elements to display' })}
+              {t('bim.no_elements', { defaultValue: 'No BIM elements found' })}
             </span>
           </div>
         </div>


### PR DESCRIPTION
Add a chunked/resumable BIM CAD upload flow for large files so uploads travel in small requests instead of a single oversized multipart body.

Includes:
- new resumable upload session endpoints on the BIM backend
- chunk upload + completion flow backed by multipart storage
- frontend switch to resumable mode for large files
- tests for the resumable flow and the frontend chunked path