### PR TITLE
Fix 500 when transferring BIM quantities to the estimate

### DIFF
--- a/backend/app/modules/bim_hub/service.py
+++ b/backend/app/modules/bim_hub/service.py
@@ -1387,6 +1387,23 @@ class BIMHubService:
             )
         return element
 
+    async def _reload_element_with_links(self, element_id: uuid.UUID) -> BIMElement:
+        """Re-fetch an element with its ``boq_links`` eagerly loaded.
+
+        A freshly created element (e.g. from ``ensure_element``'s lazy-create
+        branches) has its ``selectin`` ``boq_links`` relationship UNLOADED.
+        Serializing it through ``BIMElementResponse`` (from_attributes) would
+        trigger an emit-on-access lazy load inside Pydantic's validation
+        context, outside the async greenlet, raising ``MissingGreenlet`` →
+        a raw 500. Reloading via an explicit SELECT eager-loads the
+        relationship so serialization never touches the DB.
+        """
+        return (
+            await self.session.execute(
+                select(BIMElement).options(selectinload(BIMElement.boq_links)).where(BIMElement.id == element_id)
+            )
+        ).scalar_one()
+
     # ── Asset Register (v2.3.0) ─────────────────────────────────────────
 
     async def list_tracked_assets(
@@ -1577,7 +1594,7 @@ class BIMHubService:
                 model_id,
                 ref,
             )
-            return element
+            return await self._reload_element_with_links(element.id)
 
         row = rows[0]
         # Split the Parquet row into canonical quantity / property buckets so
@@ -1632,7 +1649,7 @@ class BIMHubService:
             model_id,
             ref,
         )
-        return element
+        return await self._reload_element_with_links(element.id)
 
     async def bulk_import_elements(
         self,


### PR DESCRIPTION
Fixes the Internal server error when transferring BIM quantities into the estimate.

When you click a mesh in the 3D viewer that has no element row yet (snapshot-seeded RVT and IFC models, or meshes the converter dropped during extract), the backend lazy-creates a placeholder element so it can still be linked to a BOQ position. That freshly created element was returned without its boq_links relationship loaded. Serializing it through the response model then triggered a lazy load outside the async greenlet, which raised MissingGreenlet and surfaced as a raw 500 before the link was ever written.

The fix reloads the element through an explicit query that eager-loads boq_links in both lazy-create branches, so serialization never touches the database again.

Verified end to end on a procedural RVT model: ensure-element now returns 200 and the BOQ link is created (201). RVT and IFC both go through this path. DWG and PDF takeoff use their own tables and were not part of this 500.
