### PR TITLE
Recognize local AI providers in ERP Chat readiness

### DIFF
--- a/frontend/src/features/erp-chat/FloatingChatPanel.tsx
+++ b/frontend/src/features/erp-chat/FloatingChatPanel.tsx
@@ -43,6 +43,7 @@ import { useFocusTrap } from '@/shared/hooks/useFocusTrap';
 import { uuid } from '@/shared/lib/browser';
 import { useFloatingChatStore, useIsMobileViewport } from './useFloatingChat';
 import { fetchChatSessions } from './api';
+import { isAiConfigured } from './aiConfigured';
 import type { ChatMessage, ChatSession, ToolCallInfo } from './types';
 
 // Reuse the full-page renderer registry so the tool-result cards inside the
@@ -1029,16 +1030,7 @@ export function FloatingChatPanel() {
       .getSettings()
       .then((settings: AISettings) => {
         if (cancelled) return;
-        const hasKey =
-          settings.anthropic_api_key_set ||
-          settings.openai_api_key_set ||
-          settings.gemini_api_key_set ||
-          settings.openrouter_api_key_set ||
-          settings.mistral_api_key_set ||
-          settings.groq_api_key_set ||
-          settings.deepseek_api_key_set ||
-          settings.cohere_api_key_set;
-        setAiConfigured(hasKey);
+        setAiConfigured(isAiConfigured(settings));
       })
       .catch(() => {
         if (!cancelled) setAiConfigured(false);

--- a/frontend/src/features/erp-chat/aiConfigured.ts
+++ b/frontend/src/features/erp-chat/aiConfigured.ts
@@ -1,0 +1,28 @@
+import type { AISettings } from '@/features/ai/api';
+
+const PROVIDER_KEY_FLAGS: (keyof AISettings)[] = [
+  'anthropic_api_key_set',
+  'openai_api_key_set',
+  'gemini_api_key_set',
+  'openrouter_api_key_set',
+  'mistral_api_key_set',
+  'groq_api_key_set',
+  'deepseek_api_key_set',
+  'together_api_key_set',
+  'fireworks_api_key_set',
+  'perplexity_api_key_set',
+  'cohere_api_key_set',
+  'ai21_api_key_set',
+  'xai_api_key_set',
+  'zhipu_api_key_set',
+  'baidu_api_key_set',
+  'yandex_api_key_set',
+  'gigachat_api_key_set',
+  'kimi_api_key_set',
+];
+
+export function isAiConfigured(settings: AISettings | null | undefined): boolean {
+  if (!settings) return false;
+  if (PROVIDER_KEY_FLAGS.some((flag) => settings[flag] === true)) return true;
+  return Boolean(settings.ollama_base_url?.trim()) || Boolean(settings.vllm_base_url?.trim());
+}

--- a/frontend/src/features/erp-chat/full-page/AIConfigBanner.tsx
+++ b/frontend/src/features/erp-chat/full-page/AIConfigBanner.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { Settings } from 'lucide-react';
 import { aiApi, type AISettings } from '@/features/ai/api';
+import { isAiConfigured } from '../aiConfigured';
 
 /**
  * Banner shown above the chat panel when the user has not configured an
@@ -34,19 +35,7 @@ export default function AIConfigBanner() {
 
   if (loading) return null;
 
-  // Determine if any provider has a key set
-  const hasKey =
-    !!settings &&
-    (settings.anthropic_api_key_set ||
-      settings.openai_api_key_set ||
-      settings.gemini_api_key_set ||
-      settings.openrouter_api_key_set ||
-      settings.mistral_api_key_set ||
-      settings.groq_api_key_set ||
-      settings.deepseek_api_key_set ||
-      settings.cohere_api_key_set);
-
-  if (hasKey) return null;
+  if (isAiConfigured(settings)) return null;
 
   return (
     <div

--- a/frontend/src/features/erp-chat/full-page/useChatFullPage.ts
+++ b/frontend/src/features/erp-chat/full-page/useChatFullPage.ts
@@ -8,6 +8,7 @@ import {
   fetchSessionMessages,
   deleteChatSession,
 } from '../api';
+import { isAiConfigured } from '../aiConfigured';
 import type { ChatMessage, ChatSession, DataPanelEntry, ToolCallInfo } from '../types';
 
 /** Shape of a persisted message row from GET /sessions/{id}/messages/. */
@@ -113,16 +114,7 @@ export function useChatFullPage(): UseChatFullPageReturn {
       .getSettings()
       .then((settings: AISettings) => {
         if (cancelled) return;
-        const hasKey =
-          settings.anthropic_api_key_set ||
-          settings.openai_api_key_set ||
-          settings.gemini_api_key_set ||
-          settings.openrouter_api_key_set ||
-          settings.mistral_api_key_set ||
-          settings.groq_api_key_set ||
-          settings.deepseek_api_key_set ||
-          settings.cohere_api_key_set;
-        setAiConfigured(hasKey);
+        setAiConfigured(isAiConfigured(settings));
       })
       .catch(() => {
         if (!cancelled) setAiConfigured(false);


### PR DESCRIPTION
## Summary
- treat configured Ollama/vLLM base URLs as valid AI configuration in ERP Chat
- share the ERP Chat readiness check between the floating panel, full-page hook, and full-page config banner
- include the remaining provider key flags so chat readiness matches the broader AI settings surface

## Validation
- `npx eslint src/features/erp-chat/aiConfigured.ts src/features/erp-chat/FloatingChatPanel.tsx src/features/erp-chat/full-page/useChatFullPage.ts src/features/erp-chat/full-page/AIConfigBanner.tsx`
- `NODE_OPTIONS=--max-old-space-size=6144 npm run typecheck`
- local Docker rebuild of `lidco-ocerp:ollama-fix` with this frontend fix

## Context
After the backend Ollama/vLLM keyless-provider fix, ERP Chat can still show “AI provider key required” when Settings > AI is configured with a local Ollama/vLLM URL and no cloud API key. The frontend readiness guard only checked cloud key booleans, so it blocked local providers before the backend resolver could use them.