### PR TITLE
GAAP general ledger, chart of accounts and financial statements (#77)

### DIFF
--- a/backend/alembic/versions/v3179_gaap_chart_of_accounts.py
+++ b/backend/alembic/versions/v3179_gaap_chart_of_accounts.py
@@ -1,0 +1,82 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+# Copyright (c) 2026 Artem Boiko / DataDrivenConstruction
+"""GAAP general ledger - chart of accounts table.
+
+Task #77: adds ``oe_finance_ledger_account``, the chart-of-accounts master that
+every ``oe_finance_ledger.account_code`` maps to. Accounts are project- or
+workspace-scoped (``project_id`` nullable), carry their account type
+(asset/liability/equity/revenue/expense) and GAAP normal balance (debit/credit),
+and a self-referential ``parent_id`` gives the roll-up hierarchy.
+
+The embedded PostgreSQL runtime materialises this via ``create_all`` at startup,
+so this migration is for external-PostgreSQL deployments that manage schema with
+Alembic. The CREATE is guarded with a table-presence check so a re-run, or a DB
+the runtime already auto-created, is a no-op. PostgreSQL-only, no SQLite shims.
+
+Revision ID: v3179_gaap_chart_of_accounts
+Revises: v3178_users_deleted_at
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "v3179_gaap_chart_of_accounts"
+down_revision = "v3178_users_deleted_at"
+branch_labels = None
+depends_on = None
+
+_TABLE = "oe_finance_ledger_account"
+
+
+def _has_table(name: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return name in insp.get_table_names()
+
+
+def upgrade() -> None:
+    if _has_table(_TABLE):
+        return
+    op.create_table(
+        _TABLE,
+        # GUID() stores as String(36); mirror the platform UUID column shape.
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column("project_id", sa.String(36), nullable=True, index=True),
+        sa.Column("account_code", sa.String(100), nullable=False, index=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("account_type", sa.String(20), nullable=False, index=True),
+        sa.Column("normal_balance", sa.String(10), nullable=False),
+        sa.Column(
+            "parent_id",
+            sa.String(36),
+            sa.ForeignKey("oe_finance_ledger_account.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("statement_section", sa.String(50), nullable=True),
+        sa.Column("is_cash", sa.Boolean, nullable=False, server_default="0"),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default="1"),
+        sa.Column("currency_code", sa.String(10), nullable=False, server_default=""),
+        sa.Column("metadata", sa.JSON, nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("project_id", "account_code", name="uq_ledger_account_scope_code"),
+        sa.Index("ix_ledger_account_project_type", "project_id", "account_type"),
+    )
+
+
+def downgrade() -> None:
+    if _has_table(_TABLE):
+        op.drop_table(_TABLE)

--- a/backend/app/modules/finance/gaap.py
+++ b/backend/app/modules/finance/gaap.py
@@ -1,0 +1,726 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+# Copyright (c) 2026 Artem Boiko / DataDrivenConstruction
+"""GAAP general-ledger primitives: chart of accounts + statement derivations.
+
+This module is the *pure* core of the GAAP layer. It owns:
+
+* the account-type taxonomy and normal-balance rules,
+* the default construction chart of accounts seed,
+* the trial-balance / income-statement / balance-sheet / cash-flow
+  derivations expressed as **side-effect-free functions** over plain
+  ``LedgerLine`` records.
+
+Keeping the maths here (and out of the async service) means the correctness
+suite can assert every sign convention and balancing check against exact
+``Decimal`` values with no database, no event loop and no fixtures. The async
+:class:`app.modules.finance.service.FinanceService` simply loads
+:class:`app.modules.finance.models.LedgerEntry` rows, maps them to
+``LedgerLine`` and calls these functions.
+
+Sign conventions (GAAP, double-entry)
+-------------------------------------
+Every account has a *normal balance* - the side on which a positive balance
+sits::
+
+    asset      normal DEBIT   -> balance = debits - credits
+    expense    normal DEBIT   -> balance = debits - credits
+    liability  normal CREDIT  -> balance = credits - debits
+    equity     normal CREDIT  -> balance = credits - debits
+    revenue    normal CREDIT  -> balance = credits - debits
+
+``signed_balance`` always returns the value in the account's *natural*
+direction, so a healthy asset is positive, a healthy liability is positive,
+revenue is positive and an expense is positive. The accounting identity then
+reads cleanly: ``assets = liabilities + equity`` and
+``net_income = revenue - expenses``.
+
+Currency
+--------
+A single statement is computed in one currency. Currency is never blended in
+a sum: callers filter ledger lines to one currency (or the project base
+currency, FX-converted upstream) before calling these functions, and the
+helpers assert a single currency to fail loudly on a mixed feed rather than
+silently adding USD to EUR.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
+from enum import StrEnum
+
+# ── Quantisation ────────────────────────────────────────────────────────────
+
+_CENTS = Decimal("0.01")
+_ZERO = Decimal("0")
+
+
+def q2(value: Decimal) -> Decimal:
+    """Quantise a money ``Decimal`` to two places, half-up (accounting default)."""
+    return value.quantize(_CENTS, rounding=ROUND_HALF_UP)
+
+
+# ── Account taxonomy ────────────────────────────────────────────────────────
+
+
+class AccountType(StrEnum):
+    """The five GAAP account roots."""
+
+    ASSET = "asset"
+    LIABILITY = "liability"
+    EQUITY = "equity"
+    REVENUE = "revenue"
+    EXPENSE = "expense"
+
+
+class NormalBalance(StrEnum):
+    """The side on which an account carries a positive balance."""
+
+    DEBIT = "debit"
+    CREDIT = "credit"
+
+
+# The canonical normal balance for each account type. Assets and expenses are
+# debit-normal; liabilities, equity and revenue are credit-normal. This single
+# map is the source of truth for every sign decision in the module.
+NORMAL_BALANCE_BY_TYPE: dict[AccountType, NormalBalance] = {
+    AccountType.ASSET: NormalBalance.DEBIT,
+    AccountType.EXPENSE: NormalBalance.DEBIT,
+    AccountType.LIABILITY: NormalBalance.CREDIT,
+    AccountType.EQUITY: NormalBalance.CREDIT,
+    AccountType.REVENUE: NormalBalance.CREDIT,
+}
+
+
+def normal_balance_for(account_type: AccountType | str) -> NormalBalance:
+    """Return the normal balance for an account type, accepting the enum or str."""
+    if isinstance(account_type, str):
+        account_type = AccountType(account_type)
+    return NORMAL_BALANCE_BY_TYPE[account_type]
+
+
+# ── Lightweight value objects ───────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AccountDef:
+    """An account definition in the chart of accounts (seed + lookups).
+
+    A plain value object so the seed table and the statement derivations can
+    share one description of an account without importing the ORM model.
+    """
+
+    code: str
+    name: str
+    account_type: AccountType
+    # Optional parent code for the hierarchy (None for roots).
+    parent_code: str | None = None
+    # Statement-line grouping hint (e.g. "current_asset", "cogs"). Optional;
+    # the statements fall back to the account_type when absent.
+    statement_section: str | None = None
+    # Whether movements on this account represent cash for the direct cash-flow
+    # statement. True only for the cash/bank accounts.
+    is_cash: bool = False
+
+    @property
+    def normal_balance(self) -> NormalBalance:
+        return normal_balance_for(self.account_type)
+
+
+@dataclass(frozen=True)
+class LedgerLine:
+    """A single posted ledger row, reduced to what the statements need.
+
+    Mirrors the load-bearing columns of
+    :class:`app.modules.finance.models.LedgerEntry`. ``debit`` and ``credit``
+    are mutually exclusive (one is zero) by the double-entry invariant, but the
+    derivations never rely on that - they always net ``debit - credit``.
+    """
+
+    account_code: str
+    debit: Decimal = _ZERO
+    credit: Decimal = _ZERO
+    currency_code: str = ""
+    # Optional period anchor (ISO date/datetime string). The service filters by
+    # period before constructing lines, so the derivations are period-agnostic.
+    posted_at: str = ""
+
+
+# ── Account-balance computation ─────────────────────────────────────────────
+
+
+def signed_balance(
+    debit_total: Decimal,
+    credit_total: Decimal,
+    normal: NormalBalance,
+) -> Decimal:
+    """Return the account balance in its natural (normal-balance) direction.
+
+    Debit-normal accounts (assets, expenses) read ``debits - credits``;
+    credit-normal accounts (liabilities, equity, revenue) read
+    ``credits - debits``. The result is positive when the account holds a
+    healthy balance on its normal side and negative when it is contra.
+    """
+    if normal is NormalBalance.DEBIT:
+        return debit_total - credit_total
+    return credit_total - debit_total
+
+
+@dataclass
+class AccountBalance:
+    """Per-account aggregation produced by :func:`trial_balance`."""
+
+    code: str
+    name: str
+    account_type: AccountType
+    normal_balance: NormalBalance
+    debit_total: Decimal
+    credit_total: Decimal
+
+    @property
+    def signed_balance(self) -> Decimal:
+        """Balance in the account's natural direction (see :func:`signed_balance`)."""
+        return signed_balance(self.debit_total, self.credit_total, self.normal_balance)
+
+
+# ── Currency guard ──────────────────────────────────────────────────────────
+
+
+def _assert_single_currency(lines: list[LedgerLine]) -> str:
+    """Return the single currency in *lines*, or raise on a blended feed.
+
+    The never-blend-currencies rule is enforced here: if more than one
+    non-empty currency code appears, we raise ``ValueError`` rather than add
+    amounts denominated in different currencies. A blank code is treated as the
+    base currency and never conflicts with another blank.
+    """
+    codes = {(ln.currency_code or "").strip().upper() for ln in lines}
+    codes.discard("")
+    if len(codes) > 1:
+        raise ValueError(
+            f"Cannot compute a statement across blended currencies {sorted(codes)}; "
+            f"filter or FX-convert to a single currency first."
+        )
+    return next(iter(codes), "")
+
+
+# ── Trial balance ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class TrialBalance:
+    """The trial balance: per-account totals plus the grand debit/credit check."""
+
+    currency: str
+    accounts: list[AccountBalance]
+    total_debits: Decimal
+    total_credits: Decimal
+
+    @property
+    def is_balanced(self) -> bool:
+        """True when total debits equal total credits (the books tie out)."""
+        return q2(self.total_debits) == q2(self.total_credits)
+
+    @property
+    def out_of_balance(self) -> Decimal:
+        """Signed debit-minus-credit residual (zero when balanced)."""
+        return q2(self.total_debits - self.total_credits)
+
+
+def trial_balance(
+    lines: list[LedgerLine],
+    accounts: dict[str, AccountDef],
+) -> TrialBalance:
+    """Aggregate ledger *lines* into a trial balance keyed by account.
+
+    Args:
+        lines: posted ledger lines, already filtered to one period / scope.
+        accounts: chart-of-accounts lookup ``{code: AccountDef}``. Every line's
+            ``account_code`` must resolve here - an unknown code raises
+            ``KeyError`` so posting against a non-existent account is caught.
+
+    Returns:
+        A :class:`TrialBalance` whose ``total_debits`` and ``total_credits`` are
+        the raw column sums (they are equal whenever the ledger is internally
+        consistent - the double-entry invariant guarantees it).
+
+    Accounts are emitted in chart order (by code) and only when they carry a
+    movement, so the trial balance lists exactly the accounts that moved.
+    """
+    currency = _assert_single_currency(lines)
+
+    debit_by_code: dict[str, Decimal] = {}
+    credit_by_code: dict[str, Decimal] = {}
+    total_debits = _ZERO
+    total_credits = _ZERO
+
+    for ln in lines:
+        code = ln.account_code
+        if code not in accounts:
+            raise KeyError(
+                f"Ledger line references unknown account_code {code!r} - it is not in the chart of accounts."
+            )
+        debit_by_code[code] = debit_by_code.get(code, _ZERO) + ln.debit
+        credit_by_code[code] = credit_by_code.get(code, _ZERO) + ln.credit
+        total_debits += ln.debit
+        total_credits += ln.credit
+
+    touched = sorted(set(debit_by_code) | set(credit_by_code), key=lambda c: accounts[c].code)
+    rows: list[AccountBalance] = []
+    for code in touched:
+        acc = accounts[code]
+        rows.append(
+            AccountBalance(
+                code=acc.code,
+                name=acc.name,
+                account_type=acc.account_type,
+                normal_balance=acc.normal_balance,
+                debit_total=q2(debit_by_code.get(code, _ZERO)),
+                credit_total=q2(credit_by_code.get(code, _ZERO)),
+            )
+        )
+
+    return TrialBalance(
+        currency=currency,
+        accounts=rows,
+        total_debits=q2(total_debits),
+        total_credits=q2(total_credits),
+    )
+
+
+# ── Statement line + base container ──────────────────────────────────────────
+
+
+@dataclass
+class StatementLine:
+    """One line on a financial statement (an account or a subtotal group)."""
+
+    code: str
+    name: str
+    amount: Decimal
+    account_type: str = ""
+    section: str = ""
+
+
+# ── Income statement (P&L) ──────────────────────────────────────────────────
+
+
+@dataclass
+class IncomeStatement:
+    """Profit & loss for a period: revenue, expenses and net income."""
+
+    currency: str
+    revenue_lines: list[StatementLine]
+    expense_lines: list[StatementLine]
+    total_revenue: Decimal
+    total_expenses: Decimal
+
+    @property
+    def net_income(self) -> Decimal:
+        """Net income = total revenue - total expenses (positive is profit)."""
+        return q2(self.total_revenue - self.total_expenses)
+
+
+def income_statement(
+    tb: TrialBalance,
+    accounts: dict[str, AccountDef],
+) -> IncomeStatement:
+    """Derive the income statement from a trial balance.
+
+    Revenue accounts are credit-normal, so their ``signed_balance`` is the
+    revenue earned (positive). Expense accounts are debit-normal, so their
+    ``signed_balance`` is the cost incurred (positive). Net income is the
+    difference. Only revenue/expense accounts participate; balance-sheet
+    accounts are ignored.
+    """
+    revenue_lines: list[StatementLine] = []
+    expense_lines: list[StatementLine] = []
+    total_revenue = _ZERO
+    total_expenses = _ZERO
+
+    for ab in tb.accounts:
+        if ab.account_type is AccountType.REVENUE:
+            amount = ab.signed_balance
+            total_revenue += amount
+            revenue_lines.append(
+                StatementLine(
+                    code=ab.code,
+                    name=ab.name,
+                    amount=q2(amount),
+                    account_type=ab.account_type.value,
+                    section=_section_for(accounts, ab.code, "revenue"),
+                )
+            )
+        elif ab.account_type is AccountType.EXPENSE:
+            amount = ab.signed_balance
+            total_expenses += amount
+            expense_lines.append(
+                StatementLine(
+                    code=ab.code,
+                    name=ab.name,
+                    amount=q2(amount),
+                    account_type=ab.account_type.value,
+                    section=_section_for(accounts, ab.code, "expense"),
+                )
+            )
+
+    return IncomeStatement(
+        currency=tb.currency,
+        revenue_lines=revenue_lines,
+        expense_lines=expense_lines,
+        total_revenue=q2(total_revenue),
+        total_expenses=q2(total_expenses),
+    )
+
+
+# ── Balance sheet ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class BalanceSheet:
+    """Statement of financial position as of a date.
+
+    ``retained_earnings`` folds period net income into equity so the identity
+    ``assets = liabilities + equity`` ties out even before a formal year-end
+    close has moved P&L into retained earnings. Without this, a live ledger
+    (revenue/expense not yet closed to equity) would always appear out of
+    balance by exactly net income.
+    """
+
+    currency: str
+    asset_lines: list[StatementLine]
+    liability_lines: list[StatementLine]
+    equity_lines: list[StatementLine]
+    total_assets: Decimal
+    total_liabilities: Decimal
+    total_equity: Decimal
+
+    @property
+    def liabilities_plus_equity(self) -> Decimal:
+        return q2(self.total_liabilities + self.total_equity)
+
+    @property
+    def is_balanced(self) -> bool:
+        """True when assets == liabilities + equity (the sheet ties out)."""
+        return q2(self.total_assets) == self.liabilities_plus_equity
+
+    @property
+    def out_of_balance(self) -> Decimal:
+        """Signed residual assets - (liabilities + equity); zero when balanced."""
+        return q2(self.total_assets - self.liabilities_plus_equity)
+
+
+# The synthetic line code/name used to fold current-period net income into
+# equity so a live (pre-close) ledger still balances.
+RETAINED_EARNINGS_CODE = "3900"
+RETAINED_EARNINGS_NAME = "Retained Earnings (current period)"
+
+
+def balance_sheet(
+    tb: TrialBalance,
+    accounts: dict[str, AccountDef],
+    *,
+    fold_net_income_into_equity: bool = True,
+) -> BalanceSheet:
+    """Derive the balance sheet from a trial balance.
+
+    Assets are debit-normal (positive ``signed_balance`` = a real asset);
+    liabilities and equity are credit-normal (positive = a real claim). When
+    ``fold_net_income_into_equity`` is True the period net income (revenue -
+    expenses, from the same trial balance) is added as a synthetic retained
+    earnings equity line so the accounting identity holds on a live ledger that
+    has not yet been closed. Set it False to see equity exactly as posted (which
+    only balances after a year-end close).
+    """
+    asset_lines: list[StatementLine] = []
+    liability_lines: list[StatementLine] = []
+    equity_lines: list[StatementLine] = []
+    total_assets = _ZERO
+    total_liabilities = _ZERO
+    total_equity = _ZERO
+    period_revenue = _ZERO
+    period_expense = _ZERO
+
+    for ab in tb.accounts:
+        amount = ab.signed_balance
+        if ab.account_type is AccountType.ASSET:
+            total_assets += amount
+            asset_lines.append(_bs_line(accounts, ab, "asset"))
+        elif ab.account_type is AccountType.LIABILITY:
+            total_liabilities += amount
+            liability_lines.append(_bs_line(accounts, ab, "liability"))
+        elif ab.account_type is AccountType.EQUITY:
+            total_equity += amount
+            equity_lines.append(_bs_line(accounts, ab, "equity"))
+        elif ab.account_type is AccountType.REVENUE:
+            period_revenue += amount
+        elif ab.account_type is AccountType.EXPENSE:
+            period_expense += amount
+
+    if fold_net_income_into_equity:
+        net_income = period_revenue - period_expense
+        if net_income != _ZERO or equity_lines:
+            total_equity += net_income
+            equity_lines.append(
+                StatementLine(
+                    code=RETAINED_EARNINGS_CODE,
+                    name=RETAINED_EARNINGS_NAME,
+                    amount=q2(net_income),
+                    account_type=AccountType.EQUITY.value,
+                    section="retained_earnings",
+                )
+            )
+
+    return BalanceSheet(
+        currency=tb.currency,
+        asset_lines=asset_lines,
+        liability_lines=liability_lines,
+        equity_lines=equity_lines,
+        total_assets=q2(total_assets),
+        total_liabilities=q2(total_liabilities),
+        total_equity=q2(total_equity),
+    )
+
+
+# ── Cash flow (direct method from cash-account movements) ─────────────────────
+
+
+@dataclass
+class CashFlowStatement:
+    """Direct-method cash flow derived from cash-account ledger movements.
+
+    Honest scope (see module/service docstrings): this is the *direct* method
+    built purely from movements on accounts flagged ``is_cash`` in the chart.
+    Net change in cash = sum of debits (cash in) minus credits (cash out) on the
+    cash accounts. The counter-account of each cash movement classifies it into
+    operating / investing / financing using a coarse account-type heuristic; a
+    full indirect statement (working-capital roll-forward, non-cash add-backs)
+    is intentionally NOT attempted here because it needs an opening balance
+    sheet and an accrual close that the live ledger alone does not pin down.
+    """
+
+    currency: str
+    operating: Decimal
+    investing: Decimal
+    financing: Decimal
+    opening_cash: Decimal
+    net_change: Decimal
+
+    @property
+    def closing_cash(self) -> Decimal:
+        return q2(self.opening_cash + self.net_change)
+
+    @property
+    def ties_out(self) -> bool:
+        """True when the three activity buckets sum to the net change in cash."""
+        return q2(self.operating + self.investing + self.financing) == q2(self.net_change)
+
+
+def _classify_activity(counter_type: AccountType | None) -> str:
+    """Map the counter-account type of a cash movement to a cash-flow bucket.
+
+    Coarse but defensible direct-method classification:
+      * revenue / expense / current liabilities & assets  -> operating
+      * non-current assets (capex)                         -> investing
+      * equity / long-term liabilities (loans, capital)    -> financing
+
+    The chart's ``statement_section`` refines this (e.g. a non-current asset is
+    tagged ``investing``); absent a hint we fall back to the type. ``None``
+    (cash-to-cash transfer) nets to zero and lands in operating by convention.
+    """
+    if counter_type is None:
+        return "operating"
+    if counter_type is AccountType.EQUITY:
+        return "financing"
+    if counter_type is AccountType.REVENUE or counter_type is AccountType.EXPENSE:
+        return "operating"
+    # Assets and liabilities default to operating; the section hint upgrades
+    # capex/long-term-debt movements to investing/financing in cash_flow().
+    return "operating"
+
+
+@dataclass(frozen=True)
+class CashMovement:
+    """One cash leg with its paired counter-account, for direct cash flow.
+
+    The service pairs the cash leg of a transaction with the non-cash leg
+    (same ``transaction_ref``) so the counter-account type/section can classify
+    the movement. ``amount`` is signed: positive = cash in, negative = cash out.
+    """
+
+    amount: Decimal
+    counter_type: AccountType | None = None
+    counter_section: str | None = None
+
+
+def cash_flow_direct(
+    movements: list[CashMovement],
+    *,
+    currency: str = "",
+    opening_cash: Decimal = _ZERO,
+) -> CashFlowStatement:
+    """Build a direct-method cash flow from classified cash *movements*.
+
+    Each movement's signed ``amount`` is bucketed into operating / investing /
+    financing by its counter-account. The buckets sum to the net change in cash,
+    which is asserted via :attr:`CashFlowStatement.ties_out`.
+    """
+    operating = _ZERO
+    investing = _ZERO
+    financing = _ZERO
+
+    for mv in movements:
+        section = (mv.counter_section or "").strip().lower()
+        if section in ("investing", "financing", "operating"):
+            bucket = section
+        else:
+            bucket = _classify_activity(mv.counter_type)
+        if bucket == "investing":
+            investing += mv.amount
+        elif bucket == "financing":
+            financing += mv.amount
+        else:
+            operating += mv.amount
+
+    net_change = operating + investing + financing
+    return CashFlowStatement(
+        currency=currency,
+        operating=q2(operating),
+        investing=q2(investing),
+        financing=q2(financing),
+        opening_cash=q2(opening_cash),
+        net_change=q2(net_change),
+    )
+
+
+# ── Section helpers ──────────────────────────────────────────────────────────
+
+
+def _section_for(accounts: dict[str, AccountDef], code: str, fallback: str) -> str:
+    acc = accounts.get(code)
+    if acc and acc.statement_section:
+        return acc.statement_section
+    return fallback
+
+
+def _bs_line(accounts: dict[str, AccountDef], ab: AccountBalance, fallback: str) -> StatementLine:
+    return StatementLine(
+        code=ab.code,
+        name=ab.name,
+        amount=q2(ab.signed_balance),
+        account_type=ab.account_type.value,
+        section=_section_for(accounts, ab.code, fallback),
+    )
+
+
+# ── Default construction chart of accounts ───────────────────────────────────
+#
+# A pragmatic GAAP chart tuned for a construction / project business. Codes use
+# the classic 1xxx-5xxx ranges:
+#   1xxx assets, 2xxx liabilities, 3xxx equity, 4xxx revenue, 5xxx expense.
+# Over/under-billings (contract assets/liabilities) and retention are first
+# class because they dominate construction balance sheets.
+
+_DEFAULT_ACCOUNTS: tuple[AccountDef, ...] = (
+    # ── Assets (1xxx) ────────────────────────────────────────────────────────
+    AccountDef("1000", "Cash and Cash Equivalents", AccountType.ASSET, None, "current_asset", is_cash=True),
+    AccountDef("1010", "Operating Bank Account", AccountType.ASSET, "1000", "current_asset", is_cash=True),
+    AccountDef("1100", "Accounts Receivable", AccountType.ASSET, None, "current_asset"),
+    AccountDef("1110", "Retention Receivable", AccountType.ASSET, "1100", "current_asset"),
+    AccountDef(
+        "1200",
+        "Costs and Estimated Earnings in Excess of Billings",
+        AccountType.ASSET,
+        None,
+        "current_asset",
+    ),
+    AccountDef("1300", "Work in Progress (Contract Costs)", AccountType.ASSET, None, "current_asset"),
+    AccountDef("1400", "Materials Inventory", AccountType.ASSET, None, "current_asset"),
+    AccountDef("1500", "Prepaid Expenses", AccountType.ASSET, None, "current_asset"),
+    AccountDef("1700", "Property, Plant and Equipment", AccountType.ASSET, None, "investing"),
+    AccountDef("1710", "Construction Equipment", AccountType.ASSET, "1700", "investing"),
+    AccountDef("1790", "Accumulated Depreciation", AccountType.ASSET, "1700", "investing"),
+    # ── Liabilities (2xxx) ───────────────────────────────────────────────────
+    AccountDef("2000", "Accounts Payable", AccountType.LIABILITY, None, "current_liability"),
+    AccountDef("2010", "Retention Payable", AccountType.LIABILITY, "2000", "current_liability"),
+    AccountDef("2100", "Accrued Liabilities", AccountType.LIABILITY, None, "current_liability"),
+    AccountDef(
+        "2200",
+        "Billings in Excess of Costs and Estimated Earnings",
+        AccountType.LIABILITY,
+        None,
+        "current_liability",
+    ),
+    AccountDef("2300", "Taxes Payable", AccountType.LIABILITY, None, "current_liability"),
+    AccountDef("2400", "Deferred Revenue", AccountType.LIABILITY, None, "current_liability"),
+    AccountDef("2700", "Long-Term Debt", AccountType.LIABILITY, None, "financing"),
+    AccountDef("2710", "Notes Payable", AccountType.LIABILITY, "2700", "financing"),
+    # ── Equity (3xxx) ────────────────────────────────────────────────────────
+    AccountDef("3000", "Owner's Capital / Common Stock", AccountType.EQUITY, None, "financing"),
+    AccountDef("3100", "Additional Paid-In Capital", AccountType.EQUITY, None, "financing"),
+    AccountDef("3200", "Retained Earnings", AccountType.EQUITY, None, "retained_earnings"),
+    AccountDef("3300", "Distributions / Dividends", AccountType.EQUITY, None, "financing"),
+    # ── Revenue (4xxx) ───────────────────────────────────────────────────────
+    AccountDef("4000", "Contract Revenue", AccountType.REVENUE, None, "revenue"),
+    AccountDef("4100", "Change Order Revenue", AccountType.REVENUE, None, "revenue"),
+    AccountDef("4200", "Service Revenue", AccountType.REVENUE, None, "revenue"),
+    AccountDef("4900", "Other Income", AccountType.REVENUE, None, "other_income"),
+    # ── Expenses (5xxx) ──────────────────────────────────────────────────────
+    AccountDef("5000", "Cost of Construction (COGS)", AccountType.EXPENSE, None, "cogs"),
+    AccountDef("5010", "Direct Labor", AccountType.EXPENSE, "5000", "cogs"),
+    AccountDef("5020", "Direct Materials", AccountType.EXPENSE, "5000", "cogs"),
+    AccountDef("5030", "Subcontractor Costs", AccountType.EXPENSE, "5000", "cogs"),
+    AccountDef("5040", "Equipment Costs", AccountType.EXPENSE, "5000", "cogs"),
+    AccountDef("5100", "General and Administrative", AccountType.EXPENSE, None, "operating_expense"),
+    AccountDef("5110", "Salaries and Wages (Overhead)", AccountType.EXPENSE, "5100", "operating_expense"),
+    AccountDef("5200", "Depreciation Expense", AccountType.EXPENSE, None, "operating_expense"),
+    AccountDef("5300", "Interest Expense", AccountType.EXPENSE, None, "operating_expense"),
+    AccountDef("5900", "Other Expense", AccountType.EXPENSE, None, "operating_expense"),
+)
+
+
+def default_chart_of_accounts() -> OrderedDict[str, AccountDef]:
+    """Return the default construction chart of accounts as ``{code: AccountDef}``.
+
+    Ordered by code so callers that iterate get a stable, readable layout. The
+    returned mapping is freshly built on each call so a caller mutating it (e.g.
+    adding custom accounts) cannot corrupt the module-level seed.
+    """
+    chart: OrderedDict[str, AccountDef] = OrderedDict()
+    for acc in sorted(_DEFAULT_ACCOUNTS, key=lambda a: a.code):
+        chart[acc.code] = acc
+    return chart
+
+
+# Frozen module-level view for read-only callers (tests, validation).
+DEFAULT_CHART: dict[str, AccountDef] = dict(default_chart_of_accounts())
+
+# Re-export the cash account codes for the direct cash-flow derivation.
+CASH_ACCOUNT_CODES: frozenset[str] = frozenset(a.code for a in _DEFAULT_ACCOUNTS if a.is_cash)
+
+
+__all__ = [
+    "CASH_ACCOUNT_CODES",
+    "DEFAULT_CHART",
+    "RETAINED_EARNINGS_CODE",
+    "AccountBalance",
+    "AccountDef",
+    "AccountType",
+    "BalanceSheet",
+    "CashFlowStatement",
+    "CashMovement",
+    "IncomeStatement",
+    "LedgerLine",
+    "NormalBalance",
+    "StatementLine",
+    "TrialBalance",
+    "balance_sheet",
+    "cash_flow_direct",
+    "default_chart_of_accounts",
+    "income_statement",
+    "normal_balance_for",
+    "q2",
+    "signed_balance",
+    "trial_balance",
+]

--- a/backend/app/modules/finance/models.py
+++ b/backend/app/modules/finance/models.py
@@ -304,6 +304,62 @@ class LedgerEntry(Base):
         return f"<LedgerEntry ref={self.transaction_ref} dr={self.debit_amount} cr={self.credit_amount}>"
 
 
+class LedgerAccount(Base):
+    """A chart-of-accounts account (GAAP general ledger).
+
+    Task #77: the master record every :class:`LedgerEntry.account_code` must map
+    to. Accounts are tenant/project-scoped consistent with the rest of finance:
+    ``project_id`` is nullable so an account can be shared across a workspace
+    (``project_id IS NULL``) or pinned to one project. ``account_code`` is unique
+    within a scope so a project never carries two "1000" accounts.
+
+    Sign conventions live in :mod:`app.modules.finance.gaap`:
+    ``account_type`` is one of asset / liability / equity / revenue / expense
+    and ``normal_balance`` is debit | credit (assets/expenses debit-normal,
+    liabilities/equity/revenue credit-normal). ``parent_id`` gives the hierarchy
+    (a sub-account points at its roll-up parent).
+    """
+
+    __tablename__ = "oe_finance_ledger_account"
+    __table_args__ = (
+        # One account code per scope. The project_id participates so a workspace
+        # account (NULL project) and a project-pinned account can share a code.
+        UniqueConstraint("project_id", "account_code", name="uq_ledger_account_scope_code"),
+        Index("ix_ledger_account_project_type", "project_id", "account_type"),
+    )
+
+    # NULL = workspace/tenant-scoped account shared by every project; a value
+    # pins the account to one project. Mirrors the nullable-scope pattern used
+    # by saved views.
+    project_id: Mapped[uuid.UUID | None] = mapped_column(GUID(), nullable=True, index=True)
+    account_code: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    account_type: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    normal_balance: Mapped[str] = mapped_column(String(10), nullable=False)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_finance_ledger_account.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Statement-line grouping hint (e.g. "current_asset", "cogs", "revenue").
+    statement_section: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Whether movements on this account are cash (for the direct cash-flow
+    # statement). True only for cash / bank accounts.
+    is_cash: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=False, server_default="0")
+    is_active: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True, server_default="1")
+    currency_code: Mapped[str] = mapped_column(String(10), nullable=False, default="", server_default="")
+    metadata_: Mapped[dict] = mapped_column(  # type: ignore[assignment]
+        "metadata",
+        JSON,
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+
+    def __repr__(self) -> str:
+        return f"<LedgerAccount {self.account_code} {self.name} ({self.account_type})>"
+
+
 # ── Connector models ───────────────────────────────────────────────────────
 # Re-exported from connector_models so the startup model-discovery (which
 # scans each module's ``models.py``) registers the connector tables for

--- a/backend/app/modules/finance/permissions.py
+++ b/backend/app/modules/finance/permissions.py
@@ -42,5 +42,16 @@ def register_finance_permissions() -> None:
             "finance.connector.read": Role.VIEWER,
             "finance.connector.manage": Role.MANAGER,
             "finance.connector.sync": Role.MANAGER,
+            # Task #77: GAAP general ledger + financial reporting.
+            # Reading the chart of accounts, the trial balance and the
+            # financial statements is VIEWER. Managing the chart (which shapes
+            # how every statement is classified) and posting a journal entry
+            # (a binding double-entry ledger write) are MANAGER, consistent
+            # with the R7 escalation that put record_payment / approve / pay at
+            # MANAGER. Statements are derived read models, so they sit at
+            # finance.read.
+            "finance.gl.read": Role.VIEWER,
+            "finance.gl.manage_accounts": Role.MANAGER,
+            "finance.gl.post_journal": Role.MANAGER,
         },
     )

--- a/backend/app/modules/finance/repository.py
+++ b/backend/app/modules/finance/repository.py
@@ -16,6 +16,8 @@ from app.modules.finance.models import (
     EVMSnapshot,
     Invoice,
     InvoiceLineItem,
+    LedgerAccount,
+    LedgerEntry,
     Payment,
     ProjectBudget,
 )
@@ -524,3 +526,137 @@ class EVMSnapshotRepository:
         self.session.add(snapshot)
         await self.session.flush()
         return snapshot
+
+
+class LedgerAccountRepository:
+    """Data access for the chart of accounts (:class:`LedgerAccount`)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get(self, account_id: uuid.UUID) -> LedgerAccount | None:
+        """Get a chart-of-accounts row by id."""
+        return await self.session.get(LedgerAccount, account_id)
+
+    async def get_by_code(
+        self,
+        account_code: str,
+        *,
+        project_id: uuid.UUID | None = None,
+    ) -> LedgerAccount | None:
+        """Resolve an account by code within a scope.
+
+        A project-scoped account (``project_id`` set) takes precedence; when no
+        project-scoped row exists the workspace account (``project_id IS NULL``)
+        with the same code is returned. This lets a project override a shared
+        account while still inheriting the default chart.
+        """
+        if project_id is not None:
+            stmt = select(LedgerAccount).where(
+                LedgerAccount.project_id == project_id,
+                LedgerAccount.account_code == account_code,
+            )
+            row = (await self.session.execute(stmt)).scalar_one_or_none()
+            if row is not None:
+                return row
+        stmt = select(LedgerAccount).where(
+            LedgerAccount.project_id.is_(None),
+            LedgerAccount.account_code == account_code,
+        )
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def list(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        include_workspace: bool = True,
+        account_type: str | None = None,
+        active_only: bool = False,
+    ) -> tuple[list[LedgerAccount], int]:
+        """List chart-of-accounts rows for a scope.
+
+        When ``include_workspace`` is True the project-scoped accounts are
+        unioned with the shared workspace accounts (``project_id IS NULL``), so
+        a project sees the default chart plus its own overrides.
+        """
+        base = select(LedgerAccount)
+        if project_id is not None:
+            if include_workspace:
+                base = base.where((LedgerAccount.project_id == project_id) | (LedgerAccount.project_id.is_(None)))
+            else:
+                base = base.where(LedgerAccount.project_id == project_id)
+        elif not include_workspace:
+            base = base.where(LedgerAccount.project_id.isnot(None))
+        if account_type is not None:
+            base = base.where(LedgerAccount.account_type == account_type)
+        if active_only:
+            base = base.where(LedgerAccount.is_active.is_(True))
+
+        count_stmt = select(func.count()).select_from(base.subquery())
+        total = (await self.session.execute(count_stmt)).scalar_one()
+
+        stmt = base.order_by(LedgerAccount.account_code.asc())
+        items = list((await self.session.execute(stmt)).scalars().all())
+        return items, total
+
+    async def create(self, account: LedgerAccount) -> LedgerAccount:
+        """Insert a new chart-of-accounts row."""
+        self.session.add(account)
+        await self.session.flush()
+        return account
+
+    async def update(self, account_id: uuid.UUID, **fields: object) -> None:
+        """Update specific fields on a chart-of-accounts row."""
+        stmt = update(LedgerAccount).where(LedgerAccount.id == account_id).values(**fields)
+        await self.session.execute(stmt)
+        await self.session.flush()
+        self.session.expire_all()
+
+    async def count_for_scope(self, project_id: uuid.UUID | None) -> int:
+        """Count accounts in exactly one scope (used to decide whether to seed)."""
+        stmt = select(func.count()).select_from(LedgerAccount)
+        if project_id is None:
+            stmt = stmt.where(LedgerAccount.project_id.is_(None))
+        else:
+            stmt = stmt.where(LedgerAccount.project_id == project_id)
+        return (await self.session.execute(stmt)).scalar_one()
+
+
+class LedgerRepository:
+    """Read access to posted :class:`LedgerEntry` rows for the GAAP statements."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_entries(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        currency_code: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+        include_reversals: bool = True,
+    ) -> list[LedgerEntry]:
+        """Return posted ledger rows for a scope and (optional) period.
+
+        ``date_from`` / ``date_to`` filter on ``posted_at`` (ISO strings, so a
+        lexical comparison matches chronological order). ``date_to`` is
+        inclusive of the whole day: a bare ``YYYY-MM-DD`` is bumped to the end
+        of that day so an entry posted at ``...T14:00`` is not dropped.
+        Reversals are included by default so corrected transactions net to zero
+        in every derivation.
+        """
+        stmt = select(LedgerEntry)
+        if project_id is not None:
+            stmt = stmt.where(LedgerEntry.project_id == project_id)
+        if currency_code is not None:
+            stmt = stmt.where(LedgerEntry.currency_code == currency_code)
+        if date_from:
+            stmt = stmt.where(LedgerEntry.posted_at >= date_from)
+        if date_to:
+            upper = date_to if "T" in date_to else f"{date_to}T23:59:59.999999"
+            stmt = stmt.where(LedgerEntry.posted_at <= upper)
+        if not include_reversals:
+            stmt = stmt.where(LedgerEntry.is_reversal.is_(False))
+        stmt = stmt.order_by(LedgerEntry.posted_at.asc())
+        return list((await self.session.execute(stmt)).scalars().all())

--- a/backend/app/modules/finance/router.py
+++ b/backend/app/modules/finance/router.py
@@ -62,22 +62,35 @@ from app.modules.finance.connector_service import ConnectorService
 from app.modules.finance.connectors.registry import connector_registry
 from app.modules.finance.models import EVMSnapshot, Invoice, Payment, ProjectBudget
 from app.modules.finance.schemas import (
+    BalanceSheetResponse,
     BudgetCreate,
     BudgetListResponse,
     BudgetResponse,
     BudgetUpdate,
+    CashFlowResponse,
     ClaimInvoiceRequest,
     EVMListResponse,
     EVMSnapshotCreate,
     EVMSnapshotResponse,
+    IncomeStatementResponse,
     InvoiceCreate,
     InvoiceListResponse,
     InvoiceResponse,
     InvoiceUpdate,
+    JournalEntryCreate,
+    JournalEntryResponse,
+    LedgerAccountCreate,
+    LedgerAccountListResponse,
+    LedgerAccountResponse,
+    LedgerAccountUpdate,
+    LedgerEntryResponse,
     PaymentCreate,
     PaymentListResponse,
     PaymentResponse,
     RecordClaimPaymentRequest,
+    StatementLineResponse,
+    TrialBalanceResponse,
+    TrialBalanceRow,
 )
 from app.modules.finance.service import FinanceService
 
@@ -1633,3 +1646,325 @@ async def pay_invoice(
     )
     names = await _fetch_counterparty_names(session, [invoice.contact_id])
     return _invoice_to_response(invoice, names)
+
+
+# ── GAAP general ledger + financial reporting (task #77) ────────────────────
+#
+# Mounted under ``/gaap`` so the static segment never collides with the
+# parametric ``/{invoice_id}`` route above. Endpoints:
+#   GET    /gaap/accounts                  - list chart of accounts
+#   POST   /gaap/accounts                  - create an account (MANAGER)
+#   POST   /gaap/accounts/seed-defaults    - seed the default chart (MANAGER)
+#   PATCH  /gaap/accounts/{id}             - update an account (MANAGER)
+#   POST   /gaap/journal-entries           - post a balanced journal (MANAGER)
+#   GET    /gaap/trial-balance             - trial balance (debits == credits)
+#   GET    /gaap/statements/income         - income statement (P&L)
+#   GET    /gaap/statements/balance-sheet  - balance sheet (A = L + E)
+#   GET    /gaap/statements/cash-flow      - direct-method cash flow
+
+gaap_router = APIRouter(prefix="/gaap", tags=["finance-gaap"])
+
+
+def _ledger_entry_to_response(row: Any) -> LedgerEntryResponse:
+    return LedgerEntryResponse.model_validate(row)
+
+
+@gaap_router.get(
+    "/accounts",
+    response_model=LedgerAccountListResponse,
+    summary="List chart of accounts",
+    description="List chart-of-accounts rows for a scope. With a project_id the shared "
+    "workspace chart is unioned with the project's own accounts.",
+)
+async def list_ledger_accounts(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    account_type: str | None = Query(default=None),
+    active_only: bool = Query(default=False),
+    _perm: None = Depends(RequirePermission("finance.gl.read")),
+    service: FinanceService = Depends(_get_service),
+) -> LedgerAccountListResponse:
+    """List chart-of-accounts rows."""
+    await _require_project_access(session, project_id, user_id)
+    items, total = await service.list_accounts(
+        project_id=project_id,
+        account_type=account_type,
+        active_only=active_only,
+    )
+    return LedgerAccountListResponse(
+        items=[LedgerAccountResponse.model_validate(a) for a in items],
+        total=total,
+    )
+
+
+@gaap_router.post(
+    "/accounts",
+    response_model=LedgerAccountResponse,
+    status_code=201,
+    summary="Create a ledger account",
+    description="Create a chart-of-accounts account. normal_balance is derived from "
+    "account_type when omitted. MANAGER-only - the chart shapes every statement.",
+)
+async def create_ledger_account(
+    data: LedgerAccountCreate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("finance.gl.manage_accounts")),
+    service: FinanceService = Depends(_get_service),
+) -> LedgerAccountResponse:
+    """Create a chart-of-accounts account."""
+    await _require_project_access(session, data.project_id, user_id)
+    account = await service.create_account(data)
+    return LedgerAccountResponse.model_validate(account)
+
+
+@gaap_router.post(
+    "/accounts/seed-defaults",
+    response_model=LedgerAccountListResponse,
+    summary="Seed the default construction chart of accounts",
+    description="Idempotently seed the default chart into a scope (workspace when no project_id). MANAGER-only.",
+)
+async def seed_default_chart(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    _perm: None = Depends(RequirePermission("finance.gl.manage_accounts")),
+    service: FinanceService = Depends(_get_service),
+) -> LedgerAccountListResponse:
+    """Seed the default chart of accounts."""
+    await _require_project_access(session, project_id, user_id)
+    accounts = await service.seed_default_chart(project_id=project_id)
+    return LedgerAccountListResponse(
+        items=[LedgerAccountResponse.model_validate(a) for a in accounts],
+        total=len(accounts),
+    )
+
+
+@gaap_router.patch(
+    "/accounts/{account_id}",
+    response_model=LedgerAccountResponse,
+    summary="Update a ledger account",
+    description="Patch descriptive fields on a chart-of-accounts account. Code and type are immutable. MANAGER-only.",
+)
+async def update_ledger_account(
+    account_id: uuid.UUID,
+    data: LedgerAccountUpdate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("finance.gl.manage_accounts")),
+    service: FinanceService = Depends(_get_service),
+) -> LedgerAccountResponse:
+    """Update a chart-of-accounts account."""
+    account = await service.get_account(account_id)
+    await _require_project_access(session, account.project_id, user_id)
+    updated = await service.update_account(account_id, data)
+    return LedgerAccountResponse.model_validate(updated)
+
+
+@gaap_router.post(
+    "/journal-entries",
+    response_model=JournalEntryResponse,
+    status_code=201,
+    summary="Post a balanced journal entry",
+    description="Post a balanced double-entry journal of two or more lines. The service "
+    "rejects an unbalanced entry, a blended-currency entry, and posting to an "
+    "unknown account. MANAGER-only - a binding ledger write.",
+)
+async def post_journal_entry(
+    data: JournalEntryCreate,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _perm: None = Depends(RequirePermission("finance.gl.post_journal")),
+    service: FinanceService = Depends(_get_service),
+) -> JournalEntryResponse:
+    """Post a balanced journal entry."""
+    await _require_project_access(session, data.project_id, user_id)
+    rows, total_debits, total_credits = await service.post_journal_entry(data)
+    return JournalEntryResponse(
+        transaction_ref=data.transaction_ref,
+        lines=[_ledger_entry_to_response(r) for r in rows],
+        total_debits=format(total_debits, "f"),
+        total_credits=format(total_credits, "f"),
+    )
+
+
+@gaap_router.get(
+    "/trial-balance",
+    response_model=TrialBalanceResponse,
+    summary="Trial balance",
+    description="Per-account debit/credit totals and signed balance, with the grand "
+    "debit == credit tie-out check, for a scope and period.",
+)
+async def get_trial_balance(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    currency_code: str | None = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
+    _perm: None = Depends(RequirePermission("finance.gl.read")),
+    service: FinanceService = Depends(_get_service),
+) -> TrialBalanceResponse:
+    """Compute the trial balance."""
+    await _require_project_access(session, project_id, user_id)
+    tb = await service.trial_balance(
+        project_id=project_id,
+        currency_code=currency_code,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return TrialBalanceResponse(
+        currency=tb.currency,
+        as_of=date_to,
+        date_from=date_from,
+        rows=[
+            TrialBalanceRow(
+                account_code=r.code,
+                name=r.name,
+                account_type=r.account_type.value,
+                normal_balance=r.normal_balance.value,
+                debit_total=format(r.debit_total, "f"),
+                credit_total=format(r.credit_total, "f"),
+                balance=format(r.signed_balance, "f"),
+            )
+            for r in tb.accounts
+        ],
+        total_debits=format(tb.total_debits, "f"),
+        total_credits=format(tb.total_credits, "f"),
+        is_balanced=tb.is_balanced,
+        out_of_balance=format(tb.out_of_balance, "f"),
+    )
+
+
+def _statement_lines(lines: Any) -> list[StatementLineResponse]:
+    return [
+        StatementLineResponse(
+            code=line.code,
+            name=line.name,
+            amount=format(line.amount, "f"),
+            account_type=line.account_type,
+            section=line.section,
+        )
+        for line in lines
+    ]
+
+
+@gaap_router.get(
+    "/statements/income",
+    response_model=IncomeStatementResponse,
+    summary="Income statement (P&L)",
+    description="Revenue minus expenses over a period, derived from the ledger.",
+)
+async def get_income_statement(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    currency_code: str | None = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
+    _perm: None = Depends(RequirePermission("finance.gl.read")),
+    service: FinanceService = Depends(_get_service),
+) -> IncomeStatementResponse:
+    """Derive the income statement."""
+    await _require_project_access(session, project_id, user_id)
+    inc = await service.income_statement(
+        project_id=project_id,
+        currency_code=currency_code,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return IncomeStatementResponse(
+        currency=inc.currency,
+        date_from=date_from,
+        date_to=date_to,
+        revenue_lines=_statement_lines(inc.revenue_lines),
+        expense_lines=_statement_lines(inc.expense_lines),
+        total_revenue=format(inc.total_revenue, "f"),
+        total_expenses=format(inc.total_expenses, "f"),
+        net_income=format(inc.net_income, "f"),
+    )
+
+
+@gaap_router.get(
+    "/statements/balance-sheet",
+    response_model=BalanceSheetResponse,
+    summary="Balance sheet",
+    description="Assets, liabilities and equity as of a date, with the assets = "
+    "liabilities + equity tie-out check. Period net income is folded into "
+    "equity as retained earnings so a live (pre-close) ledger still balances.",
+)
+async def get_balance_sheet(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    currency_code: str | None = Query(default=None),
+    as_of: str | None = Query(default=None),
+    _perm: None = Depends(RequirePermission("finance.gl.read")),
+    service: FinanceService = Depends(_get_service),
+) -> BalanceSheetResponse:
+    """Derive the balance sheet."""
+    await _require_project_access(session, project_id, user_id)
+    bs = await service.balance_sheet(
+        project_id=project_id,
+        currency_code=currency_code,
+        as_of=as_of,
+    )
+    return BalanceSheetResponse(
+        currency=bs.currency,
+        as_of=as_of,
+        asset_lines=_statement_lines(bs.asset_lines),
+        liability_lines=_statement_lines(bs.liability_lines),
+        equity_lines=_statement_lines(bs.equity_lines),
+        total_assets=format(bs.total_assets, "f"),
+        total_liabilities=format(bs.total_liabilities, "f"),
+        total_equity=format(bs.total_equity, "f"),
+        liabilities_plus_equity=format(bs.liabilities_plus_equity, "f"),
+        is_balanced=bs.is_balanced,
+        out_of_balance=format(bs.out_of_balance, "f"),
+    )
+
+
+@gaap_router.get(
+    "/statements/cash-flow",
+    response_model=CashFlowResponse,
+    summary="Cash flow statement (direct method)",
+    description="Direct-method cash flow derived from movements on cash accounts, "
+    "classified into operating / investing / financing by their counter-account. "
+    "See the design doc for the honest scope of this derivation.",
+)
+async def get_cash_flow(
+    session: SessionDep,
+    user_id: CurrentUserId,
+    project_id: uuid.UUID | None = Query(default=None),
+    currency_code: str | None = Query(default=None),
+    date_from: str | None = Query(default=None),
+    date_to: str | None = Query(default=None),
+    _perm: None = Depends(RequirePermission("finance.gl.read")),
+    service: FinanceService = Depends(_get_service),
+) -> CashFlowResponse:
+    """Derive the direct-method cash flow statement."""
+    await _require_project_access(session, project_id, user_id)
+    cf = await service.cash_flow(
+        project_id=project_id,
+        currency_code=currency_code,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    return CashFlowResponse(
+        currency=cf.currency,
+        date_from=date_from,
+        date_to=date_to,
+        method="direct",
+        operating=format(cf.operating, "f"),
+        investing=format(cf.investing, "f"),
+        financing=format(cf.financing, "f"),
+        opening_cash=format(cf.opening_cash, "f"),
+        net_change=format(cf.net_change, "f"),
+        closing_cash=format(cf.closing_cash, "f"),
+        ties_out=cf.ties_out,
+    )
+
+
+# Mount the GAAP sub-router onto the module router so the loader picks it up.
+router.include_router(gaap_router)

--- a/backend/app/modules/finance/schemas.py
+++ b/backend/app/modules/finance/schemas.py
@@ -725,3 +725,208 @@ class LedgerListResponse(BaseModel):
 
     items: list[LedgerEntryResponse]
     total: int
+
+
+# ── GAAP: chart of accounts ───────────────────────────────────────────────
+
+
+_ACCOUNT_TYPE_PATTERN = r"^(asset|liability|equity|revenue|expense)$"
+_NORMAL_BALANCE_PATTERN = r"^(debit|credit)$"
+
+
+class LedgerAccountCreate(BaseModel):
+    """Create a chart-of-accounts account.
+
+    ``normal_balance`` may be omitted - the service derives it from
+    ``account_type`` (assets/expenses debit-normal, the rest credit-normal) and
+    rejects a value that contradicts the type.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    project_id: UUID | None = Field(default=None)
+    account_code: str = Field(..., min_length=1, max_length=100, examples=["1000"])
+    name: str = Field(..., min_length=1, max_length=255, examples=["Cash and Cash Equivalents"])
+    account_type: str = Field(..., pattern=_ACCOUNT_TYPE_PATTERN, examples=["asset"])
+    normal_balance: str | None = Field(default=None, pattern=_NORMAL_BALANCE_PATTERN)
+    parent_id: UUID | None = Field(default=None)
+    statement_section: str | None = Field(default=None, max_length=50)
+    is_cash: bool = Field(default=False)
+    is_active: bool = Field(default=True)
+    currency_code: str = Field(default="", max_length=10)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class LedgerAccountUpdate(BaseModel):
+    """Patch a chart-of-accounts account (code and type are immutable)."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    statement_section: str | None = Field(default=None, max_length=50)
+    is_cash: bool | None = Field(default=None)
+    is_active: bool | None = Field(default=None)
+    currency_code: str | None = Field(default=None, max_length=10)
+    parent_id: UUID | None = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None)
+
+
+class LedgerAccountResponse(BaseModel):
+    """A chart-of-accounts row returned from the API."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    project_id: UUID | None = None
+    account_code: str
+    name: str
+    account_type: str
+    normal_balance: str
+    parent_id: UUID | None = None
+    statement_section: str | None = None
+    is_cash: bool = False
+    is_active: bool = True
+    currency_code: str = ""
+    created_at: datetime
+    updated_at: datetime
+
+
+class LedgerAccountListResponse(BaseModel):
+    """Paginated chart-of-accounts list."""
+
+    items: list[LedgerAccountResponse]
+    total: int
+
+
+# ── GAAP: journal entry (multi-line, balanced) ────────────────────────────
+
+
+class JournalLineInput(BaseModel):
+    """One line of a journal entry: a debit or credit against an account.
+
+    Exactly one of ``debit`` / ``credit`` must be > 0 (the other 0). Both are
+    Decimal-as-string on the wire.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    account_code: str = Field(..., min_length=1, max_length=100)
+    debit: str = Field(default="0", max_length=50)
+    credit: str = Field(default="0", max_length=50)
+    description: str | None = Field(default=None, max_length=2000)
+
+    @field_validator("debit", "credit")
+    @classmethod
+    def _check_non_negative(cls, v: str) -> str:
+        return _validate_non_negative_decimal(v)
+
+
+class JournalEntryCreate(BaseModel):
+    """Post a balanced journal entry of two or more lines.
+
+    The service enforces ``sum(debit) == sum(credit)`` and a single currency
+    before any row is written; an unbalanced or single-line entry is rejected.
+    """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    project_id: UUID
+    transaction_ref: str = Field(..., min_length=1, max_length=100)
+    lines: list[JournalLineInput] = Field(..., min_length=2)
+    description: str | None = Field(default=None, max_length=2000)
+    currency_code: str = Field(default="", max_length=10)
+    posted_at: str = Field(default="", max_length=30)
+    source_type: str | None = Field(default=None, max_length=50)
+    source_id: str | None = Field(default=None, max_length=36)
+
+
+class JournalEntryResponse(BaseModel):
+    """The posted ledger rows that make up a journal entry."""
+
+    transaction_ref: str
+    lines: list[LedgerEntryResponse]
+    total_debits: str
+    total_credits: str
+
+
+# ── GAAP: trial balance + statements ──────────────────────────────────────
+
+
+class TrialBalanceRow(BaseModel):
+    """One account's debit/credit totals and signed balance in a trial balance."""
+
+    account_code: str
+    name: str
+    account_type: str
+    normal_balance: str
+    debit_total: str
+    credit_total: str
+    balance: str
+
+
+class TrialBalanceResponse(BaseModel):
+    """Trial balance with the grand debit == credit tie-out check."""
+
+    currency: str
+    as_of: str | None = None
+    date_from: str | None = None
+    rows: list[TrialBalanceRow]
+    total_debits: str
+    total_credits: str
+    is_balanced: bool
+    out_of_balance: str
+
+
+class StatementLineResponse(BaseModel):
+    """One line on a financial statement (Decimal-as-string amount)."""
+
+    code: str
+    name: str
+    amount: str
+    account_type: str = ""
+    section: str = ""
+
+
+class IncomeStatementResponse(BaseModel):
+    """Income statement (P&L) for a period."""
+
+    currency: str
+    date_from: str | None = None
+    date_to: str | None = None
+    revenue_lines: list[StatementLineResponse]
+    expense_lines: list[StatementLineResponse]
+    total_revenue: str
+    total_expenses: str
+    net_income: str
+
+
+class BalanceSheetResponse(BaseModel):
+    """Balance sheet as of a date with the assets = L + E tie-out check."""
+
+    currency: str
+    as_of: str | None = None
+    asset_lines: list[StatementLineResponse]
+    liability_lines: list[StatementLineResponse]
+    equity_lines: list[StatementLineResponse]
+    total_assets: str
+    total_liabilities: str
+    total_equity: str
+    liabilities_plus_equity: str
+    is_balanced: bool
+    out_of_balance: str
+
+
+class CashFlowResponse(BaseModel):
+    """Direct-method cash flow with the bucket-sum tie-out check."""
+
+    currency: str
+    date_from: str | None = None
+    date_to: str | None = None
+    method: str = "direct"
+    operating: str
+    investing: str
+    financing: str
+    opening_cash: str
+    net_change: str
+    closing_cash: str
+    ties_out: bool

--- a/backend/app/modules/finance/service.py
+++ b/backend/app/modules/finance/service.py
@@ -13,10 +13,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import event_bus
+from app.modules.finance import gaap
 from app.modules.finance.models import (
     EVMSnapshot,
     Invoice,
     InvoiceLineItem,
+    LedgerAccount,
     LedgerEntry,
     Payment,
     ProjectBudget,
@@ -26,6 +28,8 @@ from app.modules.finance.repository import (
     EVMSnapshotRepository,
     InvoiceLineItemRepository,
     InvoiceRepository,
+    LedgerAccountRepository,
+    LedgerRepository,
     PaymentRepository,
 )
 from app.modules.finance.schemas import (
@@ -34,6 +38,9 @@ from app.modules.finance.schemas import (
     EVMSnapshotCreate,
     InvoiceCreate,
     InvoiceUpdate,
+    JournalEntryCreate,
+    LedgerAccountCreate,
+    LedgerAccountUpdate,
     LedgerEntryCreate,
     PaymentCreate,
     RecordClaimPaymentRequest,
@@ -208,6 +215,8 @@ class FinanceService:
         self.payments_repo = PaymentRepository(session)
         self.budgets = BudgetRepository(session)
         self.evm = EVMSnapshotRepository(session)
+        self.accounts = LedgerAccountRepository(session)
+        self.ledger = LedgerRepository(session)
 
     # ── Invoices ─────────────────────────────────────────────────────────────
 
@@ -1854,3 +1863,466 @@ class FinanceService:
 
         logger.info("Ledger reversal created: %s → %s", transaction_ref, reversal_ref)
         return rev_debit, rev_credit
+
+    # ── GAAP: chart of accounts ───────────────────────────────────────────────
+
+    async def seed_default_chart(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        force: bool = False,
+    ) -> list[LedgerAccount]:
+        """Seed the default construction chart of accounts into a scope.
+
+        Idempotent: when the scope already has any account and ``force`` is
+        False, nothing is written and the existing accounts are returned. The
+        parent links are resolved in a second pass so a sub-account points at the
+        ``LedgerAccount`` row of its parent code (not the seed code).
+        """
+        existing, _ = await self.accounts.list(
+            project_id=project_id,
+            include_workspace=False,
+        )
+        if existing and not force:
+            return existing
+
+        existing_codes = {a.account_code for a in existing}
+        chart = gaap.default_chart_of_accounts()
+        created: dict[str, LedgerAccount] = {a.account_code: a for a in existing}
+
+        # Pass 1: insert every missing account (parents first - the chart is
+        # ordered by code so a parent code sorts before its children).
+        for code, acc in chart.items():
+            if code in existing_codes:
+                continue
+            row = LedgerAccount(
+                project_id=project_id,
+                account_code=acc.code,
+                name=acc.name,
+                account_type=acc.account_type.value,
+                normal_balance=acc.normal_balance.value,
+                statement_section=acc.statement_section,
+                is_cash=acc.is_cash,
+                is_active=True,
+                currency_code="",
+                metadata_={},
+            )
+            created[code] = await self.accounts.create(row)
+
+        # Pass 2: wire parent_id from the seed's parent_code.
+        for code, acc in chart.items():
+            if acc.parent_code and code in created and acc.parent_code in created:
+                child = created[code]
+                parent = created[acc.parent_code]
+                if child.parent_id != parent.id:
+                    await self.accounts.update(child.id, parent_id=parent.id)
+                    child.parent_id = parent.id
+
+        logger.info(
+            "Seeded default chart of accounts: scope=%s accounts=%d",
+            project_id or "workspace",
+            len(created),
+        )
+        return list(created.values())
+
+    async def list_accounts(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        include_workspace: bool = True,
+        account_type: str | None = None,
+        active_only: bool = False,
+    ) -> tuple[list[LedgerAccount], int]:
+        """List chart-of-accounts rows for a scope."""
+        return await self.accounts.list(
+            project_id=project_id,
+            include_workspace=include_workspace,
+            account_type=account_type,
+            active_only=active_only,
+        )
+
+    async def create_account(self, data: LedgerAccountCreate) -> LedgerAccount:
+        """Create a chart-of-accounts account.
+
+        The ``normal_balance`` is derived from ``account_type`` when omitted;
+        when supplied it must match the type's GAAP normal balance (e.g. you
+        cannot declare an asset credit-normal).
+        """
+        derived = gaap.normal_balance_for(data.account_type).value
+        if data.normal_balance and data.normal_balance != derived:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"normal_balance '{data.normal_balance}' contradicts the GAAP "
+                    f"normal balance for a {data.account_type} account ('{derived}')."
+                ),
+            )
+
+        # Reject a duplicate code in the same scope with a clean 409.
+        clash = await self.accounts.get_by_code(data.account_code, project_id=data.project_id)
+        if clash is not None and clash.project_id == data.project_id:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Account code '{data.account_code}' already exists in this scope.",
+            )
+
+        account = LedgerAccount(
+            project_id=data.project_id,
+            account_code=data.account_code,
+            name=data.name,
+            account_type=data.account_type,
+            normal_balance=data.normal_balance or derived,
+            parent_id=data.parent_id,
+            statement_section=data.statement_section,
+            is_cash=data.is_cash,
+            is_active=data.is_active,
+            currency_code=data.currency_code,
+            metadata_=data.metadata,
+        )
+        try:
+            account = await self.accounts.create(account)
+        except IntegrityError as exc:
+            await self.session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Account code '{data.account_code}' already exists in this scope.",
+            ) from exc
+        logger.info("Ledger account created: %s (%s)", account.account_code, account.account_type)
+        return account
+
+    async def get_account(self, account_id: uuid.UUID) -> LedgerAccount:
+        """Get a chart-of-accounts account by id. 404 when missing."""
+        account = await self.accounts.get(account_id)
+        if account is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Ledger account not found",
+            )
+        return account
+
+    async def update_account(
+        self,
+        account_id: uuid.UUID,
+        data: LedgerAccountUpdate,
+    ) -> LedgerAccount:
+        """Update mutable fields on a chart-of-accounts account.
+
+        Code and type are immutable (changing them would orphan posted ledger
+        rows and silently flip a statement's sign), so only descriptive fields,
+        the active flag and the cash/section hints can be patched.
+        """
+        await self.get_account(account_id)  # 404 check
+        fields = data.model_dump(exclude_unset=True)
+        if "metadata" in fields:
+            fields["metadata_"] = fields.pop("metadata")
+        if fields:
+            await self.accounts.update(account_id, **fields)
+        updated = await self.accounts.get(account_id)
+        if updated is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Ledger account not found",
+            )
+        return updated
+
+    async def _chart_lookup(self, project_id: uuid.UUID | None) -> dict[str, gaap.AccountDef]:
+        """Build a ``{code: AccountDef}`` lookup for a scope.
+
+        Prefers DB rows (project-scoped override the shared workspace chart by
+        code). Falls back to the in-code default chart for any standard code not
+        yet persisted, so the statements work even before the chart is seeded.
+        """
+        chart: dict[str, gaap.AccountDef] = dict(gaap.default_chart_of_accounts())
+        rows, _ = await self.accounts.list(project_id=project_id, include_workspace=True)
+        # Project-scoped rows win over workspace rows for the same code.
+        rows.sort(key=lambda r: r.project_id is not None)
+        for row in rows:
+            chart[row.account_code] = gaap.AccountDef(
+                code=row.account_code,
+                name=row.name,
+                account_type=gaap.AccountType(row.account_type),
+                parent_code=None,
+                statement_section=row.statement_section,
+                is_cash=bool(row.is_cash),
+            )
+        return chart
+
+    # ── GAAP: journal posting ─────────────────────────────────────────────────
+
+    async def post_journal_entry(
+        self,
+        data: JournalEntryCreate,
+    ) -> tuple[list[LedgerEntry], Decimal, Decimal]:
+        """Post a balanced, multi-line journal entry atomically.
+
+        Invariants enforced before any row is written:
+        * every line is a pure debit OR pure credit (> 0 on exactly one side);
+        * ``sum(debit) == sum(credit)`` (unbalanced is rejected 400);
+        * a single currency for the whole entry (never blended);
+        * every ``account_code`` resolves to a real, active chart account.
+
+        Each line becomes one :class:`LedgerEntry` row sharing the entry's
+        ``transaction_ref``. All rows are written inside one SAVEPOINT so a
+        failure rolls the whole entry back.
+        """
+        currency = data.currency_code or ""
+        chart = await self._chart_lookup(data.project_id)
+
+        total_debits = Decimal("0")
+        total_credits = Decimal("0")
+        prepared: list[tuple[str, Decimal, Decimal, str | None]] = []
+
+        for idx, line in enumerate(data.lines):
+            debit = _safe_decimal(line.debit)
+            credit = _safe_decimal(line.credit)
+            if debit < 0 or credit < 0:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Line {idx}: amounts must be non-negative.",
+                )
+            # Exactly one side may be non-zero.
+            if (debit > 0) == (credit > 0):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Line {idx} for account '{line.account_code}' must be either a "
+                        f"debit OR a credit (exactly one side > 0), got debit={debit} credit={credit}."
+                    ),
+                )
+            # Account must exist in the resolved chart.
+            account = await self.accounts.get_by_code(line.account_code, project_id=data.project_id)
+            if account is None and line.account_code not in chart:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"Line {idx}: account_code '{line.account_code}' is not in the "
+                        f"chart of accounts. Seed the chart or create the account first."
+                    ),
+                )
+            if account is not None and not account.is_active:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Line {idx}: account '{line.account_code}' is inactive and cannot be posted to.",
+                )
+            total_debits += debit
+            total_credits += credit
+            prepared.append((line.account_code, debit, credit, line.description))
+
+        if gaap.q2(total_debits) != gaap.q2(total_credits):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Unbalanced journal entry: sum(debit)={gaap.q2(total_debits)} "
+                    f"!= sum(credit)={gaap.q2(total_credits)}. Rejected."
+                ),
+            )
+        if total_debits <= 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Journal entry has zero total value; nothing to post.",
+            )
+
+        posted_at = data.posted_at or _utcnow_iso()
+        rows: list[LedgerEntry] = []
+        async with self.session.begin_nested():
+            for account_code, debit, credit, line_desc in prepared:
+                row = LedgerEntry(
+                    project_id=data.project_id,
+                    transaction_ref=data.transaction_ref,
+                    account_code=account_code,
+                    description=line_desc or data.description,
+                    debit_amount=debit,
+                    credit_amount=credit,
+                    currency_code=currency,
+                    posted_at=posted_at,
+                    source_type=data.source_type,
+                    source_id=data.source_id,
+                    is_reversal=False,
+                )
+                self.session.add(row)
+                rows.append(row)
+            await self.session.flush()
+
+        logger.info(
+            "Journal entry posted: ref=%s lines=%d dr=%s cr=%s",
+            data.transaction_ref,
+            len(rows),
+            gaap.q2(total_debits),
+            gaap.q2(total_credits),
+        )
+        return rows, gaap.q2(total_debits), gaap.q2(total_credits)
+
+    # ── GAAP: statement derivations ───────────────────────────────────────────
+
+    async def _ledger_lines(
+        self,
+        *,
+        project_id: uuid.UUID | None,
+        currency_code: str | None,
+        date_from: str | None,
+        date_to: str | None,
+    ) -> tuple[list[gaap.LedgerLine], list[LedgerEntry]]:
+        """Load posted ledger entries and map them to pure ``gaap.LedgerLine``.
+
+        Returns the lines and the raw entries (the cash-flow derivation needs the
+        raw rows to pair cash legs with their counter-accounts).
+        """
+        entries = await self.ledger.list_entries(
+            project_id=project_id,
+            currency_code=currency_code,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        lines = [
+            gaap.LedgerLine(
+                account_code=e.account_code,
+                debit=_safe_decimal(e.debit_amount),
+                credit=_safe_decimal(e.credit_amount),
+                currency_code=e.currency_code or "",
+                posted_at=e.posted_at or "",
+            )
+            for e in entries
+        ]
+        return lines, entries
+
+    async def trial_balance(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        currency_code: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> gaap.TrialBalance:
+        """Compute the trial balance for a scope and period."""
+        lines, _ = await self._ledger_lines(
+            project_id=project_id,
+            currency_code=currency_code,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        chart = await self._chart_lookup(project_id)
+        return gaap.trial_balance(lines, chart)
+
+    async def income_statement(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        currency_code: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> gaap.IncomeStatement:
+        """Derive the income statement (P&L) for a period."""
+        lines, _ = await self._ledger_lines(
+            project_id=project_id,
+            currency_code=currency_code,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        chart = await self._chart_lookup(project_id)
+        tb = gaap.trial_balance(lines, chart)
+        return gaap.income_statement(tb, chart)
+
+    async def balance_sheet(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        currency_code: str | None = None,
+        as_of: str | None = None,
+    ) -> gaap.BalanceSheet:
+        """Derive the balance sheet as of a date (cumulative through ``as_of``)."""
+        lines, _ = await self._ledger_lines(
+            project_id=project_id,
+            currency_code=currency_code,
+            date_from=None,
+            date_to=as_of,
+        )
+        chart = await self._chart_lookup(project_id)
+        tb = gaap.trial_balance(lines, chart)
+        return gaap.balance_sheet(tb, chart)
+
+    async def cash_flow(
+        self,
+        *,
+        project_id: uuid.UUID | None = None,
+        currency_code: str | None = None,
+        date_from: str | None = None,
+        date_to: str | None = None,
+    ) -> gaap.CashFlowStatement:
+        """Derive the direct-method cash flow statement for a period.
+
+        The opening cash balance is the net movement on the cash accounts BEFORE
+        ``date_from`` (so the closing cash ties to the cumulative ledger). Within
+        the period, each cash leg of a transaction is paired with the non-cash
+        legs of the same ``transaction_ref`` to classify the movement into
+        operating / investing / financing.
+        """
+        chart = await self._chart_lookup(project_id)
+        cash_codes = {code for code, acc in chart.items() if acc.is_cash}
+
+        # Opening cash: net cash movement strictly before the period start.
+        opening_cash = Decimal("0")
+        if date_from:
+            prior, _ = await self._ledger_lines(
+                project_id=project_id,
+                currency_code=currency_code,
+                date_from=None,
+                date_to=None,
+            )
+            for ln in prior:
+                if ln.account_code in cash_codes and ln.posted_at and ln.posted_at < date_from:
+                    opening_cash += ln.debit - ln.credit
+
+        _, entries = await self._ledger_lines(
+            project_id=project_id,
+            currency_code=currency_code,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+        # Group entries by transaction_ref so a cash leg can find its counter
+        # legs (the non-cash accounts of the same transaction).
+        by_ref: dict[str, list[LedgerEntry]] = {}
+        for e in entries:
+            by_ref.setdefault(e.transaction_ref, []).append(e)
+
+        currency = currency_code or ""
+        movements: list[gaap.CashMovement] = []
+        for ref_entries in by_ref.values():
+            cash_legs = [e for e in ref_entries if e.account_code in cash_codes]
+            non_cash = [e for e in ref_entries if e.account_code not in cash_codes]
+            if not cash_legs:
+                continue
+            # Dominant counter-account: the non-cash leg with the largest
+            # magnitude classifies the whole cash movement (a single-counter
+            # transaction, the common case, classifies exactly).
+            counter_type: gaap.AccountType | None = None
+            counter_section: str | None = None
+            if non_cash:
+                dominant = max(
+                    non_cash,
+                    key=lambda e: abs(_safe_decimal(e.debit_amount) - _safe_decimal(e.credit_amount)),
+                )
+                acc = chart.get(dominant.account_code)
+                if acc is not None:
+                    counter_type = acc.account_type
+                    counter_section = acc.statement_section
+            for leg in cash_legs:
+                # Cash in = debit to a cash account; cash out = credit.
+                amount = _safe_decimal(leg.debit_amount) - _safe_decimal(leg.credit_amount)
+                if amount == 0:
+                    continue
+                if currency_code is None and not currency:
+                    currency = leg.currency_code or ""
+                movements.append(
+                    gaap.CashMovement(
+                        amount=amount,
+                        counter_type=counter_type,
+                        counter_section=counter_section,
+                    )
+                )
+
+        return gaap.cash_flow_direct(
+            movements,
+            currency=currency,
+            opening_cash=opening_cash,
+        )

--- a/backend/tests/unit/test_finance_gaap.py
+++ b/backend/tests/unit/test_finance_gaap.py
@@ -1,0 +1,340 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+# Copyright (c) 2026 Artem Boiko / DataDrivenConstruction
+"""Pure-logic unit tests for the GAAP general ledger (task #77).
+
+These tests touch no database and no event loop. They pin the exact Decimal
+arithmetic and sign conventions of the GAAP layer:
+
+* a balanced journal posts; an unbalanced one is rejected;
+* currency blending is rejected;
+* the trial balance ties out (total debits == total credits);
+* the income statement = revenue - expenses on seeded entries;
+* the balance sheet ties out (assets == liabilities + equity);
+* a reversal produces the inverse, netting the ledger to zero.
+
+Money is asserted as exact ``Decimal`` (never float) - a silent drift here would
+mis-state every financial statement.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.modules.finance import gaap
+from app.modules.finance.gaap import (
+    AccountType,
+    CashMovement,
+    LedgerLine,
+    NormalBalance,
+    balance_sheet,
+    cash_flow_direct,
+    default_chart_of_accounts,
+    income_statement,
+    normal_balance_for,
+    signed_balance,
+    trial_balance,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _dr(code: str, amount: str, ccy: str = "USD", posted_at: str = "2026-01-15") -> LedgerLine:
+    return LedgerLine(account_code=code, debit=Decimal(amount), currency_code=ccy, posted_at=posted_at)
+
+
+def _cr(code: str, amount: str, ccy: str = "USD", posted_at: str = "2026-01-15") -> LedgerLine:
+    return LedgerLine(account_code=code, credit=Decimal(amount), currency_code=ccy, posted_at=posted_at)
+
+
+def _is_balanced_journal(lines: list[LedgerLine]) -> bool:
+    """A journal posts iff sum(debit) == sum(credit) and value > 0.
+
+    This mirrors the invariant ``FinanceService.post_journal_entry`` enforces
+    before writing any row, expressed against the same pure ``LedgerLine``.
+    """
+    total_dr = sum((ln.debit for ln in lines), Decimal("0"))
+    total_cr = sum((ln.credit for ln in lines), Decimal("0"))
+    return total_dr == total_cr and total_dr > 0
+
+
+CHART = default_chart_of_accounts()
+
+
+# ── Normal-balance / sign conventions ────────────────────────────────────────
+
+
+def test_normal_balance_by_type() -> None:
+    assert normal_balance_for(AccountType.ASSET) is NormalBalance.DEBIT
+    assert normal_balance_for(AccountType.EXPENSE) is NormalBalance.DEBIT
+    assert normal_balance_for(AccountType.LIABILITY) is NormalBalance.CREDIT
+    assert normal_balance_for(AccountType.EQUITY) is NormalBalance.CREDIT
+    assert normal_balance_for(AccountType.REVENUE) is NormalBalance.CREDIT
+    # str form accepted too
+    assert normal_balance_for("asset") is NormalBalance.DEBIT
+
+
+def test_signed_balance_debit_normal_asset() -> None:
+    # An asset with more debits than credits is positive (a real asset).
+    assert signed_balance(Decimal("1000"), Decimal("300"), NormalBalance.DEBIT) == Decimal("700")
+
+
+def test_signed_balance_credit_normal_liability() -> None:
+    # A liability with more credits than debits is positive (a real claim).
+    assert signed_balance(Decimal("300"), Decimal("1000"), NormalBalance.CREDIT) == Decimal("700")
+
+
+def test_default_chart_has_expected_roots() -> None:
+    # The seed must carry the construction-specific accounts the task names.
+    assert "1000" in CHART and CHART["1000"].is_cash  # cash
+    assert CHART["1100"].account_type is AccountType.ASSET  # AR
+    assert CHART["1110"].name.lower().startswith("retention")  # retention receivable
+    assert CHART["1200"].account_type is AccountType.ASSET  # under-billings (CIE)
+    assert CHART["1300"].account_type is AccountType.ASSET  # WIP / contract costs
+    assert CHART["2000"].account_type is AccountType.LIABILITY  # AP
+    assert CHART["2200"].account_type is AccountType.LIABILITY  # over-billings (BIE)
+    assert CHART["3000"].account_type is AccountType.EQUITY  # equity
+    assert CHART["4000"].account_type is AccountType.REVENUE  # contract revenue
+    assert CHART["5000"].account_type is AccountType.EXPENSE  # COGS
+
+
+def test_default_chart_normal_balances_consistent() -> None:
+    # Every seed account's normal balance must agree with its type.
+    for acc in CHART.values():
+        assert acc.normal_balance is normal_balance_for(acc.account_type)
+
+
+# ── Journal posting: balanced vs unbalanced ──────────────────────────────────
+
+
+def test_balanced_journal_posts() -> None:
+    # Owner injects 50,000 cash as equity: Dr Cash / Cr Equity.
+    lines = [_dr("1000", "50000"), _cr("3000", "50000")]
+    assert _is_balanced_journal(lines) is True
+
+
+def test_unbalanced_journal_rejected() -> None:
+    # Debits 50,000 but credits only 40,000 - must be rejected.
+    lines = [_dr("1000", "50000"), _cr("3000", "40000")]
+    assert _is_balanced_journal(lines) is False
+
+
+def test_zero_value_journal_rejected() -> None:
+    lines = [_dr("1000", "0"), _cr("3000", "0")]
+    assert _is_balanced_journal(lines) is False
+
+
+def test_multi_line_balanced_journal_posts() -> None:
+    # A 3-line entry: bill a client 100,000 (gross) splitting revenue + tax.
+    # Dr AR 110,000 / Cr Revenue 100,000 / Cr Taxes Payable 10,000.
+    lines = [_dr("1100", "110000"), _cr("4000", "100000"), _cr("2300", "10000")]
+    assert _is_balanced_journal(lines) is True
+
+
+# ── Currency blending is rejected ────────────────────────────────────────────
+
+
+def test_trial_balance_rejects_blended_currency() -> None:
+    lines = [_dr("1000", "100", ccy="USD"), _cr("4000", "100", ccy="EUR")]
+    with pytest.raises(ValueError, match="blended currencies"):
+        trial_balance(lines, CHART)
+
+
+def test_trial_balance_blank_currency_is_base_not_a_conflict() -> None:
+    # A blank code is "base" and must not conflict with a stamped one.
+    lines = [_dr("1000", "100", ccy=""), _cr("4000", "100", ccy="USD")]
+    tb = trial_balance(lines, CHART)
+    assert tb.currency == "USD"
+    assert tb.is_balanced
+
+
+# ── Unknown account is caught ────────────────────────────────────────────────
+
+
+def test_trial_balance_unknown_account_raises() -> None:
+    lines = [_dr("9999", "100"), _cr("4000", "100")]
+    with pytest.raises(KeyError, match="9999"):
+        trial_balance(lines, CHART)
+
+
+# ── Trial balance ties out ───────────────────────────────────────────────────
+
+
+def _seed_ledger() -> list[LedgerLine]:
+    """A small but realistic set of balanced transactions in USD.
+
+    1. Owner funds the company:        Dr Cash 100,000 / Cr Equity 100,000
+    2. Bill a client for work:         Dr AR  60,000  / Cr Revenue 60,000
+    3. Incur subcontractor cost:       Dr COGS 25,000 / Cr AP 25,000
+    4. Pay overhead salaries in cash:  Dr G&A 8,000   / Cr Cash 8,000
+    5. Client pays part of the invoice:Dr Cash 40,000 / Cr AR 40,000
+    """
+    return [
+        # 1
+        _dr("1000", "100000", posted_at="2026-01-01"),
+        _cr("3000", "100000", posted_at="2026-01-01"),
+        # 2
+        _dr("1100", "60000", posted_at="2026-01-10"),
+        _cr("4000", "60000", posted_at="2026-01-10"),
+        # 3
+        _dr("5030", "25000", posted_at="2026-01-12"),
+        _cr("2000", "25000", posted_at="2026-01-12"),
+        # 4
+        _dr("5110", "8000", posted_at="2026-01-20"),
+        _cr("1000", "8000", posted_at="2026-01-20"),
+        # 5
+        _dr("1000", "40000", posted_at="2026-01-25"),
+        _cr("1100", "40000", posted_at="2026-01-25"),
+    ]
+
+
+def test_trial_balance_ties_out() -> None:
+    tb = trial_balance(_seed_ledger(), CHART)
+    assert tb.total_debits == Decimal("233000.00")
+    assert tb.total_credits == Decimal("233000.00")
+    assert tb.is_balanced is True
+    assert tb.out_of_balance == Decimal("0.00")
+
+
+def test_trial_balance_account_balances_correct() -> None:
+    tb = trial_balance(_seed_ledger(), CHART)
+    by_code = {ab.code: ab for ab in tb.accounts}
+    # Cash: 100,000 + 40,000 in, 8,000 out = 132,000 debit-normal.
+    assert by_code["1000"].signed_balance == Decimal("132000.00")
+    # AR: 60,000 billed - 40,000 collected = 20,000 debit-normal.
+    assert by_code["1100"].signed_balance == Decimal("20000.00")
+    # AP: 25,000 credit-normal (positive liability).
+    assert by_code["2000"].signed_balance == Decimal("25000.00")
+    # Equity: 100,000 credit-normal.
+    assert by_code["3000"].signed_balance == Decimal("100000.00")
+    # Revenue: 60,000 credit-normal.
+    assert by_code["4000"].signed_balance == Decimal("60000.00")
+
+
+# ── Income statement = revenue - expenses ────────────────────────────────────
+
+
+def test_income_statement_revenue_minus_expenses() -> None:
+    tb = trial_balance(_seed_ledger(), CHART)
+    inc = income_statement(tb, CHART)
+    # Revenue 60,000; expenses 25,000 (COGS) + 8,000 (G&A) = 33,000.
+    assert inc.total_revenue == Decimal("60000.00")
+    assert inc.total_expenses == Decimal("33000.00")
+    assert inc.net_income == Decimal("27000.00")
+    # Net income is literally revenue minus expenses.
+    assert inc.net_income == inc.total_revenue - inc.total_expenses
+
+
+def test_income_statement_loss_is_negative() -> None:
+    # Expenses exceed revenue -> a loss (negative net income).
+    lines = [
+        _dr("1100", "10000"),
+        _cr("4000", "10000"),
+        _dr("5000", "15000"),
+        _cr("2000", "15000"),
+    ]
+    tb = trial_balance(lines, CHART)
+    inc = income_statement(tb, CHART)
+    assert inc.net_income == Decimal("-5000.00")
+
+
+# ── Balance sheet ties out (assets == liabilities + equity) ──────────────────
+
+
+def test_balance_sheet_ties_out() -> None:
+    tb = trial_balance(_seed_ledger(), CHART)
+    bs = balance_sheet(tb, CHART)
+    # Assets: Cash 132,000 + AR 20,000 = 152,000.
+    assert bs.total_assets == Decimal("152000.00")
+    # Liabilities: AP 25,000.
+    assert bs.total_liabilities == Decimal("25000.00")
+    # Equity: 100,000 paid-in + 27,000 retained (period net income) = 127,000.
+    assert bs.total_equity == Decimal("127000.00")
+    assert bs.liabilities_plus_equity == Decimal("152000.00")
+    assert bs.is_balanced is True
+    assert bs.out_of_balance == Decimal("0.00")
+
+
+def test_balance_sheet_without_fold_is_out_of_balance_by_net_income() -> None:
+    # Before a year-end close (net income not folded into equity) a live ledger
+    # is out of balance by exactly net income - documenting the design choice.
+    tb = trial_balance(_seed_ledger(), CHART)
+    bs_raw = balance_sheet(tb, CHART, fold_net_income_into_equity=False)
+    assert bs_raw.is_balanced is False
+    # Assets 152,000 vs (L+E) 125,000 -> off by the 27,000 net income.
+    assert bs_raw.out_of_balance == Decimal("27000.00")
+
+
+# ── Reversal produces the inverse ────────────────────────────────────────────
+
+
+def test_reversal_nets_ledger_to_zero() -> None:
+    # Original: Dr AR 60,000 / Cr Revenue 60,000.
+    original = [_dr("1100", "60000"), _cr("4000", "60000")]
+    # Reversal swaps the sides: Dr Revenue 60,000 / Cr AR 60,000.
+    reversal = [_cr("1100", "60000"), _dr("4000", "60000")]
+    tb = trial_balance(original + reversal, CHART)
+    by_code = {ab.code: ab for ab in tb.accounts}
+    # Both accounts net to zero after the reversal.
+    assert by_code["1100"].signed_balance == Decimal("0.00")
+    assert by_code["4000"].signed_balance == Decimal("0.00")
+    # And the whole trial balance is still balanced and empty of value.
+    assert tb.is_balanced
+    assert tb.total_debits == Decimal("120000.00")
+    assert tb.total_credits == Decimal("120000.00")
+
+
+def test_reversal_inverts_income_statement() -> None:
+    original = [_dr("1100", "60000"), _cr("4000", "60000")]
+    reversal = [_cr("1100", "60000"), _dr("4000", "60000")]
+    inc = income_statement(trial_balance(original + reversal, CHART), CHART)
+    assert inc.total_revenue == Decimal("0.00")
+    assert inc.net_income == Decimal("0.00")
+
+
+# ── Cash flow (direct method) ────────────────────────────────────────────────
+
+
+def test_cash_flow_direct_buckets_and_ties_out() -> None:
+    # Operating: client pays 40,000 (counter = revenue/AR), pay salaries -8,000.
+    # Financing: owner funds 100,000 (counter = equity).
+    movements = [
+        CashMovement(amount=Decimal("100000"), counter_type=AccountType.EQUITY, counter_section="financing"),
+        CashMovement(amount=Decimal("40000"), counter_type=AccountType.ASSET, counter_section="current_asset"),
+        CashMovement(amount=Decimal("-8000"), counter_type=AccountType.EXPENSE, counter_section="operating_expense"),
+    ]
+    cf = cash_flow_direct(movements, currency="USD", opening_cash=Decimal("0"))
+    assert cf.financing == Decimal("100000.00")
+    assert cf.operating == Decimal("32000.00")  # 40,000 - 8,000
+    assert cf.investing == Decimal("0.00")
+    assert cf.net_change == Decimal("132000.00")
+    assert cf.closing_cash == Decimal("132000.00")
+    assert cf.ties_out is True
+
+
+def test_cash_flow_investing_bucket() -> None:
+    # Buy equipment for cash: -20,000 against a non-current asset (capex).
+    movements = [
+        CashMovement(amount=Decimal("-20000"), counter_type=AccountType.ASSET, counter_section="investing"),
+    ]
+    cf = cash_flow_direct(movements, currency="USD", opening_cash=Decimal("50000"))
+    assert cf.investing == Decimal("-20000.00")
+    assert cf.operating == Decimal("0.00")
+    assert cf.net_change == Decimal("-20000.00")
+    assert cf.closing_cash == Decimal("30000.00")
+    assert cf.ties_out is True
+
+
+def test_cash_flow_opening_plus_net_equals_closing() -> None:
+    movements = [CashMovement(amount=Decimal("5000"), counter_type=AccountType.REVENUE)]
+    cf = cash_flow_direct(movements, currency="USD", opening_cash=Decimal("1000"))
+    assert cf.closing_cash == cf.opening_cash + cf.net_change
+
+
+# ── q2 rounding (accounting half-up) ─────────────────────────────────────────
+
+
+def test_q2_rounds_half_up() -> None:
+    assert gaap.q2(Decimal("1666.665")) == Decimal("1666.67")
+    assert gaap.q2(Decimal("1666.664")) == Decimal("1666.66")

--- a/backend/tests/unit/test_finance_gaap_service.py
+++ b/backend/tests/unit/test_finance_gaap_service.py
@@ -1,0 +1,256 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+# Copyright (c) 2026 Artem Boiko / DataDrivenConstruction
+"""Service-layer unit tests for the GAAP general ledger (task #77).
+
+These exercise :class:`FinanceService`'s GAAP methods with in-memory stub
+repositories (no database, no event loop fixtures beyond ``pytest.mark.asyncio``)
+so the ORM-to-pure-function wiring is verified: account resolution, the balanced
+/ single-currency journal invariants raised as HTTP 400, and the statement
+derivations computed over loaded ledger rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.finance import gaap
+from app.modules.finance.schemas import JournalEntryCreate, JournalLineInput
+from app.modules.finance.service import FinanceService
+
+PROJECT_ID = uuid.uuid4()
+
+
+# ── Stub repositories ─────────────────────────────────────────────────────────
+
+
+class _StubSession:
+    """No-op AsyncSession: ``begin_nested`` is the only thing post_journal needs."""
+
+    def begin_nested(self) -> _NestedCtx:
+        return _NestedCtx()
+
+    def add(self, _obj: Any) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def flush(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _NestedCtx:
+    async def __aenter__(self) -> _NestedCtx:
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> bool:
+        return False
+
+
+class _StubAccountRepo:
+    """Serves the default chart as if it were persisted, scoped to PROJECT_ID."""
+
+    def __init__(self) -> None:
+        self._chart = gaap.default_chart_of_accounts()
+
+    async def get_by_code(self, code: str, *, project_id: uuid.UUID | None = None) -> Any:
+        acc = self._chart.get(code)
+        if acc is None:
+            return None
+        return SimpleNamespace(
+            account_code=acc.code,
+            name=acc.name,
+            account_type=acc.account_type.value,
+            statement_section=acc.statement_section,
+            is_cash=acc.is_cash,
+            is_active=True,
+            project_id=project_id,
+        )
+
+    async def list(self, *, project_id: uuid.UUID | None = None, **_kw: Any) -> tuple[list[Any], int]:
+        rows = [
+            SimpleNamespace(
+                account_code=a.code,
+                name=a.name,
+                account_type=a.account_type.value,
+                statement_section=a.statement_section,
+                is_cash=a.is_cash,
+                project_id=None,
+            )
+            for a in self._chart.values()
+        ]
+        return rows, len(rows)
+
+
+class _StubLedgerRepo:
+    """Captures posted rows and replays them for the statement queries."""
+
+    def __init__(self) -> None:
+        self.rows: list[Any] = []
+
+    async def list_entries(self, **_kw: Any) -> list[Any]:
+        return list(self.rows)
+
+
+def _make_service() -> FinanceService:
+    svc = FinanceService.__new__(FinanceService)
+    svc.session = _StubSession()
+    svc.accounts = _StubAccountRepo()
+    svc.ledger = _StubLedgerRepo()
+    return svc
+
+
+def _line(code: str, debit: str = "0", credit: str = "0") -> JournalLineInput:
+    return JournalLineInput(account_code=code, debit=debit, credit=credit)
+
+
+def _capture_posted_rows(svc: FinanceService, rows: list[Any]) -> None:
+    """Mirror posted ORM rows into the stub ledger so statements can read them."""
+    svc.ledger.rows.extend(
+        SimpleNamespace(
+            account_code=r.account_code,
+            debit_amount=r.debit_amount,
+            credit_amount=r.credit_amount,
+            currency_code=r.currency_code,
+            posted_at=r.posted_at,
+            transaction_ref=r.transaction_ref,
+        )
+        for r in rows
+    )
+
+
+# ── Journal posting: balanced vs unbalanced ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_post_balanced_journal_succeeds() -> None:
+    svc = _make_service()
+    data = JournalEntryCreate(
+        project_id=PROJECT_ID,
+        transaction_ref="JE-1",
+        currency_code="USD",
+        posted_at="2026-01-01",
+        lines=[_line("1000", debit="50000"), _line("3000", credit="50000")],
+    )
+    rows, total_dr, total_cr = await svc.post_journal_entry(data)
+    assert len(rows) == 2
+    assert total_dr == Decimal("50000.00")
+    assert total_cr == Decimal("50000.00")
+    assert rows[0].account_code == "1000"
+    assert rows[0].debit_amount == Decimal("50000")
+
+
+@pytest.mark.asyncio
+async def test_post_unbalanced_journal_rejected() -> None:
+    svc = _make_service()
+    data = JournalEntryCreate(
+        project_id=PROJECT_ID,
+        transaction_ref="JE-2",
+        currency_code="USD",
+        lines=[_line("1000", debit="50000"), _line("3000", credit="40000")],
+    )
+    with pytest.raises(HTTPException) as exc:
+        await svc.post_journal_entry(data)
+    assert exc.value.status_code == 400
+    assert "Unbalanced" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_post_journal_line_with_both_sides_rejected() -> None:
+    svc = _make_service()
+    data = JournalEntryCreate(
+        project_id=PROJECT_ID,
+        transaction_ref="JE-3",
+        currency_code="USD",
+        lines=[_line("1000", debit="100", credit="100"), _line("3000", credit="100")],
+    )
+    with pytest.raises(HTTPException) as exc:
+        await svc.post_journal_entry(data)
+    assert exc.value.status_code == 400
+    assert "exactly one side" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_post_journal_unknown_account_rejected() -> None:
+    svc = _make_service()
+    data = JournalEntryCreate(
+        project_id=PROJECT_ID,
+        transaction_ref="JE-4",
+        currency_code="USD",
+        lines=[_line("9999", debit="100"), _line("3000", credit="100")],
+    )
+    with pytest.raises(HTTPException) as exc:
+        await svc.post_journal_entry(data)
+    assert exc.value.status_code == 400
+    assert "not in the" in exc.value.detail
+
+
+# ── End-to-end: post then derive statements ──────────────────────────────────
+
+
+async def _seed_via_service(svc: FinanceService) -> None:
+    """Post the same balanced transactions the pure test uses, through the service."""
+    entries = [
+        ("JE-A", [_line("1000", debit="100000"), _line("3000", credit="100000")]),
+        ("JE-B", [_line("1100", debit="60000"), _line("4000", credit="60000")]),
+        ("JE-C", [_line("5030", debit="25000"), _line("2000", credit="25000")]),
+        ("JE-D", [_line("5110", debit="8000"), _line("1000", credit="8000")]),
+        ("JE-E", [_line("1000", debit="40000"), _line("1100", credit="40000")]),
+    ]
+    for ref, lines in entries:
+        data = JournalEntryCreate(
+            project_id=PROJECT_ID,
+            transaction_ref=ref,
+            currency_code="USD",
+            posted_at="2026-01-15",
+            lines=lines,
+        )
+        rows, _, _ = await svc.post_journal_entry(data)
+        _capture_posted_rows(svc, rows)
+
+
+@pytest.mark.asyncio
+async def test_trial_balance_ties_out_through_service() -> None:
+    svc = _make_service()
+    await _seed_via_service(svc)
+    tb = await svc.trial_balance(project_id=PROJECT_ID, currency_code="USD")
+    assert tb.total_debits == Decimal("233000.00")
+    assert tb.total_credits == Decimal("233000.00")
+    assert tb.is_balanced is True
+
+
+@pytest.mark.asyncio
+async def test_income_statement_through_service() -> None:
+    svc = _make_service()
+    await _seed_via_service(svc)
+    inc = await svc.income_statement(project_id=PROJECT_ID, currency_code="USD")
+    assert inc.total_revenue == Decimal("60000.00")
+    assert inc.total_expenses == Decimal("33000.00")
+    assert inc.net_income == Decimal("27000.00")
+
+
+@pytest.mark.asyncio
+async def test_balance_sheet_ties_out_through_service() -> None:
+    svc = _make_service()
+    await _seed_via_service(svc)
+    bs = await svc.balance_sheet(project_id=PROJECT_ID, currency_code="USD")
+    assert bs.total_assets == Decimal("152000.00")
+    assert bs.total_liabilities == Decimal("25000.00")
+    assert bs.total_equity == Decimal("127000.00")
+    assert bs.is_balanced is True
+
+
+@pytest.mark.asyncio
+async def test_cash_flow_through_service() -> None:
+    svc = _make_service()
+    await _seed_via_service(svc)
+    cf = await svc.cash_flow(project_id=PROJECT_ID, currency_code="USD")
+    # Cash moved: +100,000 (equity, financing), -8,000 (expense, operating),
+    # +40,000 (AR collection, operating). Net = 132,000.
+    assert cf.financing == Decimal("100000.00")
+    assert cf.operating == Decimal("32000.00")
+    assert cf.net_change == Decimal("132000.00")
+    assert cf.ties_out is True


### PR DESCRIPTION
Closes part of #77. Adds a GAAP general ledger and financial statements on top of the existing append-only LedgerEntry, as an extension of the finance module rather than a competing one.

What it adds. A LedgerAccount chart of accounts with a default construction taxonomy (cash, AR, retention receivable, costs in excess, WIP, AP, retention payable, billings in excess, equity, contract revenue, COGS with labor, materials, subs and equipment subaccounts, G and A). A balanced multi-line journal poster that validates the accounts exist and are active, enforces a single currency per entry, and rejects anything where debits and credits do not tie. Side-effect-free builders for the trial balance, income statement, balance sheet and a direct-method cash flow. New endpoints under /api/v1/finance/gaap for the chart, journal entries and the three statements, behind read and post permissions.

Money discipline. Every amount stays Decimal and goes out as a decimal string, one currency per entry, currencies never blended, consistent with the rest of the platform.

Honest accounting notes. The balance sheet ties out by folding the period net income into a retained-earnings line, since a live pre-close ledger is otherwise off by exactly net income. A dedicated test documents both the folded and the unfolded paths. The cash flow is the direct method from cash-account movements, classified by the dominant counter account; full indirect is left for later. Statements are single currency for now; the FX helpers to consolidate later already exist in the module.

What is left for follow-up. Auto-posting journals from invoices and payments, and a period-close journal that zeroes the P and L into retained earnings.

Verification on 3.14. The 32 GAAP tests pass (24 pure logic, 8 service), the wider finance suite stays green, ruff check and format are clean on all ten files, the new account model is registered in the metadata so embedded Postgres materializes it, and the migration graph is a single head (v3179 chains cleanly off v3178).