### PR TITLE
fix(vector): migrate removed qdrant-client .search() to .query_points()

### DIFF
--- a/backend/app/core/vector.py
+++ b/backend/app/core/vector.py
@@ -852,7 +852,7 @@ def vector_search(
         search_filter = None
         if region:
             search_filter = Filter(must=[FieldCondition(key="region", match=MatchValue(value=region))])
-        results = client.search(COST_TABLE, query_vector=query_vector, query_filter=search_filter, limit=limit)
+        results = client.query_points(COST_TABLE, query=query_vector, query_filter=search_filter, limit=limit).points
         return [{"id": h.id, "score": round(h.score, 4), **h.payload} for h in results]
 
     return _lancedb_search(query_vector, region, limit)
@@ -948,12 +948,12 @@ def vector_search_collection(
             must_clauses.append(FieldCondition(key="tenant_id", match=MatchValue(value=tenant_id)))
         search_filter = Filter(must=must_clauses) if must_clauses else None
         try:
-            results = client.search(
+            results = client.query_points(
                 collection_name,
-                query_vector=query_vector,
+                query=query_vector,
                 query_filter=search_filter,
                 limit=limit,
-            )
+            ).points
         except Exception as exc:
             logger.debug("Qdrant search %s failed: %s", collection_name, exc)
             return []


### PR DESCRIPTION
## Problem

`qdrant-client >= 1.12` removed the legacy `client.search()` method (consolidated into `client.query_points()`). `backend/pyproject.toml` declares `qdrant-client>=1.12.0`, so on any supported install the two `client.search(...)` calls in `backend/app/core/vector.py` raise at runtime:

```
AttributeError: 'QdrantClient' object has no attribute 'search'
```

This breaks the Qdrant backend for cost-catalogue semantic search: `GET /api/v1/costs/vector/search/` and the `vector_search_collection()` path used by `core/vector_index.py` and the per-module `vector_adapter.py` return HTTP 500. The newer CWICR path (`modules/costs/qdrant_adapter.py`) already uses `query_points()`; `vector.py` was simply never migrated.

## Fix

Migrate the two remaining call sites in `vector.py` from
`client.search(collection, query_vector=..., query_filter=..., limit=...)`
to
`client.query_points(collection, query=..., query_filter=..., limit=...).points`.

`query_points()` returns a `QueryResponse`; `.points` is the list of `ScoredPoint` carrying the same `.id` / `.score` / `.payload`, so the downstream result mapping is unchanged. Minimal, behavior-preserving — it just restores the call on modern qdrant-client.

## Testing

Verified on a live `v7.5.0` instance (qdrant-client 1.18.0): cost-catalogue semantic search now returns ranked results — e.g. query `монолитные железобетонные стены` → top hits scored ~0.91 (`Устройство монолитных … железобетонных стен …`). Previously the same path failed with the `AttributeError` above.
