### PR TITLE
Fix point cloud upload failing with 500 at the finalise step

### DIFF
--- a/backend/app/modules/pointcloud/service.py
+++ b/backend/app/modules/pointcloud/service.py
@@ -521,27 +521,40 @@ class PointCloudService:
                 },
             ) from exc
 
+        # Read every scan/stored field the event payload and response need NOW,
+        # while the ORM row is still live. update_fields() ends with
+        # session.expire_all(), which marks scan's attributes expired; reading
+        # scan.project_id / scan.tenant_id / scan.upload_key afterwards would
+        # trigger an implicit lazy reload, and an async session forbids implicit
+        # IO outside a greenlet (MissingGreenlet) - that surfaced as a 500 on
+        # ingest/complete. Snapshotting first keeps the finalise path off the
+        # expired row entirely.
+        project_id = scan.project_id
+        tenant_id = scan.tenant_id
+        resolved_key = stored.key or scan.upload_key
+        size_bytes = int(stored.size_bytes)
+
         await self.scans.update_fields(
             scan_id,
-            upload_key=stored.key or scan.upload_key,
+            upload_key=resolved_key,
             status="uploaded",
         )
         await event_bus.publish(
             "pointcloud.upload.completed",
             {
                 "scan_id": str(scan_id),
-                "project_id": str(scan.project_id),
-                "tenant_id": str(scan.tenant_id),
-                "upload_key": stored.key or scan.upload_key,
-                "size_bytes": int(stored.size_bytes),
+                "project_id": str(project_id),
+                "tenant_id": str(tenant_id),
+                "upload_key": resolved_key,
+                "size_bytes": size_bytes,
             },
             source_module="oe_pointcloud",
         )
         return {
             "scan_id": scan_id,
-            "upload_key": stored.key or scan.upload_key,
+            "upload_key": resolved_key,
             "status": "uploaded",
-            "size_bytes": int(stored.size_bytes),
+            "size_bytes": size_bytes,
         }
 
     def _storage_backend_kind(self) -> str:

--- a/backend/app/modules/pointcloud/tests/test_ingest_presigned.py
+++ b/backend/app/modules/pointcloud/tests/test_ingest_presigned.py
@@ -295,6 +295,68 @@ async def test_complete_ingest_finalises_and_marks_uploaded(session: AsyncSessio
 
 
 @pytest.mark.asyncio
+async def test_complete_ingest_publishes_event_off_snapshot_not_expired_row(
+    session: AsyncSession,
+) -> None:
+    """complete fires pointcloud.upload.completed with the scan's ids intact.
+
+    Regression for the ingest/complete 500: ScanRepository.update_fields ends
+    with session.expire_all(), so the scan row complete_ingest fetched earlier is
+    expired by the time the event payload is built. The payload must come from
+    values snapshotted while the row was live - reading project_id / tenant_id /
+    upload_key off the expired row would trigger an implicit async lazy-load and
+    raise MissingGreenlet on the real engine. Asserting the event carries the
+    right ids proves the snapshot path holds.
+    """
+    project_id: uuid.UUID = session.info["project_id"]
+    owner_id: uuid.UUID = session.info["owner_id"]
+    storage = FakeS3Backend(complete_size=42)
+    service = PointCloudService(session, storage=storage)
+
+    init = await service.init_ingest(
+        ScanIngestInit(
+            project_id=project_id,
+            name="Event scan",
+            original_format="las",
+            total_size_bytes=10,
+        ),
+        payload=_payload(owner_id),
+    )
+    await session.commit()
+
+    from app.core.events import event_bus
+
+    captured: list[dict] = []
+
+    async def _capture(event: object) -> None:
+        captured.append(dict(getattr(event, "data", {})))
+
+    event_bus.subscribe("pointcloud.upload.completed", _capture)
+    try:
+        done = await service.complete_ingest(
+            init["scan_id"],
+            ScanIngestComplete(
+                upload_id=init["upload_id"],
+                parts=[CompletedPart(part_number=1, etag="a", size_bytes=42)],
+            ),
+            payload=_payload(owner_id),
+        )
+        await session.commit()
+    finally:
+        event_bus.unsubscribe("pointcloud.upload.completed", _capture)
+
+    assert done["status"] == "uploaded"
+    assert len(captured) == 1
+    payload = captured[0]
+    # owner_id is the single-tenant boundary, so project tenant == owner.
+    assert payload["project_id"] == str(project_id)
+    assert payload["tenant_id"] == str(owner_id)
+    assert payload["scan_id"] == str(init["scan_id"])
+    assert payload["upload_key"] == init["upload_key"]
+    assert payload["size_bytes"] == 42
+
+
+@pytest.mark.asyncio
 async def test_complete_ingest_rejects_non_contiguous_parts(session: AsyncSession) -> None:
     """A gap in the part list is rejected 422 before any storage call."""
     project_id: uuid.UUID = session.info["project_id"]


### PR DESCRIPTION
Uploading a point cloud on /pointcloud failed with 500 Internal Server Error at the very end of the upload. The multipart completion ran fine, the bytes landed in storage, and then the request crashed on the next line.

The cause is in the scan finalise path. ScanRepository.update_fields ends with session.expire_all(), which marks the scan row that complete_ingest had already loaded as expired. Right after the update we built the upload-completed event payload by reading scan.project_id, scan.tenant_id and scan.upload_key off that now-expired row. On an async session an expired-attribute read triggers an implicit lazy reload, and async SQLAlchemy refuses implicit IO outside a greenlet, so it raised MissingGreenlet and the whole request returned 500.

This affected every upload on the local filesystem storage backend, which is the default for the desktop app and single-node installs, so the feature was effectively dead there.

The fix snapshots project_id, tenant_id, the resolved upload key and the size into locals while the row is still live, before update_fields runs, and builds the event payload and the response from those locals. Nothing reads the expired row anymore.

Reproduced end to end against a local stand (init, PUT the part, complete) which returned 500 before and returns 200 after. Added a regression test that subscribes to the completed event and asserts the payload still carries the right ids, since the existing finalise test used a fake backend and never hit the post-expire read.