### PR TITLE
Onboarding Full Enterprise fix, nginx 2g, takeoff money as decimal strings

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,9 @@ Thank you to everyone who has contributed.
   bugs ([#159](https://github.com/datadrivenconstruction/OpenConstructionERP/pull/159)),
   COLLADA namespace-prefix serialisation in `ifc_processor`, defence-in-depth regex
   tolerance in `ElementManager`, and `degraded` model status surfacing in the viewer UI.
+  Later raised ideas for driving BOQ quantities from live BIM parameters, surfacing real
+  server errors on Excel paste, and resolving linked elements per model in multi-model
+  setups ([#206](https://github.com/datadrivenconstruction/OpenConstructionERP/pull/206)).
 - **rjohny** ([@rjohny55](https://github.com/rjohny55)): multi-area patch set
   ([#161](https://github.com/datadrivenconstruction/OpenConstructionERP/pull/161)),
   defensive guards for the slow-query SQLAlchemy listener and the module-presence probe

--- a/backend/app/modules/takeoff/schemas.py
+++ b/backend/app/modules/takeoff/schemas.py
@@ -2,10 +2,29 @@
 
 import math
 from datetime import datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+
+
+# ── Money serialisation helper (mirrors ai_estimator / match_elements / boq) ──
+# v3 §10: dollar amounts cross the wire as a Decimal-rendered string, never a
+# binary float, so a "$0.0023" AI-cost estimate never drifts to "0.00229999".
+# The DB columns stay numeric; only the JSON contract changes.
+def _serialise_money(v: Decimal | None) -> str | None:
+    if v is None:
+        return None
+    if not isinstance(v, Decimal):
+        try:
+            v = Decimal(str(v))
+        except (InvalidOperation, ValueError):
+            return "0"
+    if not v.is_finite():
+        return "0"
+    return format(v, "f")
+
 
 # Round-6 audit (2026-05-22) - hard bound on per-axis coordinates inside a
 # polygon. PDF pages render in PostScript points (72 dpi); ISO A0 at 72 dpi
@@ -436,8 +455,12 @@ class PlanReadResult(BaseModel):
     model_used: str = ""
     provider: str = ""
     tokens_used: int = 0
-    cost_usd_estimate: float = 0.0
+    cost_usd_estimate: Decimal = Decimal("0")
     notes: str | None = None
+
+    @field_serializer("cost_usd_estimate", when_used="json")
+    def _ser_cost(self, v: Decimal | None) -> str | None:
+        return _serialise_money(v)
 
 
 class PlanReadRequest(BaseModel):
@@ -467,13 +490,17 @@ class AiTakeoffRunResponse(BaseModel):
     provider: str | None = None
     model_used: str | None = None
     total_tokens: int = 0
-    cost_usd_estimate: float = 0.0
+    cost_usd_estimate: Decimal = Decimal("0")
     duration_ms: int = 0
     proposal_count: int = 0
     accepted_count: int = 0
     validation_report: dict[str, Any] | None = None
     failure_reason: str | None = None
     created_at: datetime | None = None
+
+    @field_serializer("cost_usd_estimate", when_used="json")
+    def _ser_cost(self, v: Decimal | None) -> str | None:
+        return _serialise_money(v)
 
 
 class PlanReadAcceptRequest(BaseModel):
@@ -511,10 +538,14 @@ class PlanReadMetaResponse(BaseModel):
     confidence_medium_threshold: float = TAKEOFF_CONFIDENCE_MEDIUM_THRESHOLD
     vision_providers: list[str] = Field(default_factory=list)
     max_polygon_vertices: int = MAX_PLAN_POLYGON_VERTICES
-    max_cost_usd: float = 0.0
-    rolling_spend_usd: float = 0.0
+    max_cost_usd: Decimal = Decimal("0")
+    rolling_spend_usd: Decimal = Decimal("0")
     modes: list[str] = Field(default_factory=lambda: ["scale", "rooms", "symbols", "full"])
     vision_available: bool = False
     provider: str | None = None
     model_used: str | None = None
     reason: str | None = None
+
+    @field_serializer("max_cost_usd", "rolling_spend_usd", when_used="json")
+    def _ser_usd(self, v: Decimal | None) -> str | None:
+        return _serialise_money(v)

--- a/backend/app/modules/users/router.py
+++ b/backend/app/modules/users/router.py
@@ -925,9 +925,24 @@ async def save_onboarding(
     user = await service.get_user(uuid.UUID(user_id))
     metadata: dict[str, Any] = dict(user.metadata_ or {})
 
+    # "Full Enterprise" means the whole platform. Pin it to the backend's own
+    # authoritative functional-module list rather than trusting whatever set the
+    # client computed: if the client catalogue is even slightly behind the
+    # server's module registry, the missing keys would be sent as "not chosen"
+    # and ``modules_for`` would write an explicit False for them, silently
+    # hiding live sidebar routes (BIM, Finance, CRM and the rest). Making the
+    # server authoritative here closes that drift for good.
+    from app.core.onboarding_presets import get_preset, modules_for
+
+    effective_modules = data.enabled_modules
+    if data.company_type == "full_enterprise":
+        full_enterprise = get_preset("full_enterprise")
+        if full_enterprise is not None:
+            effective_modules = list(full_enterprise.enabled_modules)
+
     metadata["onboarding"] = {
         "company_type": data.company_type,
-        "enabled_modules": data.enabled_modules,
+        "enabled_modules": effective_modules,
         "interface_mode": data.interface_mode,
         "completed": data.completed,
     }
@@ -935,16 +950,14 @@ async def save_onboarding(
     # Also persist module preferences so the sidebar reflects the selection.
     # ``modules_for`` writes an explicit True/False for every known module and
     # forces core modules on, so a profile can never hide Projects/Settings/etc.
-    from app.core.onboarding_presets import modules_for
-
-    metadata["module_preferences"] = modules_for(data.enabled_modules)
+    metadata["module_preferences"] = modules_for(effective_modules)
 
     await service.update_profile(uuid.UUID(user_id), metadata_=metadata)
 
     return OnboardingResponse(
         completed=data.completed,
         company_type=data.company_type,
-        enabled_modules=data.enabled_modules,
+        enabled_modules=effective_modules,
         interface_mode=data.interface_mode,
     )
 

--- a/backend/tests/unit/test_onboarding_presets.py
+++ b/backend/tests/unit/test_onboarding_presets.py
@@ -1,0 +1,62 @@
+"""Unit tests for the company-profile onboarding presets.
+
+The sidebar is gated on ``module_preferences``, which ``modules_for`` builds
+from the module set a profile selects. Two behaviours matter and are easy to
+regress:
+
+- "Full Enterprise" must light up every functional module. The backend list is
+  authoritative, so even if a client catalogue drifts behind the server the
+  whole platform still shows.
+- A narrow profile must still write an explicit False for the modules it does
+  not include, otherwise the sidebar could not hide anything.
+"""
+
+from app.core.onboarding_presets import (
+    _ALL_FUNCTIONAL,
+    _CORE_MODULES,
+    get_preset,
+    is_core_module,
+    modules_for,
+)
+
+
+def test_full_enterprise_enables_every_functional_module() -> None:
+    """Full Enterprise pins to the backend's own functional list, all on."""
+    preset = get_preset("full_enterprise")
+    assert preset is not None
+    # The preset itself carries the complete functional set.
+    assert set(preset.enabled_modules) == set(_ALL_FUNCTIONAL)
+
+    prefs = modules_for(preset.enabled_modules)
+    # Every functional module is explicitly enabled - nothing is hidden.
+    for key in _ALL_FUNCTIONAL:
+        assert prefs[key] is True, f"{key} should be enabled under Full Enterprise"
+    # Sidebar routes that an external report flagged as vanishing are present.
+    for key in ("bim_hub", "finance", "crm"):
+        assert prefs[key] is True
+
+
+def test_core_modules_are_always_on() -> None:
+    """No profile can hide a core module, even an empty selection."""
+    prefs = modules_for([])
+    for key in _CORE_MODULES:
+        assert prefs[key] is True
+        assert is_core_module(key) is True
+
+
+def test_narrow_profile_disables_unselected_modules() -> None:
+    """A profile that omits a functional module writes an explicit False."""
+    prefs = modules_for(["boq", "costs", "takeoff"])
+    assert prefs["boq"] is True
+    # A functional module left out of the selection is turned off so the
+    # sidebar can hide it.
+    assert prefs["finance"] is False
+    assert prefs["crm"] is False
+
+
+def test_every_known_module_gets_an_explicit_flag() -> None:
+    """``modules_for`` returns a complete map, never a partial one."""
+    prefs = modules_for([])
+    expected = set(_CORE_MODULES) | set(_ALL_FUNCTIONAL)
+    assert expected.issubset(set(prefs))
+    assert all(isinstance(v, bool) for v in prefs.values())

--- a/backend/tests/unit/test_takeoff_manual_override.py
+++ b/backend/tests/unit/test_takeoff_manual_override.py
@@ -4,13 +4,17 @@
 
 Covers bullet 8 of the R7 hardening sweep:
   * A user's manual correction overrides the AI suggestion.
-  * Manual measurements (TakeoffMeasurement) carry ``confidence=None``
-    (the ORM model has no confidence column) — not 0.0.
+  * Manual measurements (TakeoffMeasurement) carry ``confidence=None``,
+    never a fake 0.0. Since issue #194 the ORM model has a nullable
+    ``confidence`` column (an AI plan-read proposal stamps its model score
+    there); a manual draw leaves it NULL, so NULL still means "no AI score"
+    rather than "AI was very unsure".
   * Updating a measurement with new geometry via PATCH re-computes the
     measurement_value server-side from the new points (Audit B8).
   * The ``ai_confidence`` concept: extractedElement AI output carries
-    confidence; once a user manually edits a measurement, the persisted
-    record has no AI confidence (the field does not exist on the ORM).
+    confidence; a manually drawn measurement persists with ``confidence``
+    NULL, and no alternative score column (ai_confidence / score / certainty)
+    exists on the ORM.
   * After update_measurement, the new measurement_value reflects the
     new geometry, not the old client-submitted value.
 
@@ -83,23 +87,34 @@ def _make_service() -> TakeoffService:
 # ---------------------------------------------------------------------------
 
 
-class TestMeasurementModelHasNoConfidence:
-    def test_takeoff_measurement_no_confidence_column(self) -> None:
-        """TakeoffMeasurement ORM table must NOT have a confidence column.
+class TestMeasurementConfidence:
+    def test_confidence_column_is_nullable_with_no_default(self) -> None:
+        """``confidence`` exists (issue #194) but must stay NULL for manual rows.
 
-        Manual measurements are human-drawn; an AI confidence score has no
-        meaning. If a confidence column existed it would default to 0.0
-        and misrepresent the item as "AI very unsure" instead of "no AI".
+        A plan-read proposal stamps the model score here; a manual draw must
+        leave it NULL, never default to 0.0. So the column has to be nullable
+        and carry no Python/server default that would coerce a human-drawn
+        measurement into looking "AI very unsure".
         """
         from app.modules.takeoff.models import TakeoffMeasurement
 
-        columns = {col.key for col in TakeoffMeasurement.__table__.columns}
-        assert "confidence" not in columns, (
-            "TakeoffMeasurement must not have a confidence column. Manual measurements have no AI score."
-        )
+        col = TakeoffMeasurement.__table__.columns["confidence"]
+        assert col.nullable is True, "confidence must be nullable so manual rows stay NULL"
+        assert col.default is None, "confidence must have no Python default (NULL = no AI score)"
+        assert col.server_default is None, "confidence must have no server default"
 
-    def test_takeoff_measurement_no_ai_confidence_column(self) -> None:
-        """Also check for alternative names sometimes used."""
+    def test_confidence_check_constraint_allows_null_or_unit_range(self) -> None:
+        """The CHECK keeps confidence either NULL or a real 0..1 probability."""
+        from sqlalchemy import CheckConstraint
+
+        from app.modules.takeoff.models import TakeoffMeasurement
+
+        checks = [str(c.sqltext) for c in TakeoffMeasurement.__table__.constraints if isinstance(c, CheckConstraint)]
+        joined = " ".join(checks).lower()
+        assert "confidence is null" in joined, "confidence CHECK must permit NULL (manual measurements carry no score)"
+
+    def test_takeoff_measurement_no_alternative_score_column(self) -> None:
+        """Only the canonical ``confidence`` name is allowed, no synonyms."""
         from app.modules.takeoff.models import TakeoffMeasurement
 
         columns = {col.key for col in TakeoffMeasurement.__table__.columns}

--- a/deploy/docker/nginx.conf
+++ b/deploy/docker/nginx.conf
@@ -25,9 +25,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Allow large uploads (PDF drawings, CAD files). The nginx default of 1M
-    # rejects most takeoff/BIM payloads with a 413 before they reach FastAPI.
-    client_max_body_size 100M;
+    # Allow large uploads (PDF drawings, CAD/BIM files). The nginx default of 1M
+    # rejects most takeoff/BIM payloads with a 413 before they reach FastAPI, and
+    # the previous 100M cap still bounced full federated IFC and point-cloud
+    # models. Real project models routinely run into the hundreds of megabytes,
+    # so the ceiling is lifted to 2G. The backend streams the body straight to a
+    # temp file, so a large upload costs disk, not memory.
+    client_max_body_size 2g;
 
     # Gzip compression
     gzip on;
@@ -84,5 +88,16 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_read_timeout 120s;
+
+        # Stream large CAD/BIM/point-cloud uploads straight through to the
+        # backend instead of having nginx spool the whole body to disk first.
+        # Without this a multi-hundred-MB IFC is buffered twice and a slow
+        # client connection can trip the send timeout mid-transfer. The
+        # longer timeouts cover the time it takes to push a big body over a
+        # modest uplink (the conversion itself runs in a background job, so
+        # the request returns as soon as the bytes have landed).
+        proxy_request_buffering off;
+        proxy_send_timeout 600s;
+        client_body_timeout 600s;
     }
 }

--- a/frontend/src/features/takeoff/api.ts
+++ b/frontend/src/features/takeoff/api.ts
@@ -97,8 +97,10 @@ export interface PlanReadMeta {
   confidence_medium_threshold: number;
   vision_providers: string[];
   max_polygon_vertices: number;
-  max_cost_usd: number;
-  rolling_spend_usd: number;
+  // Money on the wire is a Decimal-rendered string (v3 §10); coerce with
+  // Number() at any display site.
+  max_cost_usd: number | string;
+  rolling_spend_usd: number | string;
   modes: PlanReadMode[];
   /** False when no vision-capable AI key is configured. The "Read plan with
    *  AI" action is hidden / disabled in that case; the offline Recognize tool
@@ -120,7 +122,8 @@ export interface AiTakeoffRun {
   provider: string | null;
   model_used: string | null;
   total_tokens: number;
-  cost_usd_estimate: number;
+  // Decimal-rendered string on the wire (v3 §10); Number() to display.
+  cost_usd_estimate: number | string;
   duration_ms: number;
   proposal_count: number;
   accepted_count: number;

--- a/frontend/src/tests/__snapshots__/visual-regression.test.tsx.snap
+++ b/frontend/src/tests/__snapshots__/visual-regression.test.tsx.snap
@@ -2093,8 +2093,35 @@ exports[`Visual Regression - DashboardPage > renders loading/skeleton state 1`] 
             <p
               class="mt-0.5 text-xs text-content-tertiary line-clamp-1"
             >
-              Select an active project to upload files.
+              Create a project first, then upload files here.
             </p>
+            <button
+              class="mt-2 inline-flex items-center gap-1 text-2xs font-medium text-oe-blue hover:text-oe-blue-text transition-colors"
+              type="button"
+            >
+              <span>
+                Create a project
+              </span>
+              <svg
+                class="lucide lucide-arrow-right"
+                fill="none"
+                height="11"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="11"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 12h14"
+                />
+                <path
+                  d="m12 5 7 7-7 7"
+                />
+              </svg>
+            </button>
             <div
               class="mt-2 flex items-center gap-3 text-2xs text-content-tertiary"
             >
@@ -3436,7 +3463,7 @@ exports[`Visual Regression - DashboardPage > renders loading/skeleton state 1`] 
       style="animation-delay: 160ms;"
     >
       <div
-        class="rounded-xl border border-border-light bg-surface-elevated shadow-xs transition-all duration-normal ease-oe transform-gpu p-6"
+        class="rounded-xl border border-border-light bg-surface-elevated shadow-xs transition-all duration-normal ease-oe transform-gpu p-6 !bg-surface-elevated/70"
       >
         <div
           class="px-4 pt-3 pb-1"
@@ -3504,6 +3531,67 @@ exports[`Visual Regression - DashboardPage > renders loading/skeleton state 1`] 
               style="height: 56px;"
             />
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="animate-card-in"
+      style="animation-delay: 160ms;"
+    >
+      <div
+        class="rounded-xl border border-border-light bg-surface-elevated shadow-xs transition-all duration-normal ease-oe transform-gpu p-6"
+      >
+        <div
+          class="mb-4 flex items-center gap-2"
+        >
+          <svg
+            class="lucide lucide-camera text-content-tertiary"
+            fill="none"
+            height="16"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.75"
+            viewBox="0 0 24 24"
+            width="16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"
+            />
+            <circle
+              cx="12"
+              cy="13"
+              r="3"
+            />
+          </svg>
+          <h3
+            class="text-sm font-semibold text-content-primary"
+          >
+            Latest site photos
+          </h3>
+        </div>
+        <div
+          class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6"
+        >
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
+          <div
+            class="aspect-[3/2] w-full animate-pulse rounded-xl bg-surface-secondary"
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
A small batch of verified fixes that came out of the recent issue review and the work to get the unit gate green.

Onboarding: the Full Enterprise profile could end up hiding modules. If a client catalogue had drifted and sent a short enabled_modules list, the server wrote False for everything it left out, so BIM, Finance and CRM disappeared. The server now resolves that profile to its own functional module list and ignores the client list for it, so the full set always stays visible. Covered by a new test.

Deploy: the bundled nginx reverse proxy capped request bodies at 100M, which bounced large federated IFC and point-cloud uploads with a 413 before they reached the app. Raised to 2g with longer timeouts and request buffering off so big bodies stream straight through. This is the Docker compose proxy only; pip and desktop have no such cap.

Takeoff: the plan-read cost estimate and the rolling spend and ceiling fields went out as floats. They are Decimal now and serialize as decimal strings on the wire, matching the money rule across the rest of the platform, with the frontend widened to accept the string form. The measurement-confidence test was realigned to the shipped nullable column, and the dashboard loading snapshot refreshed for the project picker and site-photos widgets.

Credited Mourdi59 in CONTRIBUTORS for the BIM-to-BOQ ideas raised in #206.

Local run on 3.14: the targeted unit tests pass (onboarding presets, takeoff override, money guard), ruff check and ruff format are clean on the changed files. Opening as a PR so the gated unit suite confirms it.