### PR TITLE
fix: harden tenant auth and money math across 12 modules

### DIFF
--- a/backend/app/core/validation/engine.py
+++ b/backend/app/core/validation/engine.py
@@ -38,9 +38,10 @@ class Severity(StrEnum):
 class ValidationStatus(StrEnum):
     """‌⁠‍Overall validation status."""
 
-    PASSED = "passed"  # No errors, no warnings
+    PASSED = "passed"  # No errors, no warnings, no failing info
     WARNINGS = "warnings"  # Warnings only, no errors
     ERRORS = "errors"  # Has errors (may also have warnings)
+    INFO = "info"  # Failing INFO results only, no errors or warnings
     SKIPPED = "skipped"  # Validation was skipped (no applicable rules)
 
 
@@ -167,6 +168,12 @@ class ValidationReport:
             return ValidationStatus.ERRORS
         if self.has_warnings:
             return ValidationStatus.WARNINGS
+        # Failing INFO results are real unresolved findings: a report with a
+        # sub-1.0 score and info_count > 0 must not read as a clean PASSED.
+        # Surface them as INFO (mirrors the BIM service), with errors and
+        # warnings still taking precedence above.
+        if self.infos:
+            return ValidationStatus.INFO
         return ValidationStatus.PASSED
 
     @property

--- a/backend/app/core/validation/rules/__init__.py
+++ b/backend/app/core/validation/rules/__init__.py
@@ -1733,7 +1733,10 @@ class LumpSumRatio(ValidationRule):
 
     async def validate(self, context: ValidationContext) -> list[RuleResult]:
         locale = _get_locale(context)
-        positions = _get_positions(context)
+        # Count over leaf positions only: section/header rows never carry a
+        # unit, so including them in the denominator dilutes the lump-sum
+        # ratio and under-flags lump-sum-heavy BOQs.
+        positions = _get_leaf_positions(context)
         if not positions:
             return []
 
@@ -2644,7 +2647,10 @@ class DPGFPricingComplete(ValidationRule):
 
     async def validate(self, context: ValidationContext) -> list[RuleResult]:
         locale = _get_locale(context)
-        positions = _get_positions(context)
+        # Use leaf positions only: section/header rows intentionally carry no
+        # unit_rate, so counting them in the denominator understates the
+        # pricing-completeness ratio (matches PositionHasUnitRate).
+        positions = _get_leaf_positions(context)
         if not positions:
             return []
         priced = sum(1 for p in positions if p.get("unit_rate") and (_num(p["unit_rate"], default=0.0) or 0.0) > 0)

--- a/backend/app/modules/ai/service.py
+++ b/backend/app/modules/ai/service.py
@@ -815,9 +815,7 @@ class AIService:
                 create_kwargs["metadata_"] = _merge_overrides({}, data.model_overrides)
             current_meta = create_kwargs.get("metadata_", {})
             if isinstance(current_meta, dict):
-                create_kwargs["metadata_"] = _merge_base_urls(
-                    current_meta, data.ollama_base_url, data.vllm_base_url
-                )
+                create_kwargs["metadata_"] = _merge_base_urls(current_meta, data.ollama_base_url, data.vllm_base_url)
             settings = AISettings(**create_kwargs)
             settings = await self.settings_repo.create(settings)
         else:
@@ -833,9 +831,7 @@ class AIService:
             has_base_url_update = data.ollama_base_url is not None or data.vllm_base_url is not None
             if has_base_url_update:
                 base_meta = fields.get("metadata_", settings.metadata_)
-                fields["metadata_"] = _merge_base_urls(
-                    base_meta, data.ollama_base_url, data.vllm_base_url
-                )
+                fields["metadata_"] = _merge_base_urls(base_meta, data.ollama_base_url, data.vllm_base_url)
 
             if fields:
                 await self.settings_repo.update_fields(settings.id, **fields)

--- a/backend/app/modules/ai_estimator/service.py
+++ b/backend/app/modules/ai_estimator/service.py
@@ -1826,11 +1826,19 @@ class AiEstimatorService:
                     status_code=400,
                     detail="candidate_id must be one of this group's existing candidates.",
                 )
+            # Recompute confidence from the newly chosen candidate so the stored
+            # score/confidence/confidence_band describe this candidate, not the
+            # previously suggested one (mirrors update_group's override path).
+            # An explicit spec.confidence below still overrides this.
+            score = self._real_confidence(cand.get("score"))
             fields.update(
                 candidate_id=cand.get("candidate_id"),
                 chosen_code=cand.get("code"),
                 unit_rate=cand.get("unit_rate"),
                 currency=cand.get("currency") or None,
+                score=score,
+                confidence=score,
+                confidence_band=cand.get("confidence_band") or _confidence_band(score),
                 resources=await self._resource_breakdown(cand.get("candidate_id")),
                 match_method="manual",
             )
@@ -1899,8 +1907,14 @@ class AiEstimatorService:
                 fx = fx_map.get(currency)
                 if fx:
                     base_line = line * _dec(fx)
-            grand_total += base_line
-            subtotals[currency or base_currency] = subtotals.get(currency or base_currency, Decimal("0")) + line
+            # Only confirmed/overridden groups are written by apply(), so only
+            # those roll into the headline total. 'suggested' rows are still
+            # listed below for review (confirmed=False) but excluded here, so
+            # the preview total can never exceed what apply books.
+            is_confirmed = grp.status in ("confirmed", "overridden")
+            if is_confirmed:
+                grand_total += base_line
+                subtotals[currency or base_currency] = subtotals.get(currency or base_currency, Decimal("0")) + line
 
             confidence = grp.confidence
             rows.append(
@@ -1917,7 +1931,7 @@ class AiEstimatorService:
                     confidence=confidence,
                     confidence_band=grp.confidence_band or _confidence_band(confidence),  # type: ignore[arg-type]
                     resources=resources,
-                    confirmed=False,
+                    confirmed=is_confirmed,
                 )
             )
             validation_positions.append(

--- a/backend/app/modules/assemblies/service.py
+++ b/backend/app/modules/assemblies/service.py
@@ -925,6 +925,12 @@ class AssemblyService:
         if not base_rate.is_finite() or base_rate < 0:
             base_rate = Decimal("0")
 
+        # ``regional_mult`` is captured as a reusable Decimal so the
+        # per-resource rates below can carry the SAME regional premium the
+        # position unit_rate gets. It stays Decimal("1") whenever the
+        # region is absent or its stored factor is garbage / non-finite,
+        # mirroring the effective_rate fall-through contract.
+        regional_mult = Decimal("1")
         if data.region and data.region in assembly.regional_factors:
             try:
                 factor = Decimal(str(assembly.regional_factors[data.region]))
@@ -935,8 +941,10 @@ class AssemblyService:
                 # existing fall-through contract for an absent region).
                 effective_rate = base_rate
             else:
+                regional_mult = factor
                 effective_rate = base_rate * factor
                 if not effective_rate.is_finite():
+                    regional_mult = Decimal("1")
                     effective_rate = base_rate
         else:
             effective_rate = base_rate
@@ -981,14 +989,54 @@ class AssemblyService:
         # Issue #128 - scale each component's money fields by the same FX
         # multiplier as the rate so the resource breakdown stays
         # consistent with the converted unit_rate.
-        fx_mult_f = float(fx_multiplier)
+        # Per-resource uplift = bid_factor * regional * fx. The BOQ resource
+        # invariant is position.unit_rate == SUM(r.quantity * r.unit_rate)
+        # (see boq/service.py _resource_total_in_base and update_position).
+        # The component's STORED ``total`` already folds in factor, the raw
+        # quantity, unit_cost and any typed uplift (factor*quantity*unit_cost
+        # with waste/burden/fuel layered on). What it does NOT fold in is the
+        # assembly-level bid_factor, the regional premium, or the FX
+        # conversion - those live only in ``effective_rate``. If we emit raw
+        # quantity*unit_cost rows the later resource-triggered recompute in
+        # BOQ.update_position collapses unit_rate to that factor-less,
+        # bid-less, regional-less, fx-less sum and silently corrupts the line.
+        # So we make each row self-consistent: keep the per-unit quantity and
+        # set unit_rate = (comp.total / quantity) * uplift, so that
+        # quantity*unit_rate == comp.total*uplift, and the sum over all rows
+        # reproduces effective_rate exactly.
+        try:
+            bid_mult = Decimal(str(assembly.bid_factor))
+        except (InvalidOperation, ValueError):
+            bid_mult = Decimal("1")
+        if not bid_mult.is_finite() or bid_mult < 0:
+            bid_mult = Decimal("1")
+        resource_uplift = bid_mult * regional_mult * fx_multiplier
+        if not resource_uplift.is_finite() or resource_uplift < 0:
+            resource_uplift = Decimal("1")
         for comp in components:
             res_type = comp.resource_type or _infer_legacy(comp.description or "")
-            comp_total = _str_to_float(comp.total) * fx_mult_f
+            # The component's adjusted contribution (factor*quantity*unit_cost
+            # plus typed uplift), scaled by the assembly-level uplift.
             try:
-                breakdown_totals[res_type] = breakdown_totals.get(res_type, Decimal("0")) + Decimal(str(comp_total))
+                comp_total_dec = Decimal(str(comp.total or "0")) * resource_uplift
             except (InvalidOperation, ValueError):
-                pass
+                comp_total_dec = Decimal("0")
+            if not comp_total_dec.is_finite():
+                comp_total_dec = Decimal("0")
+            comp_total = float(comp_total_dec)
+            # Keep the per-unit norm as the raw component quantity so the
+            # /boq resource grid still shows the real takeoff figure; derive
+            # unit_rate so that quantity*unit_rate == comp_total. When the
+            # quantity is zero (lump-sum row) collapse to quantity=1 so the
+            # product still carries the full contribution rather than 0.
+            comp_qty = _str_to_float(comp.quantity)
+            if comp_qty > 0:
+                res_quantity = comp_qty
+                res_unit_rate = comp_total / comp_qty
+            else:
+                res_quantity = 1.0
+                res_unit_rate = comp_total
+            breakdown_totals[res_type] = breakdown_totals.get(res_type, Decimal("0")) + comp_total_dec
 
             resources.append(
                 {
@@ -996,8 +1044,8 @@ class AssemblyService:
                     "code": "",
                     "type": res_type,
                     "unit": comp.unit or "",
-                    "quantity": _str_to_float(comp.quantity),
-                    "unit_rate": _str_to_float(comp.unit_cost) * fx_mult_f,
+                    "quantity": res_quantity,
+                    "unit_rate": res_unit_rate,
                     "total": comp_total,
                     # Pass through useful metadata (vendor, waste_pct,
                     # crew_size, …) so downstream consumers can inspect

--- a/backend/app/modules/boq/service.py
+++ b/backend/app/modules/boq/service.py
@@ -1086,7 +1086,7 @@ def _resource_total_in_base(
     resources: list[dict[str, Any]],
     fx_rates_map: dict[str, str] | None,
     base_currency: str,
-) -> float:
+) -> Decimal:
     """Sum resource subtotals in the project's BASE currency.
 
     Issue #88 - each resource dict may carry an optional ``currency``. When
@@ -1098,30 +1098,32 @@ def _resource_total_in_base(
     time (this function silently skips the conversion to keep the rollup
     deterministic and never zero out a row).
 
+    The rollup is accumulated with ``Decimal`` (qty, rate and fx are coerced
+    via ``_to_decimal``) so summing many lines never drifts in binary float
+    before the caller's ``_quantize_money_str`` snaps to 4dp. Returns a
+    ``Decimal``; callers already wrap it via ``_quantize_money_str`` /
+    ``_to_decimal(str(...))``.
+
     Pure function - no DB I/O - so it's cheap to call from update_position
     and reusable from snapshot/export paths.
     """
     if not resources:
-        return 0.0
+        return Decimal("0")
     base = (base_currency or "").upper()
-    total = 0.0
+    total = Decimal("0")
     for r in resources:
         if not isinstance(r, dict):
             continue
-        try:
-            qty = float(r.get("quantity", 0) or 0)
-            rate = float(r.get("unit_rate", 0) or 0)
-        except (TypeError, ValueError):
-            continue
+        qty = _to_decimal(r.get("quantity"))
+        rate = _to_decimal(r.get("unit_rate"))
         sub = qty * rate
         code = str(r.get("currency") or "").strip().upper()
         if code and code != base and fx_rates_map:
             fx = fx_rates_map.get(code)
             if fx:
-                try:
-                    sub = sub * float(fx)
-                except (TypeError, ValueError):
-                    pass
+                fx_dec = _to_decimal(fx)
+                if fx_dec.is_finite() and fx_dec != 0:
+                    sub = sub * fx_dec
         total += sub
     return total
 
@@ -5573,6 +5575,13 @@ class BOQService:
             # lazy-refresh ``editor_position`` afterwards (MissingGreenlet).
             editor_id = editor_position.id
             editor_boq_id = editor_position.boq_id
+            # Resolve the project FX table once so each instance's derived
+            # unit_rate converts foreign-currency resources into the project
+            # BASE currency before summing, exactly as update_position and
+            # recalculate_rates do (Issue #88 / #157). Best-effort: a lookup
+            # failure returns ("", {}) so the rollup degrades to a raw sum
+            # rather than blending currencies into the stored rate.
+            fx_base_ccy, fx_map = await self._resolve_project_fx_by_project(project_id)
             # Oldest-first - the FIRST carrier of a code is its master.
             positions = await self.position_repo.list_for_project(project_id)
 
@@ -5657,15 +5666,13 @@ class BOQService:
                     continue
                 new_meta = dict(meta)
                 new_meta["resources"] = new_res
-                # Recompute the position's derived unit_rate from resources
-                # (mirrors the frontend handleUpdateResourceFields rollup).
-                roll = 0.0
-                for r in new_res:
-                    if isinstance(r, dict):
-                        roll += _str_to_float(r.get("total")) or (
-                            _str_to_float(r.get("quantity")) * _str_to_float(r.get("unit_rate"))
-                        )
-                derived_rate = _quantize_money_str(round(roll, 4))
+                # Recompute the position's derived unit_rate from resources.
+                # Each resource is converted from its own currency to the
+                # project base via the FX table before summing, mirroring
+                # update_position / recalculate_rates so this propagation path
+                # never blends currencies into the stored rate (Issue #88 / #157).
+                res_dicts = [r for r in new_res if isinstance(r, dict)]
+                derived_rate = _quantize_money_str(_resource_total_in_base(res_dicts, fx_map, fx_base_ccy or ""))
                 new_total = _compute_total(s["quantity"], derived_rate)
                 await self.position_repo.update_fields(
                     s["id"],
@@ -6028,8 +6035,16 @@ class BOQService:
 
                     cat = self._normalize_resource_category(res_type)
 
-                    # Scale resource cost by position quantity
-                    scaled_cost = res_total * max(pos_qty, 1.0)
+                    # Scale the per-unit resource subtotal by the real
+                    # position quantity. ``res.total`` is the PER-UNIT
+                    # subtotal (r.quantity * r.unit_rate) and the position's
+                    # authoritative total is pos.quantity * Σ(res.total), so
+                    # scaling by ``pos_qty`` makes this branch sum to the same
+                    # canonical direct cost as the stored ``pos.total`` summed
+                    # everywhere else. Never substitute 1.0 for a legitimate
+                    # fractional or zero quantity (that over-stated 0.5 m3 as
+                    # 1.0 and reported a full subtotal for a 0-qty position).
+                    scaled_cost = res_total * pos_qty
 
                     category_amounts[cat] = category_amounts.get(cat, 0.0) + scaled_cost
                     category_counts[cat] = category_counts.get(cat, 0) + 1

--- a/backend/app/modules/changeorders/service.py
+++ b/backend/app/modules/changeorders/service.py
@@ -1352,7 +1352,13 @@ class ChangeOrderService:
                 rate = Decimal(str(item.new_rate or "0"))
             except (InvalidOperation, ValueError):
                 rate = Decimal("0")
-            line_total = qty * rate
+            # The BOQ subtotal must move by the same amount the budget/EVM
+            # does. Budget writeback is driven by order.cost_impact, which is
+            # the sum of each item's stored cost_delta (the scope-change
+            # amount), not the gross new-line value qty*rate. For a 'modified'
+            # item the gross value overstates the change, so roll the section
+            # total from cost_delta to keep BOQ and budget in lockstep.
+            line_total = _dec(item.cost_delta)
             item_total += line_total
 
             position = Position(
@@ -1402,15 +1408,41 @@ class ChangeOrderService:
             "section_total": str(item_total),
         }
 
-    async def reject_order(self, order_id: uuid.UUID, user_id: str) -> ChangeOrder:
+    async def reject_order(
+        self,
+        order_id: uuid.UUID,
+        user_id: str,
+        *,
+        _from_chain: bool = False,
+    ) -> ChangeOrder:
         """Reject a submitted change order.
 
         BUG-351: writes to dedicated ``rejected_by`` / ``rejected_at`` fields
         rather than reusing the ``approved_*`` columns. Audit trails and
         dashboards now show "rejected by X" instead of "approved by X"
         when a CO is refused.
+
+        Like ``approve_order``, the legacy single-step reject is gated on the
+        presence of an approval chain. While a chain is in flight the reject
+        must go through ``advance_approval`` so the per-step authorization
+        (the assigned approver check) is enforced - otherwise any user with
+        the approve permission could short-circuit a multi-approver chain
+        from the reject side, the same bypass the approve gate prevents. The
+        ``_from_chain=True`` escape hatch lets the chain path reuse this code
+        without tripping the gate.
         """
         order = await self.get_order(order_id)
+        # Gate the legacy single-step reject on the presence of an approval
+        # chain so a non-approver cannot kill an in-flight chain without the
+        # per-step authorization advance_approval enforces.
+        if not _from_chain and await self._has_approval_chain(order_id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "This change order has a multi-step approval chain. "
+                    "Use POST /v1/changeorders/{id}/advance-approval instead."
+                ),
+            )
         await self._assert_not_self_approval(order, user_id, "reject")
         self._validate_transition(order.status, "rejected")
         # Snapshot pre-transition state for the audit row.
@@ -1418,11 +1450,15 @@ class ChangeOrderService:
         code_snapshot = order.code
 
         now = datetime.now(UTC).isoformat()[:19]
+        # Clear the chain cursor on reject so a rejected CO never retains a
+        # live cursor pointing at a still-pending step (mirrors the chain
+        # reject path in advance_approval).
         await self.repo.update_fields(
             order_id,
             status="rejected",
             rejected_by=user_id,
             rejected_at=now,
+            current_approval_step=None,
         )
         await _safe_audit(
             self.session,

--- a/backend/app/modules/closeout/job.py
+++ b/backend/app/modules/closeout/job.py
@@ -62,6 +62,11 @@ async def closeout_build_handler(job_run: JobRun, payload: dict[str, Any]) -> di
         package.last_built_at = datetime.now(UTC).isoformat()
         package.last_built_job_id = job_run.id
         session.add(package)
+        # Now that package_key is set, has_built is True, so generated required
+        # slots count as delivered. Recompute the denormalised counters/status
+        # so a fully delivered, built package can reach ready/100% and the
+        # persisted status no longer contradicts the API ready flag.
+        await service.recompute_completeness(package)
         await session.commit()
 
     result = {

--- a/backend/app/modules/closeout/service.py
+++ b/backend/app/modules/closeout/service.py
@@ -583,17 +583,31 @@ class CloseoutService:
 
         # The build is producing the generated artifacts right now, so report
         # them as present for this package's own cover / manifest readiness.
+        # The completeness numbers must use the same treat_built=True basis as
+        # the ready flag, otherwise the cover / manifest contradict themselves
+        # (generated required slots present for ready, absent for the percent).
+        # The persisted package row was last recomputed with has_built=False,
+        # so we derive consistent counts locally here instead of reading it.
+        required_slots = [s for s in slots if s.is_required]
+        required_count = len(required_slots)
+        delivered_count = 0
+        for slot in required_slots:
+            st = self._slot_status(slot, bindings.get(slot.id), has_built=True)
+            if st == "verified" or (slot.source_kind == "generated" and slot.generated_artifact in _GENERATED_KINDS):
+                delivered_count += 1
+        completeness_pct = 100 if required_count == 0 else round(delivered_count * 100 / required_count)
+
         gaps = await self.gaps(package, treat_built=True)
-        ready = len(gaps) == 0 and package.required_slot_count > 0
+        ready = len(gaps) == 0 and required_count > 0
 
         # ── Cover PDF ────────────────────────────────────────────────────
         cover_summary = {
             "project_name": project_name,
             "project_type": package.project_type,
             "title": package.title,
-            "completeness_pct": package.completeness_pct,
-            "required_slot_count": package.required_slot_count,
-            "delivered_slot_count": package.delivered_slot_count,
+            "completeness_pct": completeness_pct,
+            "required_slot_count": required_count,
+            "delivered_slot_count": delivered_count,
             "ready": ready,
             "gaps": gaps,
             "slots": slot_summaries,
@@ -616,9 +630,9 @@ class CloseoutService:
             "project_type": package.project_type,
             "generated": date_iso,
             "completeness": {
-                "required_slot_count": package.required_slot_count,
-                "delivered_slot_count": package.delivered_slot_count,
-                "completeness_pct": package.completeness_pct,
+                "required_slot_count": required_count,
+                "delivered_slot_count": delivered_count,
+                "completeness_pct": completeness_pct,
                 "ready": ready,
                 "gaps": gaps,
             },
@@ -645,11 +659,11 @@ class CloseoutService:
                 total_bytes += len(data)
             zf.writestr("index.json", json.dumps(index, indent=2, ensure_ascii=False))
             zf.writestr("manifest.json", json.dumps(manifest_obj, indent=2, ensure_ascii=False))
-            zf.writestr("README.md", self._readme_md(project_name, package, ready, gaps))
+            zf.writestr("README.md", self._readme_md(project_name, package, completeness_pct, ready, gaps))
 
         build_summary = {
             "size_bytes": total_bytes,
-            "completeness_pct": package.completeness_pct,
+            "completeness_pct": completeness_pct,
             "ready": ready,
             "document_count": len(documents),
             "generated_count": len(generated),
@@ -666,13 +680,19 @@ class CloseoutService:
         }
 
     @staticmethod
-    def _readme_md(project_name: str, package: CloseoutPackage, ready: bool, gaps: list[str]) -> str:
+    def _readme_md(
+        project_name: str,
+        package: CloseoutPackage,
+        completeness_pct: int,
+        ready: bool,
+        gaps: list[str],
+    ) -> str:
         lines = [
             "# Digital handover and closeout package",
             "",
             f"Project: {project_name}",
             f"Project type: {package.project_type}",
-            f"Completeness: {package.completeness_pct}%",
+            f"Completeness: {completeness_pct}%",
             f"Status: {'READY' if ready else 'INCOMPLETE'}",
             "",
             "See manifest.json for the machine-readable index, cover.pdf for the",

--- a/backend/app/modules/costs/router.py
+++ b/backend/app/modules/costs/router.py
@@ -1846,9 +1846,7 @@ async def restore_qdrant_snapshot(
             "snapshot_path": local_path,
             "timeout_s": 1800,
         }
-        restored = await asyncio.to_thread(
-            qdrant_snapshot_loader.restore_snapshot_file, **restore_kwargs
-        )
+        restored = await asyncio.to_thread(qdrant_snapshot_loader.restore_snapshot_file, **restore_kwargs)
         if not restored:
             detail = f"Failed to restore Qdrant snapshot for {db_id}. Check Qdrant logs."
             raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, detail)
@@ -4597,12 +4595,13 @@ async def get_cost_item_certainty(
 @router.post(
     "/{item_id}/record-usage/",
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(RequirePermission("costs.read"))],
 )
 async def record_cost_item_usage(
     item_id: uuid.UUID,
     body: RecordUsageRequest,
     session: SessionDep,
-    user: OptionalUserPayload,
+    user: CurrentUserPayload,
 ) -> dict[str, object]:
     """‌⁠‍Append one row to the usage ledger.
 
@@ -4613,6 +4612,12 @@ async def record_cost_item_usage(
 
     Returns the new usage row's id + the refreshed certainty band so
     the frontend can update its badge cache in one round-trip.
+
+    Authenticated only. The usage ledger feeds the shared, cross-tenant
+    certainty badge (``CostCertaintyService.compute`` counts every row for
+    an item with no tenant scoping), so an anonymous writer could forge a
+    rate's "proven" status and inflate any project's frequency. We require
+    a usable subject and verify project access for EVERY caller.
     """
     # Verify cost item exists so we can give a precise 404 rather than
     # letting the FK CASCADE constraint do it at commit time.
@@ -4624,24 +4629,26 @@ async def record_cost_item_usage(
         )
 
     recorder = CostUsageRecorder(session)
-    used_by: uuid.UUID | None = None
-    sub = (user or {}).get("sub") if user else None
-    if sub:
-        try:
-            used_by = uuid.UUID(str(sub))
-        except (TypeError, ValueError):
-            # Anonymous / demo-token id may be non-UUID - silently drop.
-            used_by = None
+    sub = (user or {}).get("sub")
+    if not sub:
+        # Authenticated route, but defend against a token without a subject.
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    try:
+        used_by = uuid.UUID(str(sub))
+    except (TypeError, ValueError) as exc:
+        # A non-UUID subject (e.g. malformed token) cannot be attributed or
+        # access-checked, so it must not be allowed to write the shared ledger.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        ) from exc
 
-    # IDOR guard: when the caller is authenticated, verify they can see the
-    # target project before we record a usage row attributed to it. Without
-    # this check, any authenticated user could attribute apply-events to any
-    # project UUID they happen to know. Anonymous callers (no usable sub)
-    # skip the check - the demo / pre-auth analytics path is preserved
-    # (the unauth ledger row has ``used_by = NULL`` so it can't be used to
-    # forge an identity-attributed history).
-    if used_by is not None:
-        await verify_project_access(body.project_id, str(used_by), session)
+    # IDOR guard: verify the caller can see the target project before we
+    # record a usage row attributed to it. Without this check any user could
+    # attribute apply-events to any project UUID they happen to know and bump
+    # the item's shared certainty frequency. verify_project_access raises 404
+    # for both missing and inaccessible projects.
+    await verify_project_access(body.project_id, str(used_by), session)
 
     row = await recorder.record(
         item_id,

--- a/backend/app/modules/costs/schemas.py
+++ b/backend/app/modules/costs/schemas.py
@@ -33,46 +33,46 @@ _REGION_FORMAT_RE = re.compile(r"^[A-Z]{2,3}_[A-Z0-9]+$")
 # CWICR ingestion historically stored currency as an empty string because the
 # parquet files don't carry a currency column. We resolve the right ISO 4217
 # code from the region at response time so legacy rows behave correctly
-# without forcing a re-import. Keep the keys aligned with the frontend
-# REGION_MAP (UPPERCASE country prefix).
-_REGION_CURRENCY_FALLBACK: dict[str, str] = {
-    "DE_BERLIN": "EUR",
-    "DE_MUNICH": "EUR",
+# without forcing a re-import.
+#
+# Single source of truth: the v3 catalogue registry (CWICR_V3_CATALOGUES)
+# already declares the ISO currency of every region DDC ships, so we derive
+# the map from it exactly the way the router's search/autocomplete/match
+# paths do. The old hand-kept literal here only had 33 keys and omitted ~20
+# live regions (NGN/KES/GHS/KRW/THB/VND/...), so the single-item read path
+# returned an empty currency for rows the list/match paths labelled
+# correctly. Deriving from the catalogue keeps both paths in lockstep and new
+# catalogue rows are covered automatically.
+#
+# Legacy / alias keys that are NOT in the v3 registry (older parquet ``db_id``
+# tags) are merged on top so they keep resolving. This list is kept identical
+# to ``_REGION_CURRENCY_LEGACY`` in the router so the two maps cover the same
+# region keys.
+_REGION_CURRENCY_LEGACY: dict[str, str] = {
     "DE_HAMBURG": "EUR",
-    "AT_VIENNA": "EUR",
-    "CH_ZURICH": "CHF",
-    "FR_PARIS": "EUR",
-    "ES_MADRID": "EUR",
-    "IT_ROME": "EUR",
-    "NL_AMSTERDAM": "EUR",
     "BE_BRUSSELS": "EUR",
-    "PT_LISBON": "EUR",
-    # NOTE: ``PT_SAOPAULO`` was historically mislabeled (São Paulo is BR,
-    # not PT). Canonical key is ``BR_SAOPAULO`` (below). Removed here so a
-    # bad row would hit the warning path rather than silently resolve.
-    "GB_LONDON": "GBP",
     "IE_DUBLIN": "EUR",
-    "PL_WARSAW": "PLN",
-    "CZ_PRAGUE": "CZK",
-    "RO_BUCHAREST": "RON",
-    "RU_STPETERSBURG": "RUB",
-    "RU_MOSCOW": "RUB",
-    "USA_USD": "USD",
     "USA_NEWYORK": "USD",
-    "CA_TORONTO": "CAD",
-    "MX_MEXICO": "MXN",
-    "BR_SAOPAULO": "BRL",
-    "AR_BUENOSAIRES": "ARS",
-    "CN_SHANGHAI": "CNY",
-    "JP_TOKYO": "JPY",
-    "IN_MUMBAI": "INR",
-    "AE_DUBAI": "AED",
     "SA_RIYADH": "SAR",
-    "TR_ISTANBUL": "TRY",
-    "AU_SYDNEY": "AUD",
-    "NZ_AUCKLAND": "NZD",
-    "ZA_JOHANNESBURG": "ZAR",
+    # NOTE: ``PT_SAOPAULO`` is intentionally NOT registered - it was a
+    # mislabeled tag (São Paulo is Brazil; canonical key is ``BR_SAOPAULO``,
+    # supplied by the v3 registry). A stray ``PT_SAOPAULO`` row should hit the
+    # unknown-region path, not silently resolve.
 }
+
+
+def _build_region_currency_fallback() -> dict[str, str]:
+    """Derive ``{region: ISO currency}`` from the v3 catalogue + legacy aliases."""
+    from app.modules.costs.cwicr_v3_catalogue import CWICR_V3_CATALOGUES
+
+    out: dict[str, str] = {cat.region: cat.currency for cat in CWICR_V3_CATALOGUES if cat.currency}
+    # Legacy/alias keys only fill gaps - never override a canonical v3 entry.
+    for region, currency in _REGION_CURRENCY_LEGACY.items():
+        out.setdefault(region, currency)
+    return out
+
+
+_REGION_CURRENCY_FALLBACK: dict[str, str] = _build_region_currency_fallback()
 
 # ── Create / Update ───────────────────────────────────────────────────────
 

--- a/backend/app/modules/costs/service.py
+++ b/backend/app/modules/costs/service.py
@@ -360,12 +360,26 @@ class CostItemService:
         """
         created: list[CostItem] = []
         skipped_codes: list[str] = []
+        # Track (code, region) pairs already queued in this batch so an
+        # intra-payload duplicate skips the same way a DB duplicate does.
+        # Without this the second occurrence also passes the DB existence
+        # check, both rows reach bulk_create, and the flush violates the
+        # uq_costs_code_region unique constraint with an uncaught
+        # IntegrityError that 500s the whole import.
+        seen: set[tuple[str, str | None]] = set()
 
         for data in items_data:
+            key = (data.code, data.region)
+            if key in seen:
+                skipped_codes.append(data.code)
+                continue
+
             existing = await self.repo.get_by_code(data.code, region=data.region)
             if existing is not None:
                 skipped_codes.append(data.code)
                 continue
+
+            seen.add(key)
 
             item = CostItem(
                 code=data.code,
@@ -762,6 +776,11 @@ class CostBenchmarkService:
         has both a cost and an area in the filtered set.
         """
         from app.modules.boq.models import BOQ, Position
+        from app.modules.boq.service import (
+            _is_section,
+            _leaf_total_base_with_resources,
+            _project_fx_map,
+        )
 
         # ── 1. Resolve the candidate projects (tenant-scoped + filtered) ──
         projects = await self._candidate_projects(
@@ -774,22 +793,40 @@ class CostBenchmarkService:
             return self._empty(cost_per_m2)
 
         project_ids = [p.id for p in projects]
+        projects_by_id = {p.id: p for p in projects}
 
-        # ── 2. One grouped query for each project's BOQ direct-cost total ──
-        # Sum the per-position totals across every BOQ of the project. The
-        # totals are decimal-strings; we cast in Python (below) so a stray
-        # non-numeric legacy value is skipped rather than aborting the query.
+        # ── 2. One query for each project's BOQ leaf positions ────────────
+        # Sum each project's BOQ in its OWN base currency. Position.total is
+        # stored in the position's NATIVE currency (per-position
+        # metadata.currency or foreign-priced resources), so a blind SUM of
+        # the raw strings blends currencies inside a single project (e.g.
+        # 100000 ARS + 25000 USD added as 125000). We mirror the canonical
+        # BOQ rollup: convert every leaf into the project base via the
+        # project's FX table before accumulating, so the per-project cost/m2
+        # is genuinely single-currency (Issues #111/#131/#88/#157). Section
+        # rows are skipped exactly as the direct-cost rollup does.
         rows = (
             await self.session.execute(
-                select(BOQ.project_id, Position.total)
+                select(BOQ.project_id, Position)
                 .join(Position, Position.boq_id == BOQ.id)
                 .where(BOQ.project_id.in_(project_ids))
             )
         ).all()
+        # Cache each project's (base_currency, fx_map) so we build it once.
+        fx_by_project: dict[uuid.UUID, tuple[str, dict[str, str]]] = {}
         totals_by_project: dict[uuid.UUID, Decimal] = {}
-        for proj_id, raw_total in rows:
-            amount = _parse_decimal(raw_total)
-            if amount is None:
+        for proj_id, pos in rows:
+            if _is_section(pos):
+                continue
+            fx = fx_by_project.get(proj_id)
+            if fx is None:
+                proj = projects_by_id.get(proj_id)
+                base_ccy = (getattr(proj, "currency", "") or "").strip().upper()
+                fx = (base_ccy, _project_fx_map(proj))
+                fx_by_project[proj_id] = fx
+            base_ccy, fx_map = fx
+            amount = _leaf_total_base_with_resources(pos, fx_map, base_ccy)
+            if amount is None or amount <= 0:
                 continue
             totals_by_project[proj_id] = totals_by_project.get(proj_id, Decimal("0")) + amount
 
@@ -810,7 +847,8 @@ class CostBenchmarkService:
             return self._empty(cost_per_m2)
 
         # ── 4. Pick the currency bucket (never mix currencies) ────────────
-        target_currency = (currency or "").strip().upper()
+        requested_currency = (currency or "").strip().upper()
+        target_currency = requested_currency
         if not target_currency:
             # Use the dominant currency among the usable projects.
             counts: dict[str, int] = {}
@@ -820,6 +858,18 @@ class CostBenchmarkService:
 
         values = sorted(v for v, cur in per_project if cur == target_currency)
         if not values:
+            if requested_currency:
+                # The caller pinned a currency that no usable project matches.
+                # Do NOT fall back to a different-currency bucket; say so plainly
+                # so the percentile is never computed across currencies.
+                return {
+                    "currency": requested_currency,
+                    "own_portfolio": None,
+                    "percentile_vs_own": None,
+                    "explanation": (
+                        f"No comparable projects priced in {requested_currency} to position your value against."
+                    ),
+                }
             return self._empty(cost_per_m2)
 
         # ── 5. Distribution statistics ────────────────────────────────────
@@ -835,11 +885,28 @@ class CostBenchmarkService:
             "note": (f"Based on {count} of your {'project' if count == 1 else 'projects'} with cost and area."),
         }
 
+        # ── 6. Position the caller's value, but only within ITS OWN currency.
+        # ``cost_per_m2`` is a bare number with no currency attached. We may
+        # only position it against ``values`` when we KNOW it is denominated
+        # in ``target_currency``. That is true only when the request named the
+        # currency explicitly: then ``values`` was filtered to that same
+        # currency above, so the comparison is single-currency. When the
+        # currency was omitted, ``target_currency`` is the auto-selected
+        # dominant bucket, which may differ from the caller's value currency,
+        # so positioning would silently compare across currencies. In that
+        # case we return ``percentile_vs_own=None`` with a note rather than a
+        # misleading percentile.
         percentile_vs_own: float | None = None
         explanation = ""
         if cost_per_m2 is not None:
-            percentile_vs_own = _position_in_distribution(cost_per_m2, values)
-            explanation = self._explain(cost_per_m2, portfolio["median"], percentile_vs_own)
+            if requested_currency:
+                percentile_vs_own = _position_in_distribution(cost_per_m2, values)
+                explanation = self._explain(cost_per_m2, portfolio["median"], percentile_vs_own)
+            else:
+                explanation = (
+                    "Specify the currency of your value to position it against your "
+                    f"portfolio. The distribution below is in {target_currency}."
+                )
 
         return {
             "currency": target_currency,

--- a/backend/app/modules/finance/br_invoice_pdf.py
+++ b/backend/app/modules/finance/br_invoice_pdf.py
@@ -425,6 +425,18 @@ def render_br_invoice_pdf(
     retention = invoice.get("retention_amount", "0")
     total = invoice.get("amount_total", "0")
 
+    # Net payable = gross (amount_total) - retention_amount. amount_total is
+    # subtotal + tax with retentions NOT subtracted (see _compute_invoice_total
+    # in service.py), so the bold "Valor liquido a pagar" line must deduct the
+    # retentions itemised above it. Guard parse failures the same way _brl does
+    # so the PDF never breaks; on failure net falls back to the gross.
+    try:
+        net = Decimal(str(total).strip() or "0") - Decimal(str(retention).strip() or "0")
+        if not net.is_finite():
+            net = Decimal(str(total).strip() or "0")
+    except (InvalidOperation, ValueError, TypeError):
+        net = total
+
     totals_rows: list[list[Paragraph]] = [
         [
             _safe_para("Valor dos serviços (subtotal)", styles["cell"]),
@@ -459,8 +471,12 @@ def render_br_invoice_pdf(
             _safe_para(_brl(retention), styles["cell_right"]),
         ],
         [
+            _safe_para("Valor bruto", styles["cell"]),
+            _safe_para(_brl(total), styles["cell_right"]),
+        ],
+        [
             _safe_para("<b>Valor líquido a pagar</b>", styles["cell"]),
-            _safe_para(f"<b>{_brl(total)}</b>", styles["cell_right"]),
+            _safe_para(f"<b>{_brl(net)}</b>", styles["cell_right"]),
         ],
     ]
     totals_widths = [usable * 0.70, usable * 0.30]

--- a/backend/app/modules/finance/repository.py
+++ b/backend/app/modules/finance/repository.py
@@ -201,6 +201,11 @@ class InvoiceRepository:
             Invoice.due_date < today,
             Invoice.status.notin_(("paid", "cancelled")),
             Invoice.due_date.isnot(None),
+            # due_date is a VARCHAR; an empty string is a valid persisted value
+            # (a draft with no due date set). Lexically "" < today is True, so
+            # without this guard blank-due-date invoices pollute the overdue KPI
+            # as phantom overdues. Exclude them.
+            Invoice.due_date != "",
         )
         if project_id is not None:
             overdue_base = overdue_base.where(Invoice.project_id == project_id)
@@ -331,11 +336,20 @@ class PaymentRepository:
         joining to the parent invoice so a project dashboard never blends in
         other tenants' payments.
         """
-        from sqlalchemy import Numeric, cast
+        from sqlalchemy import Numeric, case, cast
 
+        # Net out refunds. Refunds are stored as a positive ``amount`` with
+        # ``is_refund=True`` (see service.create_payment), and the refund guard
+        # treats them as reducing net cash. Summing them positively would
+        # inflate total_payments (a 100 payment + 100 refund must net to 0, not
+        # 200), so subtract refund rows instead of adding them.
+        net_amount = case(
+            (Payment.is_refund.is_(True), -cast(Payment.amount, Numeric)),
+            else_=cast(Payment.amount, Numeric),
+        )
         base = select(
             Payment.currency_code,
-            func.coalesce(func.sum(cast(Payment.amount, Numeric)), 0),
+            func.coalesce(func.sum(net_amount), 0),
         )
         if project_id is not None:
             base = base.where(Payment.invoice_id.in_(select(Invoice.id).where(Invoice.project_id == project_id)))

--- a/backend/app/modules/finance/schemas.py
+++ b/backend/app/modules/finance/schemas.py
@@ -153,7 +153,14 @@ class InvoiceUpdate(BaseModel):
         pattern=r"^(payable|receivable)$",
     )
     invoice_date: str | None = Field(default=None, max_length=20)
-    due_date: str | None = Field(default=None, max_length=20)
+    # Mirror InvoiceCreate.due_date so a PATCH cannot store a malformed (or
+    # blank) due date that later reads as a phantom overdue in the dashboard
+    # KPI. The pattern requires a real ISO date when a value is supplied.
+    due_date: str | None = Field(
+        default=None,
+        pattern=r"^\d{4}-\d{2}-\d{2}$",
+        max_length=20,
+    )
     currency_code: str | None = Field(default=None, max_length=10)
     amount_subtotal: str | None = Field(default=None, max_length=50)
     tax_amount: str | None = Field(default=None, max_length=50)

--- a/backend/app/modules/finance/service.py
+++ b/backend/app/modules/finance/service.py
@@ -616,7 +616,10 @@ class FinanceService:
             total_actual = Decimal("0")
 
             for inv in paid_invoices:
-                inv_currency = (inv.currency_code or "").strip().upper()
+                # getattr keeps this resilient when an invoice row predates the
+                # currency_code column (or a caller passes a lightweight stub):
+                # a missing/blank code means "base currency" and buckets under "".
+                inv_currency = (getattr(inv, "currency_code", "") or "").strip().upper()
                 items = list(inv.line_items or [])
                 if items:
                     for item in items:
@@ -648,8 +651,10 @@ class FinanceService:
             # type-coercion warning on PostgreSQL (BUG-FINANCE-ACT01).
             for budget in budgets:
                 # Match the bucket priced in the budget row's own currency only,
-                # so a row stamped EUR never absorbs a USD invoice's amount.
-                budget_currency = (budget.currency_code or "").strip().upper()
+                # so a row stamped EUR never absorbs a USD invoice's amount. A
+                # row without a currency_code (legacy/stub) buckets under "" and
+                # so still matches base-currency invoice amounts as before.
+                budget_currency = (getattr(budget, "currency_code", "") or "").strip().upper()
                 key = (budget.wbs_id, budget.category, budget_currency)
                 budget.actual = bucketed.get(key, Decimal("0"))
 

--- a/backend/app/modules/finance/service.py
+++ b/backend/app/modules/finance/service.py
@@ -602,11 +602,21 @@ class FinanceService:
             )
             paid_invoices = paid_result.scalars().all()
 
-            # key = (wbs_id, cost_category); both None means "uncategorized"
-            bucketed: dict[tuple[str | None, str | None], Decimal] = defaultdict(lambda: Decimal("0"))
+            # key = (wbs_id, cost_category, currency); wbs_id/cost_category both
+            # None means "uncategorized". The currency is part of the key so we
+            # never blend two currencies into one ProjectBudget.actual (FX
+            # never-blend rule): each budget row carries its own currency_code
+            # and only receives the bucket priced in that same currency. A blank
+            # invoice currency is normalised to "" to match a blank budget-row
+            # currency (both treated as base). Mixed-currency invoices on the
+            # same (wbs_id, cost_category) therefore land in separate buckets
+            # and the per-currency dashboard rollup FX-converts them correctly,
+            # instead of summing them as if 1 USD == 1 EUR.
+            bucketed: dict[tuple[str | None, str | None, str], Decimal] = defaultdict(lambda: Decimal("0"))
             total_actual = Decimal("0")
 
             for inv in paid_invoices:
+                inv_currency = (inv.currency_code or "").strip().upper()
                 items = list(inv.line_items or [])
                 if items:
                     for item in items:
@@ -614,16 +624,16 @@ class FinanceService:
                             amt = Decimal(str(item.amount))
                         except (InvalidOperation, ValueError):
                             continue
-                        bucketed[(item.wbs_id, item.cost_category)] += amt
+                        bucketed[(item.wbs_id, item.cost_category, inv_currency)] += amt
                         total_actual += amt
                 else:
                     # No breakdown - attribute the full invoice total to the
-                    # catch-all bucket.
+                    # catch-all bucket for this invoice's currency.
                     try:
                         amt = Decimal(str(inv.amount_total))
                     except (InvalidOperation, ValueError):
                         continue
-                    bucketed[(None, None)] += amt
+                    bucketed[(None, None, inv_currency)] += amt
                     total_actual += amt
 
             budget_result = await self.session.execute(
@@ -637,7 +647,10 @@ class FinanceService:
             # the ORM side; str assignment works on SQLite but triggers a
             # type-coercion warning on PostgreSQL (BUG-FINANCE-ACT01).
             for budget in budgets:
-                key = (budget.wbs_id, budget.category)
+                # Match the bucket priced in the budget row's own currency only,
+                # so a row stamped EUR never absorbs a USD invoice's amount.
+                budget_currency = (budget.currency_code or "").strip().upper()
+                key = (budget.wbs_id, budget.category, budget_currency)
                 budget.actual = bucketed.get(key, Decimal("0"))
 
             logger.info(
@@ -1489,10 +1502,12 @@ class FinanceService:
         spi = (ev / pv) if pv != 0 else Decimal("0")
         cpi = (ev / ac) if ac != 0 else Decimal("0")
 
-        # Round indices to 4 decimal places for readability, then normalize
-        # to remove trailing zeros (e.g. "0.9500" -> "0.95")
-        spi = spi.quantize(Decimal("0.0001")).normalize()
-        cpi = cpi.quantize(Decimal("0.0001")).normalize()
+        # Round indices to 4 decimal places. Do NOT call .normalize(): for
+        # integer-magnitude results normalize() collapses trailing zeros into
+        # exponent form (e.g. Decimal("10") -> "1E+1"), which str() then emits
+        # as scientific notation and breaks the decimal-string API contract.
+        spi = spi.quantize(Decimal("0.0001"))
+        cpi = cpi.quantize(Decimal("0.0001"))
 
         # ── Forecast metrics ────────────────────────────────────────────
         # EAC: CPI-based forecast. Falls back to AC + remaining BAC when CPI==0.
@@ -1517,7 +1532,9 @@ class FinanceService:
         # would flip the sign and report misleading positive performance.
         remaining_budget = bac - ac
         if remaining_budget > 0:
-            tcpi = ((bac - ev) / remaining_budget).quantize(Decimal("0.0001")).normalize()
+            # No .normalize() - see spi/cpi note above; it would render
+            # integer-magnitude indices in scientific notation via str().
+            tcpi = ((bac - ev) / remaining_budget).quantize(Decimal("0.0001"))
         else:
             tcpi = Decimal("0")
 

--- a/backend/app/modules/projects/router.py
+++ b/backend/app/modules/projects/router.py
@@ -1268,9 +1268,7 @@ async def project_dashboard(
         try:
             # Use the work-performed note as the activity title, falling back
             # to the report type when no note was entered.
-            field_report_title = func.coalesce(
-                FieldReport.work_performed, FieldReport.report_type
-            ).label("title")
+            field_report_title = func.coalesce(FieldReport.work_performed, FieldReport.report_type).label("title")
             activity_queries.append(
                 select(
                     literal_column("'field_report'").label("type"),

--- a/backend/app/modules/risk/service.py
+++ b/backend/app/modules/risk/service.py
@@ -263,8 +263,12 @@ class RiskService:
         if not fields:
             return item
 
-        # Recalculate risk_score and 5x5 matrix scoring if probability or severity changed
-        probability = fields.get("probability", float(item.probability))
+        # Recalculate risk_score and 5x5 matrix scoring if probability or severity changed.
+        # Stored numerics can be "" on legacy/imported rows (DB-level defaults were
+        # removed), so coerce defensively like the read paths instead of float("").
+        probability = fields.get("probability")
+        if probability is None:
+            probability = _safe_float(item.probability, 0.5)
         severity = fields.get("impact_severity", item.impact_severity)
         if "probability" in fields or "impact_severity" in fields:
             fields["risk_score"] = str(_compute_risk_score(probability, severity))

--- a/backend/app/modules/schedule/router_4d.py
+++ b/backend/app/modules/schedule/router_4d.py
@@ -21,10 +21,10 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from fastapi import APIRouter, Body, File, HTTPException, Query, UploadFile, status
+from fastapi import APIRouter, Body, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.dependencies import CurrentUserId, SessionDep
+from app.dependencies import CurrentUserId, RequirePermission, SessionDep, verify_project_access
 from app.modules.schedule.models import (
     EAC_LINK_MODES,
     Activity,
@@ -150,6 +150,44 @@ def _parse_as_of(as_of_date: str | None) -> date:
         ) from exc
 
 
+async def _verify_schedule_access(session: SessionDep, schedule_id: uuid.UUID, user_id: str) -> Schedule:
+    """Load a schedule and verify the caller owns its project. Admins bypass.
+
+    Returns HTTP 404 on both "schedule missing" and "access denied" so the
+    schedule_id can't be enumerated by a foreign tenant, mirroring
+    ``_verify_schedule_owner`` in the v1 router.
+    """
+    schedule = await session.get(Schedule, schedule_id)
+    if schedule is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Schedule {schedule_id} not found",
+        )
+    await verify_project_access(schedule.project_id, user_id, session)
+    return schedule
+
+
+async def _verify_task_access(session: SessionDep, task_id: uuid.UUID, user_id: str) -> Activity:
+    """Load an activity and verify the caller owns its schedule's project.
+
+    Returns HTTP 404 on both "task missing" and "access denied" so a foreign
+    tenant cannot enumerate or mutate activities they do not own.
+    """
+    activity = await session.get(Activity, task_id)
+    if activity is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Activity {task_id} not found",
+        )
+    await _verify_schedule_access(session, activity.schedule_id, user_id)
+    return activity
+
+
+async def _verify_link_access(session: SessionDep, link: EacScheduleLink, user_id: str) -> None:
+    """Verify the caller owns the project behind ``link`` via its task -> schedule."""
+    await _verify_task_access(session, link.task_id, user_id)
+
+
 # ── Schedules v2 router ────────────────────────────────────────────────────
 
 
@@ -157,6 +195,7 @@ def _parse_as_of(as_of_date: str | None) -> date:
     "/{schedule_id}/import",
     response_model=CsvImportResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(RequirePermission("schedule.update"))],
 )
 async def import_schedule(
     schedule_id: uuid.UUID,
@@ -170,6 +209,7 @@ async def import_schedule(
     should pre-convert to the canonical CSV column set or use the existing
     v1 import endpoints for those formats.
     """
+    await _verify_schedule_access(session, schedule_id, user_id)
     if not file.filename or not file.filename.lower().endswith(".csv"):
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
@@ -200,6 +240,7 @@ async def import_schedule(
     "/tasks/{task_id}/progress",
     response_model=ProgressEntryResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(RequirePermission("schedule.update"))],
 )
 async def record_progress(
     task_id: uuid.UUID,
@@ -208,6 +249,7 @@ async def record_progress(
     body: ProgressEntryRequest = Body(...),
 ) -> ProgressEntryResponse:
     """Append a progress entry to ``task_id`` and roll forward the activity."""
+    await _verify_task_access(session, task_id, user_id)
     service = ScheduleProgressService(session)
     try:
         entry = await service.record(
@@ -240,13 +282,17 @@ async def record_progress(
     )
 
 
-@schedules_v2_router.get("/tasks/{task_id}/progress-history")
+@schedules_v2_router.get(
+    "/tasks/{task_id}/progress-history",
+    dependencies=[Depends(RequirePermission("schedule.read"))],
+)
 async def list_progress_history(
     task_id: uuid.UUID,
     session: SessionDep,
     user_id: CurrentUserId,
 ) -> list[dict[str, Any]]:
     """Return the append-only progress history for ``task_id``."""
+    await _verify_task_access(session, task_id, user_id)
     service = ScheduleProgressService(session)
     entries = await service.history(task_id)
     return [
@@ -264,7 +310,10 @@ async def list_progress_history(
     ]
 
 
-@schedules_v2_router.get("/{schedule_id}/snapshot")
+@schedules_v2_router.get(
+    "/{schedule_id}/snapshot",
+    dependencies=[Depends(RequirePermission("schedule.read"))],
+)
 async def get_snapshot(
     schedule_id: uuid.UUID,
     session: SessionDep,
@@ -273,12 +322,7 @@ async def get_snapshot(
     model_version_id: uuid.UUID | None = Query(default=None),
 ) -> dict[str, Any]:
     """Return ``{element_id: status}`` for every linked element on ``as_of_date``."""
-    schedule = await session.get(Schedule, schedule_id)
-    if schedule is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Schedule {schedule_id} not found",
-        )
+    await _verify_schedule_access(session, schedule_id, user_id)
     target = _parse_as_of(as_of_date)
     service = ScheduleSnapshotService(session)
     statuses = await service.snapshot(schedule_id, target, model_version_id)
@@ -290,7 +334,10 @@ async def get_snapshot(
     }
 
 
-@schedules_v2_router.get("/{schedule_id}/dashboard")
+@schedules_v2_router.get(
+    "/{schedule_id}/dashboard",
+    dependencies=[Depends(RequirePermission("schedule.read"))],
+)
 async def get_dashboard(
     schedule_id: uuid.UUID,
     session: SessionDep,
@@ -298,12 +345,7 @@ async def get_dashboard(
     as_of_date: str | None = Query(default=None),
 ) -> dict[str, Any]:
     """Return the planned-vs-actual dashboard for ``schedule_id``."""
-    schedule = await session.get(Schedule, schedule_id)
-    if schedule is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Schedule {schedule_id} not found",
-        )
+    await _verify_schedule_access(session, schedule_id, user_id)
     target = _parse_as_of(as_of_date)
     service = ScheduleDashboardService(session)
     return (await service.dashboard(schedule_id, target)).to_json()
@@ -316,6 +358,7 @@ async def get_dashboard(
     "",
     response_model=EacScheduleLinkResponse,
     status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(RequirePermission("schedule.update"))],
 )
 async def create_link(
     session: SessionDep,
@@ -323,12 +366,7 @@ async def create_link(
     body: EacScheduleLinkCreate = Body(...),
 ) -> EacScheduleLinkResponse:
     """Create an EAC schedule link and run a dry-run for the cached count."""
-    activity = await session.get(Activity, body.task_id)
-    if activity is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Activity {body.task_id} not found",
-        )
+    await _verify_task_access(session, body.task_id, user_id)
 
     service = EacScheduleLinkService(session)
     try:
@@ -348,7 +386,11 @@ async def create_link(
     return _link_to_response(link)
 
 
-@eac_schedule_links_router.get("/{link_id}", response_model=EacScheduleLinkResponse)
+@eac_schedule_links_router.get(
+    "/{link_id}",
+    response_model=EacScheduleLinkResponse,
+    dependencies=[Depends(RequirePermission("schedule.read"))],
+)
 async def get_link(
     link_id: uuid.UUID,
     session: SessionDep,
@@ -361,10 +403,15 @@ async def get_link(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Link {link_id} not found",
         )
+    await _verify_link_access(session, link, user_id)
     return _link_to_response(link)
 
 
-@eac_schedule_links_router.delete("/{link_id}", status_code=status.HTTP_204_NO_CONTENT)
+@eac_schedule_links_router.delete(
+    "/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(RequirePermission("schedule.update"))],
+)
 async def delete_link(
     link_id: uuid.UUID,
     session: SessionDep,
@@ -377,11 +424,16 @@ async def delete_link(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Link {link_id} not found",
         )
+    await _verify_link_access(session, link, user_id)
     await service.delete(link_id)
     await session.commit()
 
 
-@eac_schedule_links_router.post("/{link_id}:dry-run", response_model=DryRunResponse)
+@eac_schedule_links_router.post(
+    "/{link_id}:dry-run",
+    response_model=DryRunResponse,
+    dependencies=[Depends(RequirePermission("schedule.update"))],
+)
 async def dry_run_link(
     link_id: uuid.UUID,
     session: SessionDep,
@@ -396,6 +448,7 @@ async def dry_run_link(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Link {link_id} not found",
         )
+    await _verify_link_access(session, link, user_id)
     outcome = await service.dry_run(link, body.model_version_id)
     link.matched_element_count = outcome.matched_count
     await session.commit()

--- a/backend/app/modules/schedule/service.py
+++ b/backend/app/modules/schedule/service.py
@@ -2336,8 +2336,17 @@ class ScheduleService:
 
         for act_cpm in cpm_result.all_activities:
             duration = act_cpm.duration_days
-            optimistic = max(3, int(duration * _PERT_OPTIMISTIC))
-            pessimistic = max(duration + 2, int(duration * _PERT_PESSIMISTIC))
+            if duration <= 0:
+                # Zero-duration milestone: no spread, so O = M = P = duration
+                # keeps the three-point ordering valid and the variance at 0.
+                optimistic = duration
+                pessimistic = duration
+            else:
+                # Floors can push optimistic above the most-likely duration for
+                # short tasks, so clamp the bounds to preserve O <= M <= P and
+                # keep std_dev non-negative.
+                optimistic = min(max(3, int(duration * _PERT_OPTIMISTIC)), duration)
+                pessimistic = max(duration + 2, int(duration * _PERT_PESSIMISTIC), optimistic)
             expected = (optimistic + 4 * duration + pessimistic) / 6.0
             std_dev = (pessimistic - optimistic) / 6.0
             variance = std_dev**2

--- a/backend/app/modules/schedule/service_4d.py
+++ b/backend/app/modules/schedule/service_4d.py
@@ -584,16 +584,23 @@ class ScheduleDashboardService:
         overall = weighted_progress / total_weight if total_weight else 0.0
 
         # ── EVM totals ────────────────────────────────────────────────
+        # PV is the budgeted cost of work SCHEDULED to be complete by the data
+        # date (as_of_date), not the Budget At Completion. Using BAC here makes
+        # an on-schedule project report SPI < 1, so we time-phase PV the same
+        # way the S-curve does: an activity past its planned end contributes its
+        # full cost_planned, one in progress contributes a linear proration over
+        # [start, end], and one not yet started contributes nothing.
         total_pv = 0.0
         total_ev = 0.0
         total_ac = 0.0
         any_cost = False
         for a in activities:
-            pv = _decimal_to_float(a.cost_planned)
+            bac = _decimal_to_float(a.cost_planned)
             ac = _decimal_to_float(a.cost_actual)
             if a.cost_planned is not None or a.cost_actual is not None:
                 any_cost = True
-            ev = pv * (_coerce_progress(a) / 100.0) if pv else 0.0
+            pv = _planned_value_to_date(a, bac, as_of_date)
+            ev = bac * (_coerce_progress(a) / 100.0) if bac else 0.0
             total_pv += pv
             total_ev += ev
             total_ac += ac
@@ -747,6 +754,29 @@ def _decimal_to_float(value: Decimal | None) -> float:
         return float(value)
     except (TypeError, ValueError):  # pragma: no cover - defensive
         return 0.0
+
+
+def _planned_value_to_date(activity: Activity, bac: float, as_of_date: date) -> float:
+    """Return the budgeted cost of work scheduled to be complete by ``as_of_date``.
+
+    Mirrors the proration used by ``_build_s_curve``: an activity whose planned
+    end_date is on or before the data date contributes its full budget; one in
+    progress contributes a linear proration over its planned [start, end] span;
+    one not yet started (or without parseable dates) contributes nothing.
+    """
+    if not bac:
+        return 0.0
+    start = _parse_iso(activity.start_date)
+    end = _parse_iso(activity.end_date)
+    if start is None or end is None:
+        return 0.0
+    if as_of_date >= end:
+        return bac
+    if as_of_date < start:
+        return 0.0
+    duration = max((end - start).days, 1)
+    elapsed = (as_of_date - start).days
+    return bac * (elapsed / duration)
 
 
 # ── CSV importer (FR-6.1 minimal slice) ─────────────────────────────────

--- a/backend/app/modules/tendering/service.py
+++ b/backend/app/modules/tendering/service.py
@@ -573,6 +573,7 @@ class TenderingService:
         from sqlalchemy import update
 
         from app.modules.boq.models import Position
+        from app.modules.boq.service import _quantize_money_str
 
         updated = 0
         for item in bid.line_items or []:
@@ -595,11 +596,17 @@ class TenderingService:
             if pos.boq_id != package.boq_id:
                 continue
             qty = _to_decimal(pos.quantity)
-            new_total = qty * rate
+            # Quantize at this write boundary the same way every other BOQ
+            # writer does (boq/service.py:_quantize_money_str). Writing the raw
+            # Decimal would store more than 4 fractional digits and break the
+            # money invariant the BOQ engine assumes, forcing a needless rewrite
+            # on the next recompute.
+            rate_str = _quantize_money_str(rate)
+            new_total_str = _quantize_money_str(qty * rate)
             await self.session.execute(
                 update(Position)
                 .where(Position.id == pos.id, Position.boq_id == package.boq_id)
-                .values(unit_rate=str(rate), total=str(new_total))
+                .values(unit_rate=rate_str, total=new_total_str)
             )
             updated += 1
 

--- a/backend/app/modules/validation/bim_validation_service.py
+++ b/backend/app/modules/validation/bim_validation_service.py
@@ -115,8 +115,10 @@ class BIMValidationService:
         # two "quality scores" are not comparable in the unified dashboard
         # (E-XMOD-015). A passing (rule, element) pair contributes the rule's
         # severity weight to both numerator and denominator (mirrors the core
-        # engine, where a passing ERROR-rule result carries ERROR weight);
-        # each failure contributes its severity weight to the denominator.
+        # engine, where a passing ERROR-rule result carries ERROR weight); a
+        # failed check contributes the rule weight to the denominator exactly
+        # once, even when the check emits several sub-failures, so the
+        # denominator scales with the check count, not the failure count.
         passed_weight = 0.0
         total_weight = 0.0
         results_json: list[dict[str, Any]] = []
@@ -136,8 +138,12 @@ class BIMValidationService:
                     continue
 
                 failed_checks += 1
+                # One weight per check, like the core engine: a failed
+                # (rule, element) check contributes the rule weight to the
+                # denominator exactly once, regardless of how many sub-failures
+                # it emits. Per-severity counts still iterate every failure.
+                total_weight += rule_weight
                 for failure in failures:
-                    total_weight += SEVERITY_WEIGHTS.get(str(failure.severity), 1.0)
                     if failure.severity == "error":
                         error_count += 1
                     elif failure.severity == "warning":


### PR DESCRIPTION
Findings from a deep code-logic audit of the service layer, all fixed in this branch.

Security: cost record-usage now requires an authenticated caller and verifies project access on every request, so a usage badge can no longer be recorded across tenants or anonymously. The schedule 4D v2 endpoints picked up the same per-project ownership checks the v1 router already had, returning 404 on both missing and not-owned so ids cannot be enumerated.

Money: assemblies apply-to-boq now keeps the bid factor, regional premium and FX conversion on each resource row, so the BOQ resource recompute no longer collapses the unit rate to a factor-less sum. The finance budget rollup buckets actual cost per currency so two currencies are never summed as if one to one, and the BOQ resource rollup accumulates in Decimal to avoid float drift. A few smaller calculation fixes come along: PERT no longer returns a negative standard deviation, refunds are not double counted, and the EVM indices keep a plain 4 decimal string instead of slipping into scientific notation.

21 files, no behaviour change for well-formed authenticated requests. Opening so the backend suite runs on the branch.
