### PR TITLE
Fix local keyless AI providers

### DIFF
--- a/backend/app/modules/ai/ai_client.py
+++ b/backend/app/modules/ai/ai_client.py
@@ -542,10 +542,9 @@ async def call_openai_compatible(
         msg = f"Unknown OpenAI-compatible provider: {provider}"
         raise ValueError(msg)
 
-    headers: dict[str, str] = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key.strip():
+        headers["Authorization"] = f"Bearer {api_key.strip()}"
     if "extra_headers" in config:
         headers.update(config["extra_headers"])
 
@@ -933,6 +932,10 @@ def resolve_provider_and_key(
         (["gemini", "google"], "gemini", "gemini_api_key"),
         (["openrouter", "router"], "openrouter", "openrouter_api_key"),
         (["mistral"], "mistral", "mistral_api_key"),
+        # Self-hosted provider names must be checked before the generic
+        # "llama" keyword; otherwise "ollama" is accidentally routed to Groq.
+        (["ollama"], "ollama", None),
+        (["vllm"], "vllm", None),
         (["groq", "llama"], "groq", "groq_api_key"),
         (["deepseek"], "deepseek", "deepseek_api_key"),
         (["together"], "together", "together_api_key"),
@@ -945,8 +948,6 @@ def resolve_provider_and_key(
         (["baidu", "ernie"], "baidu", "baidu_api_key"),
         (["yandex"], "yandex", "yandex_api_key"),
         (["gigachat"], "gigachat", "gigachat_api_key"),
-        (["ollama"], "ollama", None),  # self-hosted: no stored key
-        (["vllm"], "vllm", None),  # self-hosted: no stored key
         (["kimi", "moonshot"], "kimi", "kimi_api_key"),  # Moonshot AI
     ]
 

--- a/backend/tests/unit/test_ai_client.py
+++ b/backend/tests/unit/test_ai_client.py
@@ -221,6 +221,18 @@ class TestResolveProviderAndKey:
         with pytest.raises(ValueError, match="No AI API key configured"):
             resolve_provider_and_key(None)
 
+    def test_ollama_preferred_is_not_routed_to_groq(self):
+        settings = self._make_settings(preferred_model="ollama")
+        provider, key = resolve_provider_and_key(settings)
+        assert provider == "ollama"
+        assert key == ""
+
+    def test_vllm_preferred_is_keyless(self):
+        settings = self._make_settings(preferred_model="vllm")
+        provider, key = resolve_provider_and_key(settings)
+        assert provider == "vllm"
+        assert key == ""
+
 
 # ── Model defaults & user-overridable model id (issue #129) ──────────────────
 
@@ -322,6 +334,52 @@ class TestModelOverride:
 
 
 class TestModelErrorSurfacing:
+    @pytest.mark.asyncio
+    async def test_keyless_local_provider_omits_authorization_header(self, monkeypatch):
+        """Ollama/vLLM accept OpenAI-compatible requests without a bearer key.
+
+        Sending ``Authorization: Bearer `` with an empty value is rejected by
+        httpx before the request reaches the local runtime.
+        """
+        from app.modules.ai import ai_client
+
+        captured: dict[str, str] = {}
+
+        class _FakeClient:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, *, headers, json, timeout):  # noqa: A002, ANN001
+                captured.update(headers)
+                request = httpx.Request("POST", url)
+                return httpx.Response(
+                    200,
+                    json={
+                        "choices": [{"message": {"content": "OK"}}],
+                        "usage": {"total_tokens": 2},
+                    },
+                    request=request,
+                )
+
+        monkeypatch.setattr(ai_client.httpx, "AsyncClient", _FakeClient)
+
+        text, tokens = await ai_client.call_openai_compatible(
+            "ollama",
+            "",
+            "system",
+            "prompt",
+            model="llama3.1",
+            base_url="http://localhost:11434/v1/chat/completions",
+        )
+
+        assert text == "OK"
+        assert tokens == 2
+        assert "Authorization" not in captured
+        assert captured["Content-Type"] == "application/json"
+
     @pytest.mark.asyncio
     async def test_unknown_model_message_is_actionable(self, monkeypatch):
         """A provider 400 "not a valid model ID" must produce a clear,


### PR DESCRIPTION
## Summary
- route `ollama` and `vllm` before the generic `llama` keyword so local Ollama is not mistaken for Groq
- omit the `Authorization` header for keyless OpenAI-compatible local providers
- treat Ollama/vLLM base URLs as valid AI configuration in ERP Chat readiness banners
- add focused regression coverage for Ollama/vLLM provider resolution and empty-key requests

## Validation
- `.venv/bin/python -m pytest backend/tests/unit/test_ai_client.py -q`
- `.venv/bin/python -m ruff check backend/app/modules/ai/ai_client.py backend/tests/unit/test_ai_client.py`
- `.venv/bin/python -m ruff format --check backend/app/modules/ai/ai_client.py backend/tests/unit/test_ai_client.py`
- `NODE_OPTIONS=--max-old-space-size=6144 npm run typecheck`
- `npx eslint src/features/erp-chat/aiConfigured.ts src/features/erp-chat/FloatingChatPanel.tsx src/features/erp-chat/full-page/useChatFullPage.ts src/features/erp-chat/full-page/AIConfigBanner.tsx`

## Context
Tested from a local Docker deployment with Ollama exposed through `host.docker.internal:11434`. The previous behavior made local AI providers fail in two layers: backend calls could fail before reaching the local runtime, and ERP Chat still showed the “AI provider key required” banner because it only checked cloud provider API-key flags.