### PR TITLE
fix(takeoff): scope PDF measurements by stable document identity

### DIFF
--- a/backend/app/modules/projects/file_manager_service.py
+++ b/backend/app/modules/projects/file_manager_service.py
@@ -198,6 +198,17 @@ async def _collect_documents(
     out: list[FileRow] = []
     for r in rows:
         path = r.file_path or ""
+        row_extra: dict[str, Any] = {
+            "version": r.version,
+            "revision_code": r.revision_code,
+            "drawing_number": r.drawing_number,
+            "cde_state": r.cde_state,
+        }
+        source_metadata = r.metadata_ if isinstance(r.metadata_, dict) else {}
+        for key in ("source_module", "source_id"):
+            value = source_metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                row_extra[key] = value.strip()
         out.append(
             FileRow(
                 id=str(r.id),
@@ -214,12 +225,7 @@ async def _collect_documents(
                 preview_url=None,
                 category=r.category,
                 discipline=r.discipline,
-                extra={
-                    "version": r.version,
-                    "revision_code": r.revision_code,
-                    "drawing_number": r.drawing_number,
-                    "cde_state": r.cde_state,
-                },
+                extra=row_extra,
             ),
         )
     return out

--- a/backend/app/modules/takeoff/service.py
+++ b/backend/app/modules/takeoff/service.py
@@ -13,6 +13,7 @@ from typing import Any
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.documents.repository import DocumentRepository
 from app.modules.takeoff.models import AiTakeoffRun, TakeoffDocument, TakeoffMeasurement
 from app.modules.takeoff.repository import (
     AiTakeoffRunRepository,
@@ -1289,6 +1290,43 @@ class TakeoffService:
 
     # ── Measurement CRUD ─────────────────────────────────────────────────
 
+    async def _assert_measurement_document_in_project(
+        self,
+        project_id: uuid.UUID,
+        document_id: str | None,
+    ) -> None:
+        """Validate UUID measurement document ids before persisting rows.
+
+        Legacy filename-keyed rows are left as a compatibility passthrough.
+        New persisted frontend writes use stable UUIDs, and those must point
+        to either a TakeoffDocument or a Project Files Document in the same
+        project.
+        """
+
+        if not document_id:
+            return
+        try:
+            linked_id = uuid.UUID(str(document_id))
+        except (TypeError, ValueError):
+            return
+
+        takeoff_doc = await self.repo.get_by_id(linked_id)
+        if takeoff_doc is not None and takeoff_doc.project_id == project_id:
+            return
+
+        project_file_doc = await DocumentRepository(self.session).get_by_id(linked_id)
+        if project_file_doc is not None and project_file_doc.project_id == project_id:
+            return
+
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "invalid_measurement_document_id",
+                "document_id": document_id,
+                "project_id": str(project_id),
+            },
+        )
+
     async def create_measurement(
         self,
         data: TakeoffMeasurementCreate,
@@ -1302,6 +1340,8 @@ class TakeoffService:
         threat model: prevents client-supplied measurement_value from
         diverging from the actual drawn shape.
         """
+        await self._assert_measurement_document_in_project(data.project_id, data.document_id)
+
         recomputed = recompute_measurement_value(
             measurement_type=data.type,
             points=data.points,
@@ -1548,6 +1588,8 @@ class TakeoffService:
             item = existing
 
         fields = data.model_dump(exclude_unset=True)
+        if "document_id" in fields:
+            await self._assert_measurement_document_in_project(item.project_id, fields["document_id"])
         if "metadata" in fields:
             fields["metadata_"] = fields.pop("metadata")
         if "points" in fields and fields["points"] is not None:
@@ -1670,6 +1712,14 @@ class TakeoffService:
         the localStorage→server import path can't be used to bypass
         the per-row create guard.
         """
+        checked: set[tuple[uuid.UUID, str | None]] = set()
+        for data in items:
+            key = (data.project_id, data.document_id)
+            if key in checked:
+                continue
+            checked.add(key)
+            await self._assert_measurement_document_in_project(data.project_id, data.document_id)
+
         measurements = [
             TakeoffMeasurement(
                 project_id=data.project_id,

--- a/backend/tests/unit/test_takeoff_measurement_document_identity.py
+++ b/backend/tests/unit/test_takeoff_measurement_document_identity.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.takeoff.models import TakeoffMeasurement
+from app.modules.takeoff.schemas import TakeoffMeasurementCreate, TakeoffMeasurementUpdate
+from app.modules.takeoff.service import TakeoffService
+
+
+def _measurement_create(project_id: uuid.UUID, document_id: str | None) -> TakeoffMeasurementCreate:
+    return TakeoffMeasurementCreate(
+        project_id=project_id,
+        document_id=document_id,
+        page=1,
+        type="count",
+        points=[],
+        count_value=1,
+        measurement_value=1,
+        measurement_unit="pcs",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_measurement_accepts_takeoff_document_in_same_project() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=SimpleNamespace(project_id=project_id))  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    service.measurement_repo.create = AsyncMock(side_effect=lambda m: m)  # type: ignore[method-assign]
+
+    created = await service.create_measurement(_measurement_create(project_id, str(document_id)))
+
+    assert created.document_id == str(document_id)
+
+@pytest.mark.asyncio
+async def test_create_measurement_rejects_uuid_document_from_another_project() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=SimpleNamespace(project_id=uuid.uuid4()))  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    with pytest.raises(HTTPException) as exc:
+        await service.create_measurement(_measurement_create(project_id, str(document_id)))
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail["code"] == "invalid_measurement_document_id"
+
+
+@pytest.mark.asyncio
+async def test_update_measurement_rejects_uuid_document_from_another_project() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=SimpleNamespace(project_id=uuid.uuid4()))  # type: ignore[method-assign]
+    existing = TakeoffMeasurement(project_id=project_id, document_id=str(uuid.uuid4()), type="count", points=[])
+
+    with pytest.raises(HTTPException) as exc:
+        await service.update_measurement(
+            uuid.uuid4(),
+            TakeoffMeasurementUpdate(document_id=str(document_id)),
+            existing=existing,
+        )
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_bulk_create_validates_each_stable_document_identity_once() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=SimpleNamespace(project_id=project_id))  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    service.measurement_repo.create_bulk = AsyncMock(side_effect=lambda rows: rows)  # type: ignore[method-assign]
+
+    await service.bulk_create_measurements(
+        [
+            _measurement_create(project_id, str(document_id)),
+            _measurement_create(project_id, str(document_id)),
+        ],
+    )
+
+    service.repo.get_by_id.assert_awaited_once_with(document_id)
+
+
+@pytest.mark.asyncio
+async def test_legacy_filename_document_id_remains_passthrough() -> None:
+    project_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock()  # type: ignore[method-assign]
+    service.session.get = AsyncMock()  # type: ignore[method-assign]
+    service.measurement_repo.create = AsyncMock(side_effect=lambda m: m)  # type: ignore[method-assign]
+
+    created = await service.create_measurement(_measurement_create(project_id, "abc.pdf"))
+
+    assert created.document_id == "abc.pdf"
+    service.repo.get_by_id.assert_not_awaited()
+    service.session.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_measurement_accepts_project_files_document_in_same_project() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=SimpleNamespace(project_id=project_id))  # type: ignore[method-assign]
+    service.measurement_repo.create = AsyncMock(side_effect=lambda m: m)  # type: ignore[method-assign]
+
+    created = await service.create_measurement(_measurement_create(project_id, str(document_id)))
+
+    assert created.document_id == str(document_id)
+
+
+@pytest.mark.asyncio
+async def test_create_measurement_prefers_takeoff_document_before_project_files_lookup() -> None:
+    project_id = uuid.uuid4()
+    document_id = uuid.uuid4()
+    service = TakeoffService(AsyncMock())
+    service.repo.get_by_id = AsyncMock(return_value=SimpleNamespace(project_id=project_id))  # type: ignore[method-assign]
+    service.session.get = AsyncMock(return_value=SimpleNamespace(project_id=project_id))  # type: ignore[method-assign]
+    service.measurement_repo.create = AsyncMock(side_effect=lambda m: m)  # type: ignore[method-assign]
+
+    created = await service.create_measurement(_measurement_create(project_id, str(document_id)))
+
+    assert created.document_id == str(document_id)
+    service.session.get.assert_not_awaited()

--- a/frontend/src/features/boq/grid/cellRenderers.tsx
+++ b/frontend/src/features/boq/grid/cellRenderers.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useMemo, useEffect, useLayoutEffect, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { buildTakeoffMeasurementUrl, parseMeasurementDocumentSource } from '@/features/takeoff/takeoffRoutes';
 import type { ICellRendererParams, Column, GridApi } from 'ag-grid-community';
 import type { Position } from '../api';
 import {
@@ -1236,6 +1237,7 @@ export function BimLinkCellRenderer(params: ICellRendererParams) {
   const meta = (data.metadata ?? {}) as Record<string, unknown>;
   const pdfMeasurementId = meta.pdf_measurement_id as string | undefined;
   const pdfDocumentId = meta.pdf_document_id as string | undefined;
+  const pdfDocumentSource = parseMeasurementDocumentSource(meta.pdf_document_source);
   const pdfPage = meta.pdf_page as number | undefined;
   const pdfSource = meta.pdf_measurement_source as string | undefined;
   // Convention: ordinals prefixed "TK." come from the PDF takeoff flow,
@@ -1287,13 +1289,13 @@ export function BimLinkCellRenderer(params: ICellRendererParams) {
   /** Build the deep-link URL for the PDF takeoff viewer, focused on the
    *  linked measurement so the user lands on the exact annotation. */
   const pdfDeepLink = useMemo(() => {
-    const params = new URLSearchParams();
-    params.set('tab', 'measurements');
-    if (pdfMeasurementId) params.set('focus', pdfMeasurementId);
-    if (pdfDocumentId) params.set('name', pdfDocumentId);
-    if (pdfPage) params.set('page', String(pdfPage));
-    return `/takeoff?${params.toString()}`;
-  }, [pdfMeasurementId, pdfDocumentId, pdfPage]);
+    return buildTakeoffMeasurementUrl({
+      documentId: pdfDocumentId,
+      documentSource: pdfDocumentSource,
+      measurementId: pdfMeasurementId,
+      page: pdfPage,
+    });
+  }, [pdfMeasurementId, pdfDocumentId, pdfDocumentSource, pdfPage]);
 
   /** Same for DWG. */
   const dwgDeepLink = useMemo(() => {

--- a/frontend/src/features/documents/DocumentsPage.tsx
+++ b/frontend/src/features/documents/DocumentsPage.tsx
@@ -21,6 +21,7 @@ import { listSessions } from '../cad-explorer/api';
 import { fetchBIMModels } from '../bim/api';
 import { fetchDrawings } from '../dwg-takeoff/api';
 import { takeoffApi } from '../takeoff/api';
+import { buildProjectDocumentTakeoffUrl, buildTakeoffMeasurementUrl } from '../takeoff/takeoffRoutes';
 import { documentsGuide } from './documentsGuide';
 
 /* ── Types ───────────────────────────────────────────────────────────── */
@@ -180,7 +181,7 @@ function routeForDocument(doc: DocItem): { path: string; module: 'takeoff' | 'dw
   }
   if (sourceModule === 'takeoff') {
     return {
-      path: `/takeoff?doc=${encodeURIComponent(doc.id)}&name=${encodeURIComponent(doc.name)}`,
+      path: buildProjectDocumentTakeoffUrl(doc),
       module: 'takeoff',
     };
   }
@@ -1189,7 +1190,15 @@ export function DocumentsPage() {
               <button
                 key={`tk-${td.id}`}
                 type="button"
-                onClick={() => navigate(`/takeoff?tab=measurements&doc=${encodeURIComponent(td.id)}&name=${encodeURIComponent(td.filename)}`)}
+                onClick={() =>
+                  navigate(
+                    buildTakeoffMeasurementUrl({
+                      documentId: td.id,
+                      documentName: td.filename,
+                      documentSource: 'takeoff',
+                    }),
+                  )
+                }
                 className="group text-left rounded-lg border border-border-light bg-surface-primary px-3 py-2 hover:border-oe-blue/30 hover:shadow-sm transition-all"
                 title={td.filename}
               >
@@ -1386,7 +1395,10 @@ export function DocumentsPage() {
                             {previewKind === 'pdf' && (
                               <button
                                 role="menuitem"
-                                onClick={() => { setOpenMenuId(null); navigate(`/takeoff?doc=${doc.id}&name=${encodeURIComponent(doc.name)}`); }}
+                                onClick={() => {
+                                  setOpenMenuId(null);
+                                  navigate(buildProjectDocumentTakeoffUrl(doc));
+                                }}
                                 className="flex w-full items-center gap-2.5 px-3 py-2 text-xs text-content-primary hover:bg-surface-secondary transition-colors"
                               >
                                 <Ruler size={14} className="text-oe-blue" />

--- a/frontend/src/features/file-manager/FileManagerPage.tsx
+++ b/frontend/src/features/file-manager/FileManagerPage.tsx
@@ -434,7 +434,7 @@ export function FileManagerPage() {
       ctx.setActiveProject(row.project_id, name);
     }
     recordRecentlyViewed(row);
-    navigate(target.route(row.project_id, row.id));
+    navigate(target.route(row.project_id, row.id, row));
   }
 
   function handleOpenRecent(item: RecentItem) {
@@ -447,7 +447,7 @@ export function FileManagerPage() {
           : projectsLite.find((p) => p.id === item.project_id)?.name ?? ctx.activeProjectName;
       ctx.setActiveProject(item.project_id, name);
     }
-    navigate(target.route(item.project_id, item.id));
+    navigate(target.route(item.project_id, item.id, item));
   }
 
   function handleOpenCategory(kind: FileKind) {

--- a/frontend/src/features/file-manager/components/FileContextMenu.tsx
+++ b/frontend/src/features/file-manager/components/FileContextMenu.tsx
@@ -126,7 +126,7 @@ export function FileContextMenu({
           module: moduleLabel,
         })}
         onClick={() => {
-          navigate(target.route(row.project_id, row.id));
+          navigate(target.route(row.project_id, row.id, row));
           onClose();
         }}
       />

--- a/frontend/src/features/file-manager/components/FilePreviewPane.tsx
+++ b/frontend/src/features/file-manager/components/FilePreviewPane.tsx
@@ -190,7 +190,7 @@ export function FilePreviewPane({ row, onClose, onEmail, onShare, onManageAccess
           : projects.find((p) => p.id === file.project_id)?.name ?? ctxProjectName;
       setActiveProject(file.project_id, resolved);
     }
-    navigate(target.route(file.project_id, file.id));
+    navigate(target.route(file.project_id, file.id, file));
   }
 
   async function handleCopyPath() {

--- a/frontend/src/features/file-manager/components/RecentlyViewedStrip.tsx
+++ b/frontend/src/features/file-manager/components/RecentlyViewedStrip.tsx
@@ -23,6 +23,7 @@ export interface RecentItem {
   kind: FileKind;
   name: string;
   extension?: string | undefined;
+  extra?: Record<string, unknown>;
   viewed_at: number;
 }
 
@@ -64,6 +65,7 @@ export function recordRecentlyViewed(row: FileRow) {
       kind: row.kind,
       name: row.name,
       extension: row.extension ?? undefined,
+      extra: row.extra,
       viewed_at: Date.now(),
     },
     ...items.filter((r) => r.id !== row.id),

--- a/frontend/src/features/file-manager/kindModule.test.ts
+++ b/frontend/src/features/file-manager/kindModule.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { primaryModule } from './kindModule';
+import type { FileRow } from './types';
+
+function file(overrides: Partial<FileRow>): FileRow {
+  return {
+    id: 'file-id',
+    kind: 'document',
+    name: 'abc.pdf',
+    project_id: 'project-id',
+    size_bytes: 1,
+    mime_type: 'application/pdf',
+    extension: 'pdf',
+    modified_at: null,
+    physical_path: '',
+    relative_path: '',
+    storage_backend: 'local',
+    download_url: null,
+    preview_url: null,
+    thumbnail_url: null,
+    discipline: null,
+    category: 'drawing',
+    extra: {},
+    ...overrides,
+  };
+}
+
+describe('file manager module routing', () => {
+  it('opens ordinary Project Files PDFs in the document measurement namespace', () => {
+    const row = file({ id: 'project-file-doc-id', name: 'abc.pdf' });
+    const target = primaryModule(row.kind, row.extension);
+
+    expect(target.route(row.project_id, row.id, row)).toBe(
+      '/takeoff?tab=measurements&doc=project-file-doc-id&source=document&name=abc.pdf',
+    );
+  });
+
+  it('opens takeoff mirrors in the original Takeoff measurement namespace', () => {
+    const row = file({
+      id: 'project-file-mirror-id',
+      name: 'takeoff-upload.pdf',
+      extra: {
+        source_module: 'takeoff',
+        source_id: 'takeoff-doc-id',
+      },
+    });
+    const target = primaryModule(row.kind, row.extension);
+
+    expect(target.route(row.project_id, row.id, row)).toBe(
+      '/takeoff?tab=measurements&doc=takeoff-doc-id&name=takeoff-upload.pdf',
+    );
+  });
+});

--- a/frontend/src/features/file-manager/kindModule.ts
+++ b/frontend/src/features/file-manager/kindModule.ts
@@ -1,4 +1,5 @@
 import { BarChart3, Box, FileBarChart, FileText, Image as ImageIcon, MapPin, Package, Pencil, PenTool, Radar, Ruler, type LucideIcon } from 'lucide-react';
+import { buildProjectDocumentTakeoffUrl } from '@/features/takeoff/takeoffRoutes';
 import type { FileKind } from './types';
 
 // Single source of truth for per-kind accent colours. Both the landing
@@ -105,7 +106,7 @@ export interface ModuleTarget {
   descriptionI18nKey: string;
   icon: LucideIcon;
   /** Path template — `{projectId}` is substituted in by the consumer. */
-  route: (projectId: string, fileId?: string) => string;
+  route: (projectId: string, fileId?: string, file?: FileRouteContext) => string;
   /**
    * Some destinations (Clash Detection, CAD-BIM BI Explorer) resolve the
    * project from the global project-context store rather than from a path
@@ -119,11 +120,28 @@ export interface ModuleTarget {
 
 const PROJECT = (p: string, sub: string) => `/projects/${p}/${sub}`;
 
+export interface FileRouteContext {
+  id: string;
+  name: string;
+  kind: FileKind;
+  extension?: string | null;
+  extra?: Record<string, unknown>;
+}
+
 // Append a deep-link query parameter only when we actually have a file
 // id. Keeping the bare path when it's missing avoids URLs like
 // `/takeoff?doc=` that some routers parse as an empty string.
 const withParam = (path: string, key: string, value?: string): string =>
   value ? `${path}${path.includes('?') ? '&' : '?'}${key}=${encodeURIComponent(value)}` : path;
+
+function pdfTakeoffRoute(_projectId: string, fileId?: string, file?: FileRouteContext): string {
+  if (!fileId) return '/takeoff';
+  return buildProjectDocumentTakeoffUrl({
+    id: fileId,
+    name: file?.name ?? 'Document',
+    metadata: file?.extra,
+  });
+}
 
 export const KIND_MODULES: Record<FileKind, ModuleTarget[]> = {
   document: [
@@ -138,10 +156,7 @@ export const KIND_MODULES: Record<FileKind, ModuleTarget[]> = {
       description: 'Open this PDF and start measuring',
       descriptionI18nKey: 'files.module.pdf_takeoff_desc',
       icon: Ruler,
-      route: (_p, f) =>
-        f
-          ? `/takeoff?doc=${encodeURIComponent(f)}&source=document&tab=measurements`
-          : '/takeoff',
+      route: pdfTakeoffRoute,
     },
     {
       label: 'File Manager',
@@ -179,10 +194,7 @@ export const KIND_MODULES: Record<FileKind, ModuleTarget[]> = {
       icon: Ruler,
       // TakeoffPage reads `doc`/`source`/`tab` (not `sheet`), so mirror the
       // document-kind builder: open the source PDF with the measurements tab.
-      route: (_p, f) =>
-        f
-          ? `/takeoff?doc=${encodeURIComponent(f)}&source=document&tab=measurements`
-          : '/takeoff',
+      route: pdfTakeoffRoute,
     },
     {
       label: 'File Manager',
@@ -270,10 +282,7 @@ export const KIND_MODULES: Record<FileKind, ModuleTarget[]> = {
       icon: Ruler,
       // TakeoffPage reads `doc`/`source`/`tab` (not `session`), so mirror the
       // document-kind builder so the file actually opens in the viewer.
-      route: (_p, f) =>
-        f
-          ? `/takeoff?doc=${encodeURIComponent(f)}&source=document&tab=measurements`
-          : '/takeoff',
+      route: pdfTakeoffRoute,
     },
   ],
   report: [

--- a/frontend/src/features/markups/MarkupsPage.tsx
+++ b/frontend/src/features/markups/MarkupsPage.tsx
@@ -62,6 +62,7 @@ import { UnifiedMarkupsList } from './UnifiedMarkupsList';
 import { EditMarkupModal } from './EditMarkupModal';
 import { markupsGuide } from './markupsGuide';
 import { ApprovalInstanceCard } from '@/features/approval-routes';
+import { buildTakeoffMeasurementUrl } from '@/features/takeoff/takeoffRoutes';
 
 /* ── Constants ─────────────────────────────────────────────────────────── */
 
@@ -1473,28 +1474,19 @@ export function MarkupsPage() {
   );
 
   // Push a measurement markup into PDF Takeoff as a quantity (CONN-67).
-  // Takeoff matches its document by filename, which is exactly the document
-  // name we already resolve for the row, so we hand it ``docId=<name>`` and
-  // open straight on the Measurements tab. The measured value and unit ride
-  // along as ``mv`` / ``mu`` so the takeoff "Add measurement" form can
-  // pre-fill them (that consumer lands with the takeoff batch); the
-  // navigation itself is already useful without it.
+  // Markups hub rows refer to Project Files documents, so route through the
+  // shared takeoff URL builder with source=document and the stable document id.
   const handleUseAsQuantity = useCallback(
     (markup: Markup) => {
-      const params = new URLSearchParams();
-      params.set('tab', 'measurements');
       const docName = markup.document_id
         ? docNameById.get(markup.document_id)
         : undefined;
-      if (docName) params.set('docId', docName);
-      if (markup.measurement_value != null) {
-        params.set('mv', String(markup.measurement_value));
-      }
-      if (markup.measurement_unit) params.set('mu', markup.measurement_unit);
-      if (markup.label || markup.text) {
-        params.set('mdesc', (markup.label || markup.text) as string);
-      }
-      navigate(`/takeoff?${params.toString()}`);
+      const url = buildTakeoffMeasurementUrl({
+        documentId: markup.document_id,
+        documentName: docName,
+        documentSource: markup.document_id ? 'document' : null,
+      });
+      navigate(url);
     },
     [navigate, docNameById],
   );

--- a/frontend/src/features/markups/__tests__/aggregator.test.ts
+++ b/frontend/src/features/markups/__tests__/aggregator.test.ts
@@ -150,6 +150,17 @@ describe('aggregator normalisation', () => {
     expect(u.deepLink).toContain('measurementId=pdf-1');
   });
 
+  it('deep-links Project Files PDF measurements with source=document', () => {
+    const u = fromPdfMeasurement(
+      makePdfMeasurement({ document_id: 'project-file-doc-id' }),
+      { documentName: 'Plans.pdf', documentSource: 'document' },
+    );
+
+    expect(u.deepLink).toBe(
+      '/takeoff?tab=measurements&doc=project-file-doc-id&source=document&name=Plans.pdf&measurementId=pdf-1&page=1',
+    );
+  });
+
   it('coerces unknown type values to "other"', () => {
     const u = fromPdfMeasurement(
       makePdfMeasurement({ type: 'alien_glyph' as MeasurementResponse['type'] }),

--- a/frontend/src/features/markups/aggregator.ts
+++ b/frontend/src/features/markups/aggregator.ts
@@ -27,6 +27,7 @@
 import type { Markup, MarkupType } from './api';
 import type { DwgAnnotation, DwgDrawing } from '@/features/dwg-takeoff/api';
 import type { MeasurementResponse } from '@/features/takeoff/api';
+import { buildTakeoffMeasurementUrl, type MeasurementDocumentSource } from '@/features/takeoff/takeoffRoutes';
 
 /* ── Source discriminators ───────────────────────────────────────────── */
 
@@ -175,7 +176,7 @@ export function fromDwgAnnotation(
 
 export function fromPdfMeasurement(
   m: MeasurementResponse,
-  opts: { documentName?: string | null } = {},
+  opts: { documentName?: string | null; documentSource?: MeasurementDocumentSource | null } = {},
 ): UnifiedMarkup {
   const docName =
     opts.documentName ?? (m.document_id ? m.document_id : 'PDF takeoff');
@@ -204,9 +205,13 @@ export function fromPdfMeasurement(
     // The takeoff page restores the viewer from ``?doc=`` (not ``docId``)
     // when ``tab=measurements``; ``measurementId`` then selects and scrolls
     // to the row. Emitting ``docId`` left the viewer blank.
-    deepLink: m.document_id
-      ? `/takeoff?tab=measurements&doc=${encodeURIComponent(m.document_id)}&measurementId=${m.id}`
-      : `/takeoff?tab=measurements&measurementId=${m.id}`,
+    deepLink: buildTakeoffMeasurementUrl({
+      documentId: m.document_id,
+      documentName: opts.documentName,
+      documentSource: opts.documentSource,
+      measurementId: m.id,
+      page: m.page,
+    }),
   };
 }
 

--- a/frontend/src/features/markups/useUnifiedMarkups.ts
+++ b/frontend/src/features/markups/useUnifiedMarkups.ts
@@ -19,6 +19,7 @@ import { fetchMarkups } from './api';
 import { fetchDrawings, fetchAnnotations } from '@/features/dwg-takeoff/api';
 import { takeoffApi, type MeasurementResponse } from '@/features/takeoff/api';
 import type { DwgAnnotation, DwgDrawing } from '@/features/dwg-takeoff/api';
+import { type MeasurementDocumentSource, parseMeasurementDocumentSource } from '@/features/takeoff/takeoffRoutes';
 
 import {
   fromDwgAnnotation,
@@ -75,6 +76,14 @@ export function useUnifiedMarkups(projectId: string | null | undefined): UseUnif
     staleTime: 60_000,
   });
 
+  // Takeoff documents lookup — let us show friendly names for takeoff documents too.
+  const takeoffDocsQuery = useQuery({
+    queryKey: [...UNIFIED_MARKUPS_QUERY_KEY, projectId, 'takeoff-documents'],
+    queryFn: () => takeoffApi.listDocuments(projectId as string),
+    enabled: !!projectId,
+    staleTime: 60_000,
+  });
+
   // DWG — per-project drawings, then per-drawing annotations.
   const drawingsQuery = useQuery<DwgDrawing[]>({
     queryKey: [...UNIFIED_MARKUPS_QUERY_KEY, projectId, 'dwg-drawings'],
@@ -118,15 +127,18 @@ export function useUnifiedMarkups(projectId: string | null | undefined): UseUnif
   });
 
   const { items, summary } = useMemo(() => {
-    const docNameById = new Map<string, string>();
-    for (const d of documentsQuery.data ?? []) docNameById.set(d.id, d.name);
+    const projectDocNames = new Map<string, string>();
+    for (const d of documentsQuery.data ?? []) projectDocNames.set(d.id, d.name);
+
+    const takeoffDocNames = new Map<string, string>();
+    for (const td of takeoffDocsQuery.data ?? []) takeoffDocNames.set(td.id, td.filename);
 
     const drawingById = new Map<string, DwgDrawing>();
     for (const d of drawingsQuery.data ?? []) drawingById.set(d.id, d);
 
     const hub = (hubQuery.data ?? []).map((m) =>
       fromMarkupsHub(m, {
-        documentName: m.document_id ? docNameById.get(m.document_id) ?? null : null,
+        documentName: m.document_id ? projectDocNames.get(m.document_id) ?? takeoffDocNames.get(m.document_id) ?? null : null,
       }),
     );
 
@@ -138,11 +150,32 @@ export function useUnifiedMarkups(projectId: string | null | undefined): UseUnif
       })
       .filter((x): x is UnifiedMarkup => x !== null);
 
-    const pdf = (pdfQuery.data ?? []).map((m) =>
-      fromPdfMeasurement(m, {
-        documentName: m.document_id ? docNameById.get(m.document_id) ?? m.document_id : null,
-      }),
-    );
+    const pdf = (pdfQuery.data ?? []).map((m) => {
+      const metadataSource = parseMeasurementDocumentSource(m.metadata?.document_source);
+      let documentName = m.document_id || null;
+      let documentSource: MeasurementDocumentSource | null = metadataSource;
+      if (m.document_id) {
+        if (metadataSource === 'document') {
+          documentName = projectDocNames.get(m.document_id) ?? documentName;
+        } else if (metadataSource === 'takeoff') {
+          documentName = takeoffDocNames.get(m.document_id) ?? documentName;
+        } else {
+          const projectDocName = projectDocNames.get(m.document_id);
+          const takeoffDocName = takeoffDocNames.get(m.document_id);
+          if (projectDocName) {
+            documentName = projectDocName;
+            documentSource = 'document';
+          } else if (takeoffDocName) {
+            documentName = takeoffDocName;
+            documentSource = 'takeoff';
+          }
+        }
+      }
+      return fromPdfMeasurement(m, {
+        documentName,
+        documentSource,
+      });
+    });
 
     const merged = mergeUnified(hub, dwg, pdf);
     return { items: merged, summary: summarise(merged) };
@@ -152,6 +185,7 @@ export function useUnifiedMarkups(projectId: string | null | undefined): UseUnif
     pdfQuery.data,
     drawingsQuery.data,
     documentsQuery.data,
+    takeoffDocsQuery.data,
   ]);
 
   const isLoading =
@@ -167,6 +201,8 @@ export function useUnifiedMarkups(projectId: string | null | undefined): UseUnif
     (drawingsQuery.error as Error | undefined) ??
     (dwgAnnotationsQuery.error as Error | undefined) ??
     (pdfQuery.error as Error | undefined) ??
+    (documentsQuery.error as Error | undefined) ??
+    (takeoffDocsQuery.error as Error | undefined) ??
     null;
 
   return { items, summary, isLoading, error };

--- a/frontend/src/features/takeoff/TakeoffPage.tsx
+++ b/frontend/src/features/takeoff/TakeoffPage.tsx
@@ -42,6 +42,11 @@ import { takeoffApi, type TakeoffDocumentResponse } from './api';
 import { canonicalizeUnit } from './lib/units';
 import { aiApi } from '@/features/ai/api';
 import { hasLlmKey } from '@/features/ai-estimator/useAiReadiness';
+import {
+  resolveProjectDocumentTakeoffTarget,
+  type MeasurementDocumentSource,
+  type ProjectDocumentTakeoffLink,
+} from './takeoffRoutes';
 
 const TakeoffViewerModule = lazy(() => import('@/modules/pdf-takeoff/TakeoffViewerModule'));
 
@@ -91,6 +96,51 @@ interface UploadedDocument {
   extractingTables: boolean;
   uploadError?: string;
   uploading?: boolean;
+}
+
+interface ViewerDocument {
+  url: string;
+  name: string;
+  measurementDocumentId: string;
+  measurementDocumentSource: MeasurementDocumentSource;
+  takeoffDocumentId?: string;
+  projectFileDocumentId?: string;
+}
+
+function takeoffDownloadUrl(docId: string): string {
+  return `/api/v1/takeoff/documents/${encodeURIComponent(docId)}/download/`;
+}
+
+function projectFileDownloadUrl(docId: string): string {
+  return `/api/v1/documents/${encodeURIComponent(docId)}/download/`;
+}
+
+function makeTakeoffViewerDoc(docId: string, name: string): ViewerDocument {
+  return {
+    url: takeoffDownloadUrl(docId),
+    name,
+    measurementDocumentId: docId,
+    measurementDocumentSource: 'takeoff',
+    takeoffDocumentId: docId,
+  };
+}
+
+function makeProjectFileViewerDoc(
+  doc: ProjectDocumentTakeoffLink,
+): ViewerDocument {
+  const target = resolveProjectDocumentTakeoffTarget(doc);
+  const measurementDocumentId = target.documentId || doc.id;
+  const measurementDocumentSource = target.documentSource || 'document';
+  return {
+    url: measurementDocumentSource === 'takeoff'
+      ? takeoffDownloadUrl(measurementDocumentId)
+      : projectFileDownloadUrl(doc.id),
+    name: target.documentName || doc.name,
+    measurementDocumentId,
+    measurementDocumentSource,
+    takeoffDocumentId: measurementDocumentSource === 'takeoff' ? measurementDocumentId : undefined,
+    projectFileDocumentId: doc.id,
+  };
 }
 
 interface QuickMeasurement {
@@ -1163,6 +1213,7 @@ export function TakeoffPage() {
   /* ── State ──────────────────────────────────────────────────────────── */
 
   const activeProjectId = useProjectContextStore((s) => s.activeProjectId);
+  const setActiveProject = useProjectContextStore((s) => s.setActiveProject);
   const selectedProjectId = activeProjectId ?? '';
   const [selectedBoqId, setSelectedBoqId] = useState('');
   const [documents, setDocuments] = useState<UploadedDocument[]>([]);
@@ -1172,7 +1223,7 @@ export function TakeoffPage() {
   const filmstripUploadRef = useRef<HTMLInputElement>(null);
 
   /** Currently opened document in the Measurements viewer. */
-  const [viewerDoc, setViewerDoc] = useState<{ url: string; name: string } | null>(null);
+  const [viewerDoc, setViewerDoc] = useState<ViewerDocument | null>(null);
 
   /** Revision compare drawer (Item 17) — diffs two takeoff PDFs. */
   const [showCompare, setShowCompare] = useState(false);
@@ -1279,10 +1330,7 @@ export function TakeoffPage() {
     );
     if (!match) return;
     setActiveDocId(match.id);
-    setViewerDoc({
-      url: `/api/v1/takeoff/documents/${match.id}/download/`,
-      name: match.filename,
-    });
+    setViewerDoc(makeTakeoffViewerDoc(match.id, match.filename));
     setActiveTab('measurements');
     const next = new URLSearchParams(searchParams);
     next.delete('name');
@@ -1295,15 +1343,19 @@ export function TakeoffPage() {
   useEffect(() => {
     const docId = searchParams.get('doc');
     const tab = searchParams.get('tab');
+    const source = searchParams.get('source');
     if (!docId || tab !== 'measurements') return;
-    if (viewerDoc) return; // already open
+    if (source === 'document') return;
+    if (
+      viewerDoc?.measurementDocumentId === docId &&
+      viewerDoc.measurementDocumentSource === 'takeoff'
+    ) {
+      return; // already open
+    }
     if (!serverDocuments || serverDocuments.length === 0) return;
     const match = serverDocuments.find((d) => d.id === docId);
     if (!match) return;
-    setViewerDoc({
-      url: `/api/v1/takeoff/documents/${docId}/download/`,
-      name: match.filename,
-    });
+    setViewerDoc(makeTakeoffViewerDoc(docId, match.filename));
     setActiveTab('measurements');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serverDocuments, searchParams]);
@@ -1319,24 +1371,60 @@ export function TakeoffPage() {
     const docId = searchParams.get('doc');
     const source = searchParams.get('source');
     if (!docId || source !== 'document') return;
-    if (viewerDoc) return;
+    if (viewerDoc?.projectFileDocumentId === docId) {
+      setActiveTab('measurements');
+      return;
+    }
     let cancelled = false;
     (async () => {
       try {
-        const meta = await apiGet<{ id: string; name: string; filename?: string }>(
+        const meta = await apiGet<{
+          id: string;
+          name: string;
+          filename?: string;
+          project_id?: string | null;
+          metadata?: { source_module?: string; source_id?: string };
+        }>(
           `/v1/documents/${encodeURIComponent(docId)}`,
         );
         if (cancelled) return;
+        const projectId = typeof meta.project_id === 'string' && meta.project_id.trim()
+          ? meta.project_id.trim()
+          : null;
+        if (projectId && useProjectContextStore.getState().activeProjectId !== projectId) {
+          let projectName = projects?.find((p) => p.id === projectId)?.name ?? '';
+          if (!projectName) {
+            try {
+              const project = await apiGet<Pick<Project, 'id' | 'name'>>(
+                `/v1/projects/${encodeURIComponent(projectId)}`,
+              );
+              if (cancelled) return;
+              projectName = project.name ?? '';
+            } catch {
+              if (cancelled) return;
+            }
+          }
+          setActiveProject(projectId, projectName);
+        }
         const displayName =
           meta.filename ||
           meta.name ||
           searchParams.get('name') ||
           t('takeoff.document_placeholder', { defaultValue: 'Document' });
-        setActiveDocId(docId);
-        setViewerDoc({
-          url: `/api/v1/documents/${encodeURIComponent(docId)}/download/`,
+        const nextViewerDoc = makeProjectFileViewerDoc({
+          id: docId,
           name: displayName,
+          metadata: meta.metadata,
         });
+        if (
+          viewerDoc?.measurementDocumentId === nextViewerDoc.measurementDocumentId &&
+          viewerDoc.measurementDocumentSource === nextViewerDoc.measurementDocumentSource
+        ) {
+          setActiveTab('measurements');
+          return;
+        }
+        setActiveDocId(nextViewerDoc.measurementDocumentId);
+        setViewerDoc(nextViewerDoc);
         setActiveTab('measurements');
       } catch {
         // Documents-module fetch failed; leave viewer untouched so the
@@ -1347,17 +1435,14 @@ export function TakeoffPage() {
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  }, [searchParams, viewerDoc, projects, setActiveProject]);
 
   /* ── /markups deep-link: ?docId=<filename|uuid>&measurementId=<uuid> ───
    *
-   * The unified Markups hub builds deep-links from `measurement.document_id`,
-   * which the PDF-takeoff backend stores as the **filename** (see
-   * useMeasurementPersistence — takeoffApi.list is keyed by filename, and
-   * MeasurementCreate.document_id is the same string). So `docId` here is
-   * usually a filename, occasionally a real takeoff_documents UUID. We try
-   * both: exact filename match against the takeoff docs catalogue first,
-   * then UUID id match as a fallback.
+   * The unified Markups hub builds deep-links from `measurement.document_id`.
+   * Current writes use the stable takeoff/document UUID. Older rows can still
+   * carry a filename, so we try exact filename match against the takeoff docs
+   * catalogue first, then UUID id match as a fallback.
    *
    * On hit: open the PDF in the Measurements viewer and stash the
    * measurementId so TakeoffViewerModule can select + scroll-to it once
@@ -1367,7 +1452,7 @@ export function TakeoffPage() {
    * to /markups — far less confusing than the previous silent blank page.
    */
   useEffect(() => {
-    const docId = searchParams.get('docId');
+    const docId = searchParams.get('docId') || searchParams.get('doc');
     const measurementId = searchParams.get('measurementId');
     const tab = searchParams.get('tab');
     // Track the measurementId param so the viewer can act on it once the
@@ -1375,14 +1460,17 @@ export function TakeoffPage() {
     // module fetches its own measurement list keyed by filename).
     setInitialMeasurementId(measurementId);
 
-    if (!docId) {
+    if (!docId || !measurementId) {
       setDeepLinkNotFound(false);
       return;
     }
     if (tab === 'measurements') {
       setActiveTab('measurements');
     }
-    if (viewerDoc) return; // already opened from a prior effect
+    if (searchParams.get('source') === 'document') {
+      setDeepLinkNotFound(false);
+      return;
+    }
     if (!serverDocuments) return; // wait for the catalogue to load
 
     const decodedDocId = decodeURIComponent(docId);
@@ -1397,14 +1485,19 @@ export function TakeoffPage() {
       ) ?? serverDocuments.find((d) => d.id === decodedDocId);
 
     if (match) {
+      if (
+        viewerDoc?.measurementDocumentId === match.id &&
+        viewerDoc.measurementDocumentSource === 'takeoff'
+      ) {
+        setDeepLinkNotFound(false);
+        setActiveTab('measurements');
+        return;
+      }
       setDeepLinkNotFound(false);
       setActiveDocId(match.id);
-      setViewerDoc({
-        url: `/api/v1/takeoff/documents/${match.id}/download/`,
-        name: match.filename,
-      });
+      setViewerDoc(makeTakeoffViewerDoc(match.id, match.filename));
       setActiveTab('measurements');
-    } else if (serverDocuments.length >= 0) {
+    } else {
       // Catalogue is loaded but no row matches — surface a friendly miss.
       setDeepLinkNotFound(true);
     }
@@ -1424,7 +1517,10 @@ export function TakeoffPage() {
         headers['Authorization'] = `Bearer ${token}`;
       }
 
-      const response = await fetch(`/api/v1/takeoff/documents/upload/`, {
+      const uploadUrl = selectedProjectId
+        ? `/api/v1/takeoff/documents/upload/?project_id=${encodeURIComponent(selectedProjectId)}`
+        : `/api/v1/takeoff/documents/upload/`;
+      const response = await fetch(uploadUrl, {
         method: 'POST',
         headers,
         body: formData,
@@ -1601,6 +1697,7 @@ export function TakeoffPage() {
         // Attempt to upload; on success replace the temp entry
         uploadMutation.mutate(file, {
           onSuccess: (data) => {
+            const filename = data.filename || file.name;
             setDocuments((prev) =>
               prev.map((d) =>
                 d.id === tempId
@@ -1609,20 +1706,25 @@ export function TakeoffPage() {
                       id: data.id,
                       pages: data.pages || d.pages,
                       size_bytes: data.size_bytes || d.size_bytes,
-                      filename: data.filename || d.filename,
+                      filename,
                       uploading: false,
                     }
                   : d,
               ),
             );
             setActiveDocId(data.id);
+            setViewerDoc(makeTakeoffViewerDoc(data.id, filename));
+            setActiveTab('measurements');
             // Persist the newly-opened document in the URL so reload keeps
             // it mounted (prevents the "uploaded project disappears on
             // refresh" bug — backend persistence was already fine).
             setSearchParams(
               (prev) => {
                 const next = new URLSearchParams(prev);
+                next.set('tab', 'measurements');
                 next.set('doc', data.id);
+                next.set('name', filename);
+                next.delete('source');
                 return next;
               },
               { replace: true },
@@ -1645,7 +1747,7 @@ export function TakeoffPage() {
         });
       }
     },
-    [uploadMutation, refetchServerDocuments],
+    [uploadMutation, refetchServerDocuments, setSearchParams],
   );
 
   const handleRemoveDocument = useCallback(
@@ -1841,10 +1943,7 @@ export function TakeoffPage() {
         return;
       }
       setActiveDocId(docId);
-      setViewerDoc({
-        url: `/api/v1/takeoff/documents/${docId}/download/`,
-        name: doc.filename,
-      });
+      setViewerDoc(makeTakeoffViewerDoc(docId, doc.filename));
       setActiveTab('measurements');
       // Pin the current doc to the URL so reload restores the viewer.
       setSearchParams(
@@ -1852,6 +1951,9 @@ export function TakeoffPage() {
           const next = new URLSearchParams(prev);
           next.set('doc', docId);
           next.set('tab', 'measurements');
+          next.delete('source');
+          next.delete('name');
+          next.delete('measurementId');
           return next;
         },
         { replace: true },
@@ -2304,9 +2406,13 @@ export function TakeoffPage() {
                 <TakeoffViewerModule
                   initialPdfUrl={viewerDoc?.url}
                   initialPdfName={viewerDoc?.name}
+                  initialMeasurementDocumentId={viewerDoc?.measurementDocumentId}
+                  initialMeasurementDocumentSource={viewerDoc?.measurementDocumentSource}
+                  initialTakeoffDocumentId={viewerDoc?.takeoffDocumentId}
                   initialMeasurementId={initialMeasurementId}
                   recentDocuments={serverDocuments}
                   onOpenRecentDocument={handleOpenDocInViewer}
+                  onUploadPdf={handleFilesSelected}
                 />
               </Suspense>
             )}

--- a/frontend/src/features/takeoff/__tests__/TakeoffPage.deepLink.test.tsx
+++ b/frontend/src/features/takeoff/__tests__/TakeoffPage.deepLink.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  apiGetMock,
+  listDocumentsMock,
+  searchParams,
+  setSearchParamsMock,
+} = vi.hoisted(() => ({
+  apiGetMock: vi.fn(),
+  listDocumentsMock: vi.fn(),
+  searchParams: new URLSearchParams('tab=measurements&doc=document-1&source=document'),
+  setSearchParamsMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => vi.fn(),
+    useParams: () => ({}),
+    useSearchParams: () => [searchParams, setSearchParamsMock],
+  };
+});
+
+vi.mock('@/shared/lib/api', () => ({
+  apiGet: apiGetMock,
+  apiPost: vi.fn(),
+}));
+
+vi.mock('@/features/ai/api', () => ({
+  aiApi: {
+    getSettings: vi.fn(async () => ({})),
+  },
+}));
+
+vi.mock('@/features/ai-estimator/useAiReadiness', () => ({
+  hasLlmKey: () => false,
+}));
+
+vi.mock('../api', () => ({
+  takeoffApi: {
+    listDocuments: listDocumentsMock,
+  },
+}));
+
+vi.mock('@/modules/pdf-takeoff/TakeoffViewerModule', () => ({
+  default: (props: {
+    initialMeasurementDocumentId?: string;
+    initialMeasurementDocumentSource?: string;
+  }) => (
+    <div
+      data-testid="takeoff-viewer"
+      data-document-id={props.initialMeasurementDocumentId}
+      data-document-source={props.initialMeasurementDocumentSource}
+    />
+  ),
+}));
+
+import { useProjectContextStore } from '@/stores/useProjectContextStore';
+import { TakeoffPage } from '../TakeoffPage';
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TakeoffPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('TakeoffPage Project Files deep links', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useProjectContextStore.getState().clearProject();
+    apiGetMock.mockReset();
+    listDocumentsMock.mockReset();
+    setSearchParamsMock.mockReset();
+    searchParams.set('tab', 'measurements');
+    searchParams.set('doc', 'document-1');
+    searchParams.set('source', 'document');
+    searchParams.delete('docId');
+    searchParams.delete('measurementId');
+    searchParams.delete('name');
+
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === '/v1/projects/') return [];
+      if (url === '/v1/documents/document-1') {
+        return {
+          id: 'document-1',
+          name: 'Plan.pdf',
+          filename: 'Plan.pdf',
+          project_id: 'project-1',
+          metadata: {},
+        };
+      }
+      if (url === '/v1/projects/project-1') {
+        return {
+          id: 'project-1',
+          name: 'Project One',
+          description: '',
+          classification_standard: '',
+        };
+      }
+      if (url.startsWith('/v1/boq/boqs/')) return [];
+      return [];
+    });
+    listDocumentsMock.mockResolvedValue([]);
+  });
+
+  it('restores project context before mounting a Project Files document deep link', async () => {
+    renderPage();
+
+    const viewer = await screen.findByTestId('takeoff-viewer');
+
+    expect(viewer).toHaveAttribute('data-document-id', 'document-1');
+    expect(viewer).toHaveAttribute('data-document-source', 'document');
+    await waitFor(() => {
+      const state = useProjectContextStore.getState();
+      expect(state.activeProjectId).toBe('project-1');
+      expect(state.activeProjectName).toBe('Project One');
+    });
+    expect(apiGetMock).toHaveBeenCalledWith('/v1/documents/document-1');
+    expect(apiGetMock).toHaveBeenCalledWith('/v1/projects/project-1');
+  });
+
+  it('does not treat a plain takeoff document restore URL as a Markups deep link miss', async () => {
+    searchParams.set('doc', 'takeoff-doc-1');
+    searchParams.delete('source');
+    listDocumentsMock.mockResolvedValue([
+      {
+        id: 'other-takeoff-doc',
+        filename: 'Other.pdf',
+      },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(listDocumentsMock).toHaveBeenCalled();
+    });
+    await expect(
+      screen.findByTestId('takeoff-deeplink-not-found', {}, { timeout: 100 }),
+    ).rejects.toThrow();
+  });
+
+  it('shows the Markups deep-link miss only when a measurement target is present', async () => {
+    searchParams.set('doc', 'missing-takeoff-doc');
+    searchParams.set('measurementId', 'measurement-1');
+    searchParams.delete('source');
+    listDocumentsMock.mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByTestId('takeoff-deeplink-not-found')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/takeoff/__tests__/takeoffRoutes.test.ts
+++ b/frontend/src/features/takeoff/__tests__/takeoffRoutes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProjectDocumentTakeoffUrl,
+  buildTakeoffMeasurementUrl,
+  parseMeasurementDocumentSource,
+  resolveProjectDocumentTakeoffTarget,
+} from '../takeoffRoutes';
+
+describe('takeoff measurement routes', () => {
+  it('routes ordinary Project Files PDFs with source=document and the Project Files UUID', () => {
+    const url = buildProjectDocumentTakeoffUrl({
+      id: 'project-file-doc-id',
+      name: 'abc.pdf',
+    });
+
+    expect(url).toBe('/takeoff?tab=measurements&doc=project-file-doc-id&source=document&name=abc.pdf');
+  });
+
+  it('routes Project Files mirrors back to the original Takeoff UUID namespace', () => {
+    const target = resolveProjectDocumentTakeoffTarget({
+      id: 'project-file-mirror-id',
+      name: 'takeoff-upload.pdf',
+      metadata: {
+        source_module: 'takeoff',
+        source_id: 'takeoff-doc-id',
+      },
+    });
+
+    expect(target).toEqual({
+      documentId: 'takeoff-doc-id',
+      documentName: 'takeoff-upload.pdf',
+      documentSource: 'takeoff',
+    });
+    expect(buildTakeoffMeasurementUrl(target)).toBe(
+      '/takeoff?tab=measurements&doc=takeoff-doc-id&name=takeoff-upload.pdf',
+    );
+  });
+
+  it('builds focused measurement links without the legacy focus parameter', () => {
+    expect(
+      buildTakeoffMeasurementUrl({
+        documentId: 'document-id',
+        documentSource: 'document',
+        measurementId: 'measurement-id',
+        page: 3,
+      }),
+    ).toBe('/takeoff?tab=measurements&doc=document-id&source=document&measurementId=measurement-id&page=3');
+  });
+
+  it('parses measurement document source metadata defensively', () => {
+    expect(parseMeasurementDocumentSource('document')).toBe('document');
+    expect(parseMeasurementDocumentSource('takeoff')).toBe('takeoff');
+    expect(parseMeasurementDocumentSource('other')).toBeNull();
+    expect(parseMeasurementDocumentSource(undefined)).toBeNull();
+  });
+});

--- a/frontend/src/features/takeoff/takeoffRoutes.ts
+++ b/frontend/src/features/takeoff/takeoffRoutes.ts
@@ -1,0 +1,60 @@
+export type MeasurementDocumentSource = 'takeoff' | 'document';
+
+export function parseMeasurementDocumentSource(value: unknown): MeasurementDocumentSource | null {
+  return value === 'document' || value === 'takeoff' ? value : null;
+}
+
+export interface TakeoffMeasurementTarget {
+  documentId?: string | null;
+  documentName?: string | null;
+  documentSource?: MeasurementDocumentSource | null;
+  measurementId?: string | null;
+  page?: number | null;
+}
+
+export interface ProjectDocumentTakeoffLink {
+  id: string;
+  name: string;
+  metadata?: {
+    source_module?: unknown;
+    source_id?: unknown;
+  } | null;
+}
+
+function cleanString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+export function resolveProjectDocumentTakeoffTarget(
+  doc: ProjectDocumentTakeoffLink,
+): TakeoffMeasurementTarget {
+  const sourceModule = cleanString(doc.metadata?.source_module);
+  const sourceId = cleanString(doc.metadata?.source_id);
+  if (sourceModule === 'takeoff' && sourceId) {
+    return {
+      documentId: sourceId,
+      documentName: doc.name,
+      documentSource: 'takeoff',
+    };
+  }
+  return {
+    documentId: doc.id,
+    documentName: doc.name,
+    documentSource: 'document',
+  };
+}
+
+export function buildTakeoffMeasurementUrl(target: TakeoffMeasurementTarget): string {
+  const params = new URLSearchParams();
+  params.set('tab', 'measurements');
+  if (target.documentId) params.set('doc', target.documentId);
+  if (target.documentSource === 'document') params.set('source', 'document');
+  if (target.documentName) params.set('name', target.documentName);
+  if (target.measurementId) params.set('measurementId', target.measurementId);
+  if (target.page) params.set('page', String(target.page));
+  return `/takeoff?${params.toString()}`;
+}
+
+export function buildProjectDocumentTakeoffUrl(doc: ProjectDocumentTakeoffLink): string {
+  return buildTakeoffMeasurementUrl(resolveProjectDocumentTakeoffTarget(doc));
+}

--- a/frontend/src/modules/pdf-takeoff/TakeoffViewerModule.tsx
+++ b/frontend/src/modules/pdf-takeoff/TakeoffViewerModule.tsx
@@ -66,6 +66,7 @@ import {
 import { apiGet, apiPost } from '../../shared/lib/api';
 import { formatFileSize } from '../../shared/lib/formatters';
 import { useMeasurementPersistence } from './useMeasurementPersistence';
+import type { MeasurementDocumentSource } from '@/features/takeoff/takeoffRoutes';
 import {
   type ScaleConfig,
   type CalibrationUnit,
@@ -291,8 +292,14 @@ export interface RecentTakeoffDocument {
 interface TakeoffViewerModuleProps {
   /** URL to pre-load a PDF from (e.g. `/api/v1/takeoff/documents/{id}/download/`). */
   initialPdfUrl?: string;
-  /** Optional filename to associate with the pre-loaded PDF (used for persistence key). */
+  /** Optional filename to display for the pre-loaded PDF. */
   initialPdfName?: string;
+  /** Stable measurement document id. Filename is display-only. */
+  initialMeasurementDocumentId?: string | null;
+  /** Source table for the stable measurement document id. */
+  initialMeasurementDocumentSource?: MeasurementDocumentSource | null;
+  /** Raw takeoff document id for takeoff-document-only operations such as AI plan read. */
+  initialTakeoffDocumentId?: string | null;
   /** Optional measurement id to auto-select + scroll-to once the measurement
    *  list lands (used by the /markups → /takeoff deep-link). Matches either
    *  the frontend id or the server-side UUID. */
@@ -302,14 +309,20 @@ interface TakeoffViewerModuleProps {
   recentDocuments?: RecentTakeoffDocument[];
   /** Open one of the recent documents in the viewer (parent owns navigation). */
   onOpenRecentDocument?: (docId: string) => void;
+  /** Persist newly-selected PDFs through the parent Takeoff upload flow. */
+  onUploadPdf?: (files: File[]) => void;
 }
 
 export default function TakeoffViewerModule({
   initialPdfUrl,
   initialPdfName,
+  initialMeasurementDocumentId,
+  initialMeasurementDocumentSource,
+  initialTakeoffDocumentId,
   initialMeasurementId,
   recentDocuments,
   onOpenRecentDocument,
+  onUploadPdf,
 }: TakeoffViewerModuleProps = {}) {
   const { t } = useTranslation();
 
@@ -496,7 +509,12 @@ export default function TakeoffViewerModule({
   const [bulkAddMeasurements, setBulkAddMeasurements] = useState<Measurement[] | null>(null);
 
   // Document persistence + server sync
-  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string | null>(initialPdfName ?? null);
+  const [measurementDocumentId, setMeasurementDocumentId] = useState<string | null>(
+    initialMeasurementDocumentId ?? null,
+  );
+  const [measurementDocumentSource, setMeasurementDocumentSource] =
+    useState<MeasurementDocumentSource | null>(initialMeasurementDocumentSource ?? null);
   // Per-page text-layer audit (8.2.0). When a document was opened from the
   // server we fetch its metadata to learn how many pages came back with no
   // text layer (likely scanned drawings that need OCR) so the viewer can flag
@@ -512,12 +530,14 @@ export default function TakeoffViewerModule({
   const [isExportingXlsx, setIsExportingXlsx] = useState(false);
   const { hasPersistedData, saveNow, clearPersisted, syncing, syncedToServer } = useMeasurementPersistence({
     fileName,
+    documentIdentity: measurementDocumentId,
+    documentSource: measurementDocumentSource,
     measurements,
-    setMeasurements: (ms) => setMeasurements(ms),
+    setMeasurements,
     // Per-page scale: the hook persists the whole page-scale model and
     // migrates a legacy single-scale document into the default on load.
     pageScales,
-    setPageScales: (ps) => setPageScales(ps),
+    setPageScales,
     // The current page's effective scale is still sent on each measurement
     // (scale_pixels_per_unit) so the server-side B8 recompute uses the same
     // ratio the row was drawn at.
@@ -556,6 +576,11 @@ export default function TakeoffViewerModule({
   const handleFileUpload = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    if (onUploadPdf) {
+      onUploadPdf([file]);
+      e.target.value = '';
+      return;
+    }
     setIsLoading(true);
     try {
       const arrayBuffer = await file.arrayBuffer();
@@ -563,7 +588,9 @@ export default function TakeoffViewerModule({
       setPdfDoc(doc);
       setTotalPages(doc.numPages);
       setCurrentPage(1);
-      setFileName(file.name); // Triggers persistence hook to load saved measurements
+      setFileName(file.name);
+      setMeasurementDocumentId(null);
+      setMeasurementDocumentSource(null);
       setActivePoints([]);
       undoStackRef.current = [];
       redoStackRef.current = [];
@@ -586,7 +613,26 @@ export default function TakeoffViewerModule({
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [addToast, onUploadPdf, t]);
+
+  const handleFilesDropped = useCallback((files: File[]) => {
+    const pdf = files.find((f) => f.type === 'application/pdf' || f.name.toLowerCase().endsWith('.pdf'));
+    if (!pdf) {
+      // Visible feedback so the user isn't left wondering why a non-PDF drop did nothing.
+      addToast({
+        type: 'warning',
+        title: t('takeoff.landing_drop_pdf_only_title', { defaultValue: 'PDF only' }),
+        message: t('takeoff.landing_drop_pdf_only_msg', { defaultValue: 'This viewer measures PDF drawings. Drop a PDF file to get started.' }),
+      });
+      return;
+    }
+    if (onUploadPdf) {
+      onUploadPdf([pdf]);
+      return;
+    }
+    const fakeEvent = { target: { files: [pdf], value: '' } } as unknown as React.ChangeEvent<HTMLInputElement>;
+    handleFileUpload(fakeEvent);
+  }, [addToast, handleFileUpload, onUploadPdf, t]);
 
   /* ── Reset cross-page in-progress state on page change ───────────
    * Without this, an in-progress drawing (one click placed) on page 1,
@@ -653,6 +699,8 @@ export default function TakeoffViewerModule({
         setTotalPages(doc.numPages);
         setCurrentPage(1);
         setFileName(initialPdfName || 'Document.pdf');
+        setMeasurementDocumentId(initialMeasurementDocumentId ?? null);
+        setMeasurementDocumentSource(initialMeasurementDocumentSource ?? null);
         setActivePoints([]);
         undoStackRef.current = [];
         redoStackRef.current = [];
@@ -679,7 +727,7 @@ export default function TakeoffViewerModule({
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialPdfUrl, initialPdfName]);
+  }, [initialPdfUrl, initialPdfName, initialMeasurementDocumentId, initialMeasurementDocumentSource]);
 
   /* ── Fetch server-side document metadata (text-layer audit) ───────── */
   // When a PDF is opened from the server (filmstrip / deep link) the URL is
@@ -690,14 +738,12 @@ export default function TakeoffViewerModule({
   useEffect(() => {
     setNoTextLayer(null);
     setNoTextBannerDismissed(false);
-    if (!initialPdfUrl) return;
-    const match = initialPdfUrl.match(/\/documents\/([^/?#]+)/);
-    const docId = match?.[1];
+    const docId = initialTakeoffDocumentId?.trim();
     if (!docId) return;
     let cancelled = false;
     (async () => {
       try {
-        const meta = await takeoffApi.getDocument(decodeURIComponent(docId));
+        const meta = await takeoffApi.getDocument(docId);
         if (cancelled || !meta) return;
         const count = meta.pages_without_text ?? 0;
         if (count > 0) {
@@ -708,7 +754,7 @@ export default function TakeoffViewerModule({
       }
     })();
     return () => { cancelled = true; };
-  }, [initialPdfUrl]);
+  }, [initialTakeoffDocumentId]);
 
   /* ── Warn on unsaved changes (tab close / navigation) ────────────── */
 
@@ -2593,7 +2639,7 @@ export default function TakeoffViewerModule({
     if (recognizeBusy) return;
     // The server reads the stored PDF off disk, so it needs the document's
     // id, which the deep-link download URL carries.
-    const docId = initialPdfUrl?.match(/\/documents\/([^/?#]+)\/(?:download|recognize)/)?.[1];
+    const docId = initialTakeoffDocumentId;
     if (!docId) {
       addToast({
         type: 'info',
@@ -2658,7 +2704,7 @@ export default function TakeoffViewerModule({
     } finally {
       setRecognizeBusy(false);
     }
-  }, [recognizeBusy, initialPdfUrl, currentPage, scale, activeGroup, nextAnnotation, addToast, t]);
+  }, [recognizeBusy, initialTakeoffDocumentId, currentPage, scale, activeGroup, nextAnnotation, addToast, t]);
 
   /* ── Read plan with AI: vision-LLM plan reading (issue #194) ────────────
    * The opt-in, bring-your-own-key, cost-capped complement to the offline
@@ -2700,7 +2746,7 @@ export default function TakeoffViewerModule({
    *  reviews and accepts (human-confirmed). Never auto-applies. */
   const handleReadWithAi = useCallback(async () => {
     if (planReadBusy) return;
-    const docId = initialPdfUrl?.match(/\/documents\/([^/?#]+)\/(?:download|recognize)/)?.[1];
+    const docId = initialTakeoffDocumentId;
     const projectId = selectedProjectId || activeProjectId || '';
     if (!docId || !projectId) {
       addToast({
@@ -2805,7 +2851,7 @@ export default function TakeoffViewerModule({
     }
   }, [
     planReadBusy,
-    initialPdfUrl,
+    initialTakeoffDocumentId,
     selectedProjectId,
     activeProjectId,
     currentPage,
@@ -3073,7 +3119,8 @@ export default function TakeoffViewerModule({
           ...existingMeta,
           pdf_measurement_source: sourceLabel,
           pdf_measurement_id: measurement.serverId ?? measurement.id,
-          pdf_document_id: fileName ?? undefined,
+          pdf_document_id: measurementDocumentId ?? undefined,
+          pdf_document_source: measurementDocumentSource ?? undefined,
           pdf_page: measurement.page,
         },
       });
@@ -3119,7 +3166,7 @@ export default function TakeoffViewerModule({
     } finally {
       setLinkingInProgress(false);
     }
-  }, [measurements, addToast, t, normalizeUnit, queryClient]);
+  }, [measurements, measurementDocumentId, measurementDocumentSource, addToast, t, normalizeUnit, queryClient]);
 
   /** Create a brand-new BOQ position from the measurement and link to it.
    *  The ordinal is auto-generated as TK.NNN based on existing TK positions.
@@ -3171,7 +3218,8 @@ export default function TakeoffViewerModule({
           metadata: {
             pdf_measurement_source: `Takeoff: ${measurement.annotation || measurement.type} (page ${measurement.page})`,
             pdf_measurement_id: measurement.serverId ?? measurement.id,
-            pdf_document_id: fileName ?? undefined,
+            pdf_document_id: measurementDocumentId ?? undefined,
+            pdf_document_source: measurementDocumentSource ?? undefined,
             pdf_page: measurement.page,
           },
         });
@@ -3217,7 +3265,17 @@ export default function TakeoffViewerModule({
     } finally {
       setLinkingInProgress(false);
     }
-  }, [measurements, linkPickerBoqId, linkBoqPositions, addToast, t, normalizeUnit, queryClient]);
+  }, [
+    measurements,
+    linkPickerBoqId,
+    linkBoqPositions,
+    measurementDocumentId,
+    measurementDocumentSource,
+    addToast,
+    t,
+    normalizeUnit,
+    queryClient,
+  ]);
 
   /** Remove the link between a measurement and its BOQ position.
    *  We intentionally leave the BOQ position alone — unlinking just
@@ -3367,7 +3425,8 @@ export default function TakeoffViewerModule({
           takeoff_raw_unit: m.unit,
           pdf_measurement_source: `Takeoff: ${m.annotation || m.type} (page ${m.page})`,
           pdf_measurement_id: m.serverId ?? m.id,
-          pdf_document_id: fileName ?? undefined,
+          pdf_document_id: measurementDocumentId ?? undefined,
+          pdf_document_source: measurementDocumentSource ?? undefined,
           pdf_page: m.page,
         },
       }));
@@ -3456,7 +3515,16 @@ export default function TakeoffViewerModule({
     } finally {
       setLinkingInProgress(false);
     }
-  }, [bulkAddMeasurements, linkPickerBoqId, normalizeUnit, fileName, addToast, t, queryClient]);
+  }, [
+    bulkAddMeasurements,
+    linkPickerBoqId,
+    normalizeUnit,
+    measurementDocumentId,
+    measurementDocumentSource,
+    addToast,
+    t,
+    queryClient,
+  ]);
 
   /* ── Undo ────────────────────────────────────────────────────────── */
 
@@ -3915,18 +3983,7 @@ export default function TakeoffViewerModule({
                       e.currentTarget.classList.remove('ring-2', 'ring-oe-blue/40');
                       const dropped = Array.from(e.dataTransfer.files);
                       if (dropped.length === 0) return;
-                      const pdf = dropped.find((f) => f.type === 'application/pdf' || f.name.toLowerCase().endsWith('.pdf'));
-                      if (pdf) {
-                        const fakeEvent = { target: { files: [pdf] } } as unknown as React.ChangeEvent<HTMLInputElement>;
-                        handleFileUpload(fakeEvent);
-                      } else {
-                        // Visible feedback so the user isn't left wondering why a non-PDF drop did nothing.
-                        addToast({
-                          type: 'warning',
-                          title: t('takeoff.landing_drop_pdf_only_title', { defaultValue: 'PDF only' }),
-                          message: t('takeoff.landing_drop_pdf_only_msg', { defaultValue: 'This viewer measures PDF drawings. Drop a PDF file to get started.' }),
-                        });
-                      }
+                      handleFilesDropped(dropped);
                     }}
                     className="group/drop flex flex-col items-center justify-center gap-3 rounded-xl p-6 text-center cursor-pointer transition-all flex-1 border-2 border-dashed border-border-medium bg-gradient-to-br from-blue-50/60 via-white to-violet-50/40 dark:from-blue-950/20 dark:via-gray-800/40 dark:to-violet-950/20 hover:border-oe-blue/50 hover:shadow-md"
                   >

--- a/frontend/src/modules/pdf-takeoff/useMeasurementPersistence.test.ts
+++ b/frontend/src/modules/pdf-takeoff/useMeasurementPersistence.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { takeoffApi, type MeasurementResponse } from '@/features/takeoff/api';
 import {
   useMeasurementPersistence,
   getDocumentIndex,
@@ -18,6 +19,33 @@ const makeMeasurement = (id: string, page = 1) => ({
   annotation: `Distance ${id}`,
   page,
   group: 'General',
+});
+
+const serverMeasurement = (
+  overrides: Partial<MeasurementResponse> = {},
+): MeasurementResponse => ({
+  id: 'server-m1',
+  project_id: 'project-a',
+  document_id: 'doc-123',
+  page: 1,
+  type: 'distance',
+  group_name: 'General',
+  group_color: '#3B82F6',
+  annotation: 'Distance m1',
+  points: [{ x: 0, y: 0 }, { x: 100, y: 0 }],
+  measurement_value: 2.5,
+  measurement_unit: 'm',
+  depth: null,
+  volume: null,
+  perimeter: null,
+  count_value: null,
+  scale_pixels_per_unit: 100,
+  linked_boq_position_id: null,
+  metadata: { frontend_id: 'm1' },
+  created_by: 'user-1',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
 });
 
 const defaultScale = { pixelsPerUnit: 100, unitLabel: 'm' };
@@ -52,6 +80,7 @@ describe('useMeasurementPersistence', () => {
     const { result } = renderHook(() =>
       useMeasurementPersistence({
         fileName: 'test.pdf',
+        documentIdentity: 'doc-test',
         measurements: [m1],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -65,7 +94,7 @@ describe('useMeasurementPersistence', () => {
     });
 
     // Check localStorage contains the data
-    const raw = localStorage.getItem('oe_takeoff_test.pdf');
+    const raw = localStorage.getItem('oe_takeoff_p_local__doc-test');
     expect(raw).toBeTruthy();
     const parsed = JSON.parse(raw!);
     expect(parsed.measurements).toHaveLength(1);
@@ -81,16 +110,17 @@ describe('useMeasurementPersistence', () => {
     const m1 = makeMeasurement('m1');
     const savedScale = { pixelsPerUnit: 50, unitLabel: 'm' };
     localStorage.setItem(
-      'oe_takeoff_plan.pdf',
+      'oe_takeoff_p_local__doc-plan',
       JSON.stringify({ measurements: [m1], scale: savedScale, savedAt: Date.now() }),
     );
-    localStorage.setItem('oe_takeoff_index', JSON.stringify(['plan.pdf']));
+    localStorage.setItem('oe_takeoff_index', JSON.stringify(['oe_takeoff_p_local__doc-plan']));
 
     const setM = vi.fn();
     const setPS = vi.fn();
     renderHook(() =>
       useMeasurementPersistence({
         fileName: 'plan.pdf',
+        documentIdentity: 'doc-plan',
         measurements: [],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -114,16 +144,17 @@ describe('useMeasurementPersistence', () => {
       byPage: { 3: { pixelsPerUnit: 25, unitLabel: 'm' } },
     };
     localStorage.setItem(
-      'oe_takeoff_multi.pdf',
+      'oe_takeoff_p_local__doc-multi',
       JSON.stringify({ measurements: [m1], pageScales, scale: defaultScale, savedAt: Date.now() }),
     );
-    localStorage.setItem('oe_takeoff_index', JSON.stringify(['multi.pdf']));
+    localStorage.setItem('oe_takeoff_index', JSON.stringify(['oe_takeoff_p_local__doc-multi']));
 
     const setM = vi.fn();
     const setPS = vi.fn();
     renderHook(() =>
       useMeasurementPersistence({
         fileName: 'multi.pdf',
+        documentIdentity: 'doc-multi',
         measurements: [],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -142,14 +173,15 @@ describe('useMeasurementPersistence', () => {
     const setPS = vi.fn();
     // Save first
     localStorage.setItem(
-      'oe_takeoff_test.pdf',
+      'oe_takeoff_p_local__doc-test',
       JSON.stringify({ measurements: [], scale: defaultScale, savedAt: Date.now() }),
     );
-    localStorage.setItem('oe_takeoff_index', JSON.stringify(['test.pdf']));
+    localStorage.setItem('oe_takeoff_index', JSON.stringify(['oe_takeoff_p_local__doc-test']));
 
     const { result } = renderHook(() =>
       useMeasurementPersistence({
         fileName: 'test.pdf',
+        documentIdentity: 'doc-test',
         measurements: [],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -162,8 +194,8 @@ describe('useMeasurementPersistence', () => {
       result.current.clearPersisted();
     });
 
-    expect(localStorage.getItem('oe_takeoff_test.pdf')).toBeNull();
-    expect(getDocumentIndex()).not.toContain('test.pdf');
+    expect(localStorage.getItem('oe_takeoff_p_local__doc-test')).toBeNull();
+    expect(getDocumentIndex()).not.toContain('oe_takeoff_p_local__doc-test');
   });
 
   it('getDocumentIndex returns list of saved documents', () => {
@@ -174,17 +206,16 @@ describe('useMeasurementPersistence', () => {
   });
 
   it('removeFromStorage removes a specific document', () => {
-    localStorage.setItem('oe_takeoff_doc.pdf', '{}');
-    localStorage.setItem('oe_takeoff_index', JSON.stringify(['doc.pdf', 'other.pdf']));
+    localStorage.setItem('oe_takeoff_p_local__doc-id', '{}');
+    localStorage.setItem('oe_takeoff_index', JSON.stringify(['oe_takeoff_p_local__doc-id', 'other.pdf']));
 
-    removeFromStorage('doc.pdf');
+    removeFromStorage(null, 'doc-id');
 
-    expect(localStorage.getItem('oe_takeoff_doc.pdf')).toBeNull();
+    expect(localStorage.getItem('oe_takeoff_p_local__doc-id')).toBeNull();
     expect(getDocumentIndex()).toEqual(['other.pdf']);
   });
 
-  it('auto-saves on measurement changes (debounced)', async () => {
-    vi.useFakeTimers();
+  it('auto-saves measurement changes immediately for reload safety', () => {
     const m1 = makeMeasurement('m1');
     const setM = vi.fn();
     const setPS = vi.fn();
@@ -192,6 +223,7 @@ describe('useMeasurementPersistence', () => {
     renderHook(() =>
       useMeasurementPersistence({
         fileName: 'auto.pdf',
+        documentIdentity: 'doc-auto',
         measurements: [m1],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -200,17 +232,144 @@ describe('useMeasurementPersistence', () => {
       }),
     );
 
-    // Before debounce
-    expect(localStorage.getItem('oe_takeoff_auto.pdf')).toBeNull();
+    const raw = localStorage.getItem('oe_takeoff_p_local__doc-auto');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!).measurements).toHaveLength(1);
+  });
 
-    // After 500ms debounce
-    vi.advanceTimersByTime(600);
-    const raw = localStorage.getItem('oe_takeoff_auto.pdf');
+  it('saves drawn measurements before server hydration finishes', () => {
+    const list = vi.spyOn(takeoffApi, 'list').mockReturnValue(new Promise<never>(() => {}));
+    const m1 = makeMeasurement('m1');
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'pending.pdf',
+        documentIdentity: 'doc-pending',
+        measurements: [m1],
+        setMeasurements: vi.fn(),
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    const raw = localStorage.getItem('oe_takeoff_p_project-a__doc-pending');
     expect(raw).toBeTruthy();
     expect(JSON.parse(raw!).measurements).toHaveLength(1);
 
-    vi.useRealTimers();
+    list.mockRestore();
   });
+
+  it('does not overwrite existing local data with an empty pre-hydration state', () => {
+    const list = vi.spyOn(takeoffApi, 'list').mockReturnValue(new Promise<never>(() => {}));
+    const m1 = makeMeasurement('m1');
+    localStorage.setItem(
+      'oe_takeoff_p_project-a__doc-pending',
+      JSON.stringify({ measurements: [m1], scale: defaultScale, savedAt: Date.now() }),
+    );
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'pending.pdf',
+        documentIdentity: 'doc-pending',
+        measurements: [],
+        setMeasurements: vi.fn(),
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    const raw = localStorage.getItem('oe_takeoff_p_project-a__doc-pending');
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!).measurements).toHaveLength(1);
+
+    list.mockRestore();
+  });
+
+  it('hydrates server rows plus unsynced local rows after a partial server sync', async () => {
+    const localM1 = makeMeasurement('m1');
+    const localM2 = makeMeasurement('m2');
+    localStorage.setItem(
+      'oe_takeoff_p_project-a__doc-partial',
+      JSON.stringify({
+        measurements: [localM1, localM2],
+        scale: defaultScale,
+        pageScales: basePageScales,
+        savedAt: Date.now(),
+      }),
+    );
+    const list = vi.spyOn(takeoffApi, 'list').mockResolvedValue([
+      serverMeasurement({ document_id: 'doc-partial', points: localM1.points }),
+    ]);
+    const setM = vi.fn();
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'partial.pdf',
+        documentIdentity: 'doc-partial',
+        measurements: [],
+        setMeasurements: setM,
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    await waitFor(() => {
+      const lastCall = setM.mock.calls.at(-1)?.[0];
+      expect(lastCall).toHaveLength(2);
+      expect(lastCall.map((m: { id: string }) => m.id)).toEqual(['m1', 'm2']);
+      expect(lastCall[0]!.serverId).toBe('server-m1');
+      expect(lastCall[1]!.serverId).toBeUndefined();
+    });
+
+    list.mockRestore();
+  });
+
+  it('discards local measurements that have a serverId but are missing from the server', async () => {
+    const localM1 = makeMeasurement('m1');
+    const localM2 = { ...makeMeasurement('m2'), serverId: 'server-m2' };
+    localStorage.setItem(
+      'oe_takeoff_p_project-a__doc-deleted',
+      JSON.stringify({
+        measurements: [localM1, localM2],
+        scale: defaultScale,
+        pageScales: basePageScales,
+        savedAt: Date.now(),
+      }),
+    );
+    const list = vi.spyOn(takeoffApi, 'list').mockResolvedValue([
+      serverMeasurement({ document_id: 'doc-deleted', points: localM1.points }),
+    ]);
+    const setM = vi.fn();
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'deleted.pdf',
+        documentIdentity: 'doc-deleted',
+        measurements: [],
+        setMeasurements: setM,
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    await waitFor(() => {
+      const lastCall = setM.mock.calls.at(-1)?.[0];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0]!.id).toBe('m1');
+      expect(lastCall[0]!.serverId).toBe('server-m1');
+    });
+
+    list.mockRestore();
+  });
+
 
   it('savedDocumentCount reflects storage index size', () => {
     localStorage.setItem('oe_takeoff_index', JSON.stringify(['a.pdf', 'b.pdf', 'c.pdf']));
@@ -232,14 +391,15 @@ describe('useMeasurementPersistence', () => {
   });
 
   it('handles corrupt localStorage gracefully', () => {
-    localStorage.setItem('oe_takeoff_bad.pdf', '{invalid json');
-    localStorage.setItem('oe_takeoff_index', JSON.stringify(['bad.pdf']));
+    localStorage.setItem('oe_takeoff_p_local__doc-bad', '{invalid json');
+    localStorage.setItem('oe_takeoff_index', JSON.stringify(['oe_takeoff_p_local__doc-bad']));
 
     const setM = vi.fn();
     const setPS = vi.fn();
     renderHook(() =>
       useMeasurementPersistence({
         fileName: 'bad.pdf',
+        documentIdentity: 'doc-bad',
         measurements: [],
         setMeasurements: setM,
         pageScales: basePageScales,
@@ -248,7 +408,383 @@ describe('useMeasurementPersistence', () => {
       }),
     );
 
-    // Should not call setMeasurements with corrupt data
-    expect(setM).not.toHaveBeenCalled();
+    // Corrupt data is ignored, but the hook still clears any stale in-memory
+    // measurements before attempting to hydrate the new document scope.
+    expect(setM).toHaveBeenCalledWith([]);
+  });
+
+  it('stores stable document identities under project-scoped localStorage keys', () => {
+    const m1 = makeMeasurement('m1');
+    const setM = vi.fn();
+    const setPS = vi.fn();
+    const { result } = renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'abc.pdf',
+        documentIdentity: 'doc-123',
+        measurements: [m1],
+        setMeasurements: setM,
+        pageScales: basePageScales,
+        setPageScales: setPS,
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    act(() => {
+      result.current.saveNow();
+    });
+
+    expect(localStorage.getItem('oe_takeoff_p_project-a__doc-123')).toBeTruthy();
+    expect(localStorage.getItem('oe_takeoff_abc.pdf')).toBeNull();
+  });
+
+  it('persists local-only uploads locally without server-syncing them', async () => {
+    vi.useFakeTimers();
+    const bulkCreate = vi.spyOn(takeoffApi, 'bulkCreate').mockResolvedValue([]);
+    const m1 = makeMeasurement('m1');
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'abc.pdf',
+        documentIdentity: null,
+        measurements: [m1],
+        setMeasurements: vi.fn(),
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3500);
+    });
+
+    expect(localStorage.getItem('oe_takeoff_p_project-a__abc.pdf')).toBeTruthy();
+    expect(bulkCreate).not.toHaveBeenCalled();
+    vi.useRealTimers();
+    bulkCreate.mockRestore();
+  });
+
+  it('persists local-only uploads (no stable identity) to localStorage under fileName-keyed slot', () => {
+    const m1 = makeMeasurement('m1');
+    const setM = vi.fn();
+    const setPS = vi.fn();
+
+    const { result } = renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'abc.pdf',
+        documentIdentity: null,
+        measurements: [m1],
+        setMeasurements: setM,
+        pageScales: basePageScales,
+        setPageScales: setPS,
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    act(() => {
+      result.current.saveNow();
+    });
+
+    expect(localStorage.getItem('oe_takeoff_p_project-a__abc.pdf')).toBeTruthy();
+  });
+
+  it('server-syncs new measurements with the stable document identity, not the filename', async () => {
+    vi.useFakeTimers();
+    const list = vi.spyOn(takeoffApi, 'list').mockResolvedValue([]);
+    const bulkCreate = vi.spyOn(takeoffApi, 'bulkCreate').mockResolvedValue([]);
+    const m1 = makeMeasurement('m1');
+
+    renderHook(() =>
+      useMeasurementPersistence({
+        fileName: 'abc.pdf',
+        documentIdentity: 'doc-123',
+        measurements: [m1],
+        setMeasurements: vi.fn(),
+        pageScales: basePageScales,
+        setPageScales: vi.fn(),
+        scale: defaultScale,
+        projectId: 'project-a',
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(list).toHaveBeenCalledWith('project-a', 'doc-123');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3500);
+    });
+
+    expect(bulkCreate).toHaveBeenCalled();
+    expect(bulkCreate.mock.calls[0]![0][0]!.document_id).toBe('doc-123');
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not leak measurements to the new document key on document switch', () => {
+    const m1 = makeMeasurement('m1');
+    const setM = vi.fn();
+    const setPS = vi.fn();
+
+    const { rerender } = renderHook(
+      (props) =>
+        useMeasurementPersistence({
+          fileName: props.fileName,
+          documentIdentity: props.documentIdentity,
+          measurements: props.measurements,
+          setMeasurements: setM,
+          pageScales: basePageScales,
+          setPageScales: setPS,
+          scale: defaultScale,
+          projectId: 'project-a',
+        }),
+      {
+        initialProps: {
+          fileName: 'docA.pdf',
+          documentIdentity: 'doc-A',
+          measurements: [m1],
+        },
+      },
+    );
+
+    expect(localStorage.getItem('oe_takeoff_p_project-a__doc-A')).toBeTruthy();
+    expect(localStorage.getItem('oe_takeoff_p_project-a__doc-B')).toBeNull();
+
+    act(() => {
+      rerender({
+        fileName: 'docB.pdf',
+        documentIdentity: 'doc-B',
+        measurements: [m1],
+      });
+    });
+
+    expect(localStorage.getItem('oe_takeoff_p_project-a__doc-B')).toBeNull();
+  });
+
+  it('does not send duplicate bulk-create requests for in-flight measurements', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(takeoffApi, 'list').mockResolvedValue([]);
+
+    let resolveBulkCreate: (val: any) => void = () => {};
+    const bulkCreatePromise = new Promise<any[]>((resolve) => {
+      resolveBulkCreate = resolve;
+    });
+    const bulkCreate = vi.spyOn(takeoffApi, 'bulkCreate').mockReturnValue(bulkCreatePromise as any);
+
+    const m1 = makeMeasurement('m1');
+    const setM = vi.fn();
+
+    const { rerender } = renderHook(
+      (props) =>
+        useMeasurementPersistence({
+          fileName: 'abc.pdf',
+          documentIdentity: 'doc-123',
+          measurements: props.measurements,
+          setMeasurements: setM,
+          pageScales: basePageScales,
+          setPageScales: vi.fn(),
+          scale: defaultScale,
+          projectId: 'project-a',
+        }),
+      {
+        initialProps: {
+          measurements: [m1],
+        },
+      },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3500);
+    });
+
+    expect(bulkCreate).toHaveBeenCalledTimes(1);
+
+    const m2 = makeMeasurement('m2');
+    act(() => {
+      rerender({ measurements: [m1, m2] });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3500);
+    });
+
+    expect(bulkCreate).toHaveBeenCalledTimes(2);
+    const secondCall = bulkCreate.mock.calls[1];
+    expect(secondCall).toBeDefined();
+    expect(secondCall![0]).toHaveLength(1);
+    expect(secondCall![0]![0]!.metadata?.frontend_id).toBe('m2');
+
+    resolveBulkCreate([{ id: 'server-m1', metadata: { frontend_id: 'm1' } }]);
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sends a PATCH request when a synced measurement is reshaped', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(takeoffApi, 'list').mockResolvedValue([]);
+    const update = vi.spyOn(takeoffApi, 'update').mockResolvedValue({
+      id: 'server-m1',
+      measurement_value: 5.0,
+      metadata: { frontend_id: 'm1' },
+    } as any);
+
+    const m1 = { ...makeMeasurement('m1'), serverId: 'server-m1' };
+    const setM = vi.fn();
+
+    const { rerender } = renderHook(
+      (props) =>
+        useMeasurementPersistence({
+          fileName: 'abc.pdf',
+          documentIdentity: 'doc-123',
+          measurements: props.measurements,
+          setMeasurements: setM,
+          pageScales: basePageScales,
+          setPageScales: vi.fn(),
+          scale: defaultScale,
+          projectId: 'project-a',
+        }),
+      {
+        initialProps: {
+          measurements: [m1],
+        },
+      },
+    );
+
+    // Run effect to seed baseline
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Change geometry of m1
+    const m1Reshaped = {
+      ...m1,
+      points: [{ x: 0, y: 0 }, { x: 200, y: 0 }],
+      value: 5.0,
+    };
+
+    act(() => {
+      rerender({ measurements: [m1Reshaped] });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(update).toHaveBeenCalledWith('server-m1', expect.objectContaining({
+      points: m1Reshaped.points,
+    }));
+
+    expect(setM).toHaveBeenCalled();
+    const lastCall = setM.mock.calls.at(-1)?.[0];
+    expect(typeof lastCall).toBe('function');
+    const nextState = lastCall([m1Reshaped]);
+    expect(nextState[0]).toEqual(expect.objectContaining({
+      id: 'm1',
+      value: 5.0,
+    }));
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('does not lose concurrently added/edited measurements when a reshape PATCH resolves', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(takeoffApi, 'list').mockResolvedValue([]);
+
+    let resolveUpdate: (val: any) => void = () => {};
+    const updatePromise = new Promise<any>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    const update = vi.spyOn(takeoffApi, 'update').mockReturnValue(updatePromise);
+
+    const m1 = { ...makeMeasurement('m1'), serverId: 'server-m1' };
+    const setM = vi.fn();
+
+    const { rerender } = renderHook(
+      (props) =>
+        useMeasurementPersistence({
+          fileName: 'abc.pdf',
+          documentIdentity: 'doc-123',
+          measurements: props.measurements,
+          setMeasurements: setM,
+          pageScales: basePageScales,
+          setPageScales: vi.fn(),
+          scale: defaultScale,
+          projectId: 'project-a',
+        }),
+      {
+        initialProps: {
+          measurements: [m1] as any[],
+        },
+      },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Reshape m1
+    const m1Reshaped = {
+      ...m1,
+      points: [{ x: 0, y: 0 }, { x: 200, y: 0 }],
+      value: 5.0,
+    };
+
+    act(() => {
+      rerender({ measurements: [m1Reshaped] });
+    });
+
+    // Advance to fire the patch effect timer, but don't resolve the promise yet
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+
+    // Concurrently add a new measurement m2 while the update is in flight
+    const m2 = makeMeasurement('m2');
+    act(() => {
+      rerender({ measurements: [m1Reshaped, m2] });
+    });
+
+    // Now resolve the PATCH update
+    await act(async () => {
+      resolveUpdate({
+        id: 'server-m1',
+        measurement_value: 5.0,
+        metadata: { frontend_id: 'm1' },
+      });
+      await Promise.resolve();
+    });
+
+    // setM should be called with both measurements, updating m1's value but retaining m2
+    expect(setM).toHaveBeenCalled();
+    const lastCall = setM.mock.calls.at(-1)?.[0];
+
+    // It should be a function (functional updater) because we fixed the stale closure!
+    expect(typeof lastCall).toBe('function');
+
+    const nextState = lastCall([m1Reshaped, m2]);
+    expect(nextState).toHaveLength(2);
+    expect(nextState[0].id).toBe('m1');
+    expect(nextState[0].value).toBe(5.0);
+    expect(nextState[1].id).toBe('m2'); // m2 is preserved!
+
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 });

--- a/frontend/src/modules/pdf-takeoff/useMeasurementPersistence.ts
+++ b/frontend/src/modules/pdf-takeoff/useMeasurementPersistence.ts
@@ -1,6 +1,7 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { QueryClientContext } from '@tanstack/react-query';
 import { takeoffApi, type MeasurementCreate, type MeasurementResponse } from '@/features/takeoff/api';
+import type { MeasurementDocumentSource } from '@/features/takeoff/takeoffRoutes';
 import {
   type PageScales,
   hydratePageScales,
@@ -69,13 +70,24 @@ interface PersistedDocument {
 const STORAGE_PREFIX = 'oe_takeoff_';
 const INDEX_KEY = 'oe_takeoff_index';
 
-function docKey(fileName: string): string {
-  return `${STORAGE_PREFIX}${fileName.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+function sanitizeKeyPart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
 }
 
-function loadFromStorage(fileName: string): PersistedDocument | null {
+function docKey(projectId: string | null | undefined, documentId: string): string {
+  return `${STORAGE_PREFIX}p_${sanitizeKeyPart(projectId || 'local')}__${sanitizeKeyPart(documentId)}`;
+}
+
+function legacyDocKey(fileName: string): string {
+  return `${STORAGE_PREFIX}${sanitizeKeyPart(fileName)}`;
+}
+
+function loadFromStorage(
+  projectId: string | null | undefined,
+  documentId: string,
+): PersistedDocument | null {
   try {
-    const raw = localStorage.getItem(docKey(fileName));
+    const raw = localStorage.getItem(docKey(projectId, documentId));
     if (!raw) return null;
     return JSON.parse(raw) as PersistedDocument;
   } catch {
@@ -83,23 +95,41 @@ function loadFromStorage(fileName: string): PersistedDocument | null {
   }
 }
 
-function saveToStorage(fileName: string, data: PersistedDocument): void {
+function saveToStorage(
+  projectId: string | null | undefined,
+  documentId: string,
+  data: PersistedDocument,
+): boolean {
   try {
-    localStorage.setItem(docKey(fileName), JSON.stringify(data));
+    const key = docKey(projectId, documentId);
+    localStorage.setItem(key, JSON.stringify(data));
     const index = getDocumentIndex();
-    if (!index.includes(fileName)) {
-      index.push(fileName);
+    if (!index.includes(key)) {
+      index.push(key);
       localStorage.setItem(INDEX_KEY, JSON.stringify(index));
     }
+    return true;
   } catch {
     // localStorage full — silently fail
+    return false;
   }
 }
 
-export function removeFromStorage(fileName: string): void {
+export function removeFromStorage(
+  projectId: string | null | undefined,
+  documentId: string,
+  fileName?: string | null,
+): void {
   try {
-    localStorage.removeItem(docKey(fileName));
-    const index = getDocumentIndex().filter((n) => n !== fileName);
+    const key = docKey(projectId, documentId);
+    localStorage.removeItem(key);
+    if (fileName) {
+      localStorage.removeItem(legacyDocKey(fileName));
+    }
+    const legacyKey = fileName ? legacyDocKey(fileName) : null;
+    const index = getDocumentIndex().filter(
+      (n) => n !== key && (!legacyKey || n !== legacyKey),
+    );
     localStorage.setItem(INDEX_KEY, JSON.stringify(index));
   } catch {
     // ignore
@@ -163,6 +193,7 @@ function toApiFormat(
   projectId: string,
   documentId: string,
   pageScales?: PageScales,
+  documentSource?: MeasurementDocumentSource | null,
 ): MeasurementCreate {
   // Area measurements carry the polygon area in `m.value`; volume
   // measurements carry the area separately in `m.area`. Persist the
@@ -209,6 +240,7 @@ function toApiFormat(
       linked_boq_id: m.linkedBoqId,
       linked_position_ordinal: m.linkedPositionOrdinal,
       linked_position_label: m.linkedPositionLabel,
+      document_source: documentSource ?? undefined,
     },
   };
 }
@@ -318,8 +350,12 @@ function pageScalesFromServer(rows: MeasurementResponse[]): PageScales | null {
 
 interface UseMeasurementPersistenceOptions {
   fileName: string | null;
+  documentIdentity?: string | null;
+  documentSource?: MeasurementDocumentSource | null;
   measurements: Measurement[];
-  setMeasurements: (measurements: Measurement[]) => void;
+  setMeasurements: (
+    measurements: Measurement[] | ((prev: Measurement[]) => Measurement[]),
+  ) => void;
   /** Per-page (per-sheet) scale model. Persisted whole; a legacy
    *  single-scale document is migrated into the default on load. */
   pageScales: PageScales;
@@ -345,6 +381,8 @@ interface UseMeasurementPersistenceResult {
 
 export function useMeasurementPersistence({
   fileName,
+  documentIdentity,
+  documentSource,
   measurements,
   setMeasurements,
   pageScales,
@@ -353,8 +391,9 @@ export function useMeasurementPersistence({
   projectId,
 }: UseMeasurementPersistenceOptions): UseMeasurementPersistenceResult {
   const hasPersistedRef = useRef(false);
-  const lastFileRef = useRef<string | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastScopeRef = useRef<string | null>(null);
+  const lastLocalSaveSignatureRef = useRef<string | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
   const [syncing, setSyncing] = useState(false);
   const [syncedToServer, setSyncedToServer] = useState(false);
   const serverSyncRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -366,24 +405,61 @@ export function useMeasurementPersistence({
   const geometrySigRef = useRef<Map<string, string>>(new Map());
   const patchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const inFlightPatchRef = useRef<Set<string>>(new Set());
+  const inFlightSyncRef = useRef<Set<string>>(new Set());
   // Read the QueryClient directly from context — ``useContext`` returns
   // ``undefined`` instead of throwing when the provider is absent (e.g. in
   // unit tests that render the hook in isolation). When present, we use
   // it to broadcast a refresh to the unified Markups hub.
   const qc = useContext(QueryClientContext);
 
-  // Load persisted data when file name changes — try server first, fallback to localStorage
+  // Load persisted data when the stable document id or local filename changes.
+  // Server sync uses only stable document ids; localStorage also supports a
+  // filename fallback so local-only PDFs survive remounts without leaking into
+  // the backend measurement namespace.
   useEffect(() => {
-    if (!fileName || fileName === lastFileRef.current) return;
-    lastFileRef.current = fileName;
+    const documentId = documentIdentity?.trim() || fileName?.trim() || null;
+    if (!documentId) {
+      setMeasurements([]);
+      hasPersistedRef.current = false;
+      setSyncedToServer(false);
+      setIsHydrated(false);
+      lastScopeRef.current = null;
+      lastLocalSaveSignatureRef.current = null;
+      inFlightSyncRef.current = new Set();
+      return;
+    }
+    const stableDocumentId = documentId;
+    const stableProjectId = projectId || undefined;
+    const scopeKey = `${stableProjectId || 'local'}:${stableDocumentId}`;
+    if (scopeKey === lastScopeRef.current) return;
+    lastScopeRef.current = scopeKey;
+    setSyncedToServer(false);
+    setIsHydrated(false);
+    lastLocalSaveSignatureRef.current = null;
+    geometrySigRef.current = new Map();
+    inFlightSyncRef.current = new Set();
+    setMeasurements([]);
 
     let cancelled = false;
 
     async function loadData() {
-      // Try server first if project is available
-      if (projectId) {
+      const loadLocalData = (): PersistedDocument | null => {
+        let data = loadFromStorage(stableProjectId, stableDocumentId);
+        if (!data && !stableProjectId && fileName) {
+          try {
+            const raw = localStorage.getItem(legacyDocKey(fileName));
+            data = raw ? (JSON.parse(raw) as PersistedDocument) : null;
+          } catch {
+            data = null;
+          }
+        }
+        return data;
+      };
+
+      // Try server first only when the document has a database identity.
+      if (stableProjectId && documentIdentity?.trim()) {
         try {
-          const serverData = await takeoffApi.list(projectId, fileName ?? undefined);
+          const serverData = await takeoffApi.list(stableProjectId, stableDocumentId);
           if (!cancelled && serverData.length > 0) {
             hasPersistedRef.current = true;
             setSyncedToServer(true);
@@ -395,13 +471,32 @@ export function useMeasurementPersistence({
                 .filter((m) => m.serverId)
                 .map((m) => [m.serverId as string, geometrySignature(m)]),
             );
-            // Reconstruct the per-page scale from the per-measurement ratios
-            // the server stored. The localStorage copy (set below on next
-            // save) is authoritative when present, but for a project loaded
-            // on a fresh device this is the only place the calibration lives.
+            const localData = loadLocalData();
+            const serverIds = new Set(
+              mapped.flatMap((m) => [m.id, m.serverId].filter((id): id is string => Boolean(id))),
+            );
+            // Keep server rows authoritative once they exist, but preserve
+            // local-only rows that were drawn before the debounced server sync
+            // completed. Otherwise a fast reload after two measurements can
+            // hydrate from a one-row server response and overwrite the still
+            // richer local fallback.
+            const unsyncedLocal = (localData?.measurements ?? [])
+              .filter((m) => !m.suggested)
+              .filter((m) => {
+                if (m.serverId) return false; // Synced but missing from server = deleted
+                return !serverIds.has(m.id);
+              });
+            // Reconstruct the per-page scale from localStorage when present;
+            // otherwise fall back to per-measurement ratios stored by the
+            // server for a fresh browser/device.
             const fromServer = pageScalesFromServer(serverData);
-            if (fromServer) setPageScales(fromServer);
-            setMeasurements(mapped);
+            if (localData) {
+              setPageScales(hydratePageScales(localData.pageScales, localData.scale));
+            } else if (fromServer) {
+              setPageScales(fromServer);
+            }
+            setMeasurements([...mapped, ...unsyncedLocal]);
+            setIsHydrated(true);
             return;
           }
         } catch {
@@ -411,7 +506,7 @@ export function useMeasurementPersistence({
 
       // Fallback to localStorage
       if (!cancelled) {
-        const data = loadFromStorage(fileName!);
+        const data = loadLocalData();
         if (data) {
           hasPersistedRef.current = true;
           setMeasurements(data.measurements);
@@ -423,82 +518,135 @@ export function useMeasurementPersistence({
         } else {
           hasPersistedRef.current = false;
         }
+        setIsHydrated(true);
       }
     }
 
     loadData();
     return () => { cancelled = true; };
-  }, [fileName, projectId, setMeasurements, setPageScales]);
+  }, [documentIdentity, fileName, projectId, setMeasurements, setPageScales]);
 
-  // Auto-save to localStorage with debounce (500ms)
-  useEffect(() => {
-    if (!fileName) return;
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      // Never persist AI suggestions: only confirmed measurements are saved.
-      // Persist BOTH the new per-page model and the legacy single ``scale``
-      // (the current page's, as a best-effort default) so a downgrade to an
-      // older build that only reads ``scale`` still finds a usable value.
-      saveToStorage(fileName, {
-        measurements: measurements.filter((m) => !m.suggested),
-        pageScales,
-        scale,
-        savedAt: Date.now(),
-      });
-    }, 500);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [fileName, measurements, pageScales, scale]);
+  // Auto-save to localStorage as soon as React commits measurement state. This
+  // is the reload-safe fallback while server sync is debounced; waiting for
+  // normal effects, or for the initial server hydration request to finish, can
+  // lose a freshly drawn measurement when the user refreshes right after
+  // drawing.
+  useLayoutEffect(() => {
+    const documentId = documentIdentity?.trim() || fileName?.trim() || null;
+    if (!documentId) return;
+    const scopeKey = `${projectId || 'local'}:${documentId}`;
+    if (lastScopeRef.current !== null && scopeKey !== lastScopeRef.current) return;
+    const persistedMeasurements = measurements.filter((m) => !m.suggested);
+    if (!isHydrated && persistedMeasurements.length === 0) return;
+    // Never persist AI suggestions: only confirmed measurements are saved.
+    // Persist BOTH the new per-page model and the legacy single ``scale``
+    // (the current page's, as a best-effort default) so a downgrade to an
+    // older build that only reads ``scale`` still finds a usable value.
+    const localSaveSignature = JSON.stringify({
+      scopeKey,
+      measurements: persistedMeasurements,
+      pageScales,
+      scale,
+    });
+    if (localSaveSignature === lastLocalSaveSignatureRef.current) return;
+    const saved = saveToStorage(projectId, documentId, {
+      measurements: persistedMeasurements,
+      pageScales,
+      scale,
+      savedAt: Date.now(),
+    });
+    if (saved) {
+      lastLocalSaveSignatureRef.current = localSaveSignature;
+    }
+  }, [isHydrated, documentIdentity, fileName, projectId, measurements, pageScales, scale]);
 
   // Auto-sync to server with debounce (3s). Both measurement and annotation
   // types persist now (v2.6.7) — backend schema accepts the full set.
   useEffect(() => {
-    if (!fileName || !projectId) return;
+    const documentId = documentIdentity?.trim() || null;
+    if (!isHydrated || !documentId || !projectId) return;
     if (measurements.length === 0) return;
     const serverMeasurements = measurements;
 
     if (serverSyncRef.current) clearTimeout(serverSyncRef.current);
+    serverSyncRef.current = null;
+    const toCreate = serverMeasurements
+      // Suggested-but-unconfirmed measurements are excluded; accepting a
+      // suggestion clears `suggested` and the next tick syncs it (#194).
+      .filter((m) => !m.serverId && !m.suggested && !inFlightSyncRef.current.has(m.id))
+      // Per-page scale: toApiFormat resolves each row's own page scale
+      // from pageScales, so a multi-sheet set syncs correct ratios.
+      .map((m) => toApiFormat(m, projectId, documentId, pageScales, documentSource));
+    if (toCreate.length === 0) {
+      if (!serverMeasurements.some((m) => !m.serverId && !m.suggested)) {
+        setSyncedToServer(true);
+      }
+      return;
+    }
+
     serverSyncRef.current = setTimeout(async () => {
       setSyncing(true);
       try {
-        const toCreate = serverMeasurements
-          // Suggested-but-unconfirmed measurements are excluded; accepting a
-          // suggestion clears `suggested` and the next tick syncs it (#194).
-          .filter((m) => !m.serverId && !m.suggested)
-          // Per-page scale: toApiFormat resolves each row's own page scale
-          // from pageScales, so a multi-sheet set syncs correct ratios.
-          .map((m) => toApiFormat(m, projectId, fileName, pageScales));
+        toCreate.forEach((m) => {
+          const fid = m.metadata?.frontend_id;
+          if (typeof fid === 'string') {
+            inFlightSyncRef.current.add(fid);
+          }
+        });
 
-        if (toCreate.length > 0) {
+        try {
           const created = await takeoffApi.bulkCreate(toCreate);
-          // Update serverId on created measurements
-          setMeasurements(measurements.map((m) => {
-            if (m.serverId) return m;
-            const match = created.find((c) =>
-              (c.metadata?.frontend_id as string) === m.id
-            );
-            if (!match) return m;
-            // Seed the reshape baseline for the freshly-synced row so a
-            // later in-canvas edit PATCHes, but a no-op tick does not (#194).
-            geometrySigRef.current.set(match.id, geometrySignature(m));
-            return { ...m, serverId: match.id };
-          }));
+          const createdByFrontendId = new Map<string, MeasurementResponse>();
+          for (const c of created) {
+            const fid = c.metadata?.frontend_id;
+            if (typeof fid === 'string') createdByFrontendId.set(fid, c);
+          }
+          const synced = serverMeasurements
+            .map((m) => {
+              if (m.serverId) return null;
+              const match = createdByFrontendId.get(m.id);
+              return match ? { measurement: m, serverId: match.id } : null;
+            })
+            .filter((x): x is { measurement: Measurement; serverId: string } => x !== null);
+          // Update serverId on created measurements using functional updater to avoid stale state races
+          setMeasurements((prev) =>
+            prev.map((m) => {
+              if (m.serverId) return m;
+              const match = createdByFrontendId.get(m.id);
+              return match ? { ...m, serverId: match.id } : m;
+            })
+          );
+          for (const { measurement, serverId } of synced) {
+            // Seed the reshape baseline for the freshly-synced row so a later
+            // in-canvas edit PATCHes, but a no-op tick does not (#194).
+            geometrySigRef.current.set(serverId, geometrySignature(measurement));
+            inFlightSyncRef.current.delete(measurement.id);
+          }
           // Surface the new measurements in the unified Markups hub.
           qc?.invalidateQueries({ queryKey: ['unified-markups'] });
+        } catch (err) {
+          toCreate.forEach((m) => {
+            const fid = m.metadata?.frontend_id;
+            if (typeof fid === 'string') {
+              inFlightSyncRef.current.delete(fid);
+            }
+          });
+          throw err;
         }
         setSyncedToServer(true);
       } catch {
         // Server sync failed — data safe in localStorage
       } finally {
         setSyncing(false);
+        serverSyncRef.current = null;
       }
     }, 3000);
 
     return () => {
       if (serverSyncRef.current) clearTimeout(serverSyncRef.current);
+      serverSyncRef.current = null;
     };
-  }, [fileName, projectId, measurements, setMeasurements, pageScales]);
+  }, [isHydrated, documentIdentity, documentSource, projectId, measurements, setMeasurements, pageScales]);
 
   // Reshape PATCH (#194 Feature 1). When a measurement that already has a
   // `serverId` has its geometry changed in-canvas, PATCH just that row so
@@ -508,6 +656,7 @@ export function useMeasurementPersistence({
   // if a row is already in-flight we skip it this tick and the changed
   // signature keeps it dirty for the next pass (last-write-wins per row).
   useEffect(() => {
+    if (!isHydrated) return;
     if (!projectId) return;
     if (measurements.length === 0) return;
 
@@ -527,9 +676,18 @@ export function useMeasurementPersistence({
 
     if (patchTimerRef.current) clearTimeout(patchTimerRef.current);
     patchTimerRef.current = setTimeout(async () => {
+      // Re-filter dirty rows using the latest geometrySigRef values. This prevents
+      // redundant PATCH requests if a previous in-flight sync resolved while this
+      // timer was waiting.
+      const activeDirty = dirty.filter((m) => {
+        const prevSig = geometrySigRef.current.get(m.serverId!);
+        return prevSig !== geometrySignature(m);
+      });
+      if (activeDirty.length === 0) return;
+
       const reconciled: { frontendId: string; value: number; area?: number }[] = [];
       await Promise.all(
-        dirty.map(async (m) => {
+        activeDirty.map(async (m) => {
           const serverId = m.serverId!;
           if (inFlightPatchRef.current.has(serverId)) return; // coalesce
           inFlightPatchRef.current.add(serverId);
@@ -564,9 +722,12 @@ export function useMeasurementPersistence({
       );
 
       if (reconciled.length > 0) {
-        setMeasurements(
-          measurements.map((m) => {
-            const r = reconciled.find((x) => x.frontendId === m.id);
+        const reconciledByFrontendId = new Map(
+          reconciled.map((r) => [r.frontendId, r]),
+        );
+        setMeasurements((prev) =>
+          prev.map((m) => {
+            const r = reconciledByFrontendId.get(m.id);
             if (!r) return m;
             return {
               ...m,
@@ -582,18 +743,21 @@ export function useMeasurementPersistence({
     return () => {
       if (patchTimerRef.current) clearTimeout(patchTimerRef.current);
     };
-  }, [projectId, measurements, setMeasurements, pageScales, qc]);
+  }, [isHydrated, projectId, measurements, setMeasurements, pageScales, qc]);
 
   const saveNow = useCallback(() => {
-    if (!fileName) return;
-    saveToStorage(fileName, { measurements, pageScales, scale, savedAt: Date.now() });
-  }, [fileName, measurements, pageScales, scale]);
+    const documentId = documentIdentity?.trim() || fileName?.trim() || null;
+    if (!documentId) return;
+    saveToStorage(projectId, documentId, { measurements, pageScales, scale, savedAt: Date.now() });
+  }, [documentIdentity, fileName, projectId, measurements, pageScales, scale]);
 
   const clearPersisted = useCallback(() => {
-    if (!fileName) return;
-    removeFromStorage(fileName);
+    const documentId = documentIdentity?.trim() || fileName?.trim() || null;
+    if (!documentId) return;
+    removeFromStorage(projectId, documentId, fileName);
     hasPersistedRef.current = false;
-  }, [fileName]);
+    lastLocalSaveSignatureRef.current = null;
+  }, [documentIdentity, fileName, projectId]);
 
   return {
     hasPersistedData: hasPersistedRef.current,


### PR DESCRIPTION
## Summary

This fixes PDF Takeoff measurement persistence so measurements are scoped by the
selected project and a stable document identity instead of by display filename.

The change threads stable document identity through the Project Files,
Takeoff, Markups, BOQ, and PDF viewer paths; keeps local-only uploads out of
server sync until they have a stable document; and validates backend measurement
writes against project-owned Takeoff or Project Files documents.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

Fixes #238

## Changes Made

- Added shared takeoff routing helpers for Project Files PDFs, Takeoff-native
  PDFs, Markups deep links, and BOQ PDF source links.
- Separated PDF display filename from measurement persistence identity.
- Project Files PDFs now open Measurements with the Project Files document UUID
  as the measurement identity.
- Project Files rows that mirror Takeoff uploads resolve back to the original
  Takeoff document UUID.
- Takeoff uploads from the embedded viewer include the active `project_id` when
  they are routed through the persisted Takeoff upload flow.
- Local-only viewer uploads no longer server-sync measurements without a stable
  project/document identity.
- LocalStorage fallback keys are project/document-scoped, with safe legacy
  fallback for old filename-only local entries.
- Backend measurement create, bulk-create, and update paths validate that stable
  UUID document IDs belong to the same project as either a Takeoff document or a
  Project Files document.
- Markups and BOQ links carry enough PDF document identity to reopen the correct
  measurement namespace.

## Document Source Discriminator

This PR keeps the existing `TakeoffMeasurement.document_id` string field and
uses metadata to record the document namespace where needed:

```text
metadata.document_source = "takeoff" | "document"
```

This is intentionally migration-light. It lets the viewer, Markups, BOQ links,
and backend validation distinguish whether `document_id` refers to a Takeoff
document UUID or a Project Files document UUID without adding a schema
migration.

If maintainers prefer a stronger long-term contract, the same discriminator
could be promoted to a first-class `document_source` field in the takeoff
measurement create/update/response API, and optionally the database schema. That
would be architecturally cleaner, but it would broaden this PR and require a
clearer compatibility story for existing filename-keyed rows.

## Legacy LocalStorage Behavior

The new localStorage fallback keys are scoped by project and stable document
identity. The previous filename-only localStorage fallback is intentionally not
used for project-scoped documents, because that is the behavior that allowed
same-filename measurements to attach to the wrong PDF.

That means old unsynced browser-local drafts for project documents may not
auto-migrate into the new scoped key. Server-persisted measurements and
local-only viewer uploads retain their intended behavior.

## Files Modified

Backend:

- `backend/app/modules/projects/file_manager_service.py`
- `backend/app/modules/takeoff/service.py`
- `backend/tests/unit/test_takeoff_measurement_document_identity.py`

Frontend:

- `frontend/src/features/boq/grid/cellRenderers.tsx`
- `frontend/src/features/documents/DocumentsPage.tsx`
- `frontend/src/features/file-manager/FileManagerPage.tsx`
- `frontend/src/features/file-manager/components/FileContextMenu.tsx`
- `frontend/src/features/file-manager/components/FilePreviewPane.tsx`
- `frontend/src/features/file-manager/components/RecentlyViewedStrip.tsx`
- `frontend/src/features/file-manager/kindModule.ts`
- `frontend/src/features/file-manager/kindModule.test.ts`
- `frontend/src/features/markups/MarkupsPage.tsx`
- `frontend/src/features/markups/aggregator.ts`
- `frontend/src/features/markups/__tests__/aggregator.test.ts`
- `frontend/src/features/markups/useUnifiedMarkups.ts`
- `frontend/src/features/takeoff/TakeoffPage.tsx`
- `frontend/src/features/takeoff/takeoffRoutes.ts`
- `frontend/src/features/takeoff/__tests__/TakeoffPage.deepLink.test.tsx`
- `frontend/src/features/takeoff/__tests__/takeoffRoutes.test.ts`
- `frontend/src/modules/pdf-takeoff/TakeoffViewerModule.tsx`
- `frontend/src/modules/pdf-takeoff/useMeasurementPersistence.ts`
- `frontend/src/modules/pdf-takeoff/useMeasurementPersistence.test.ts`

## Verification

Automated checks run locally:

```bash
backend/.venv/bin/python -m pytest backend/tests/unit/test_takeoff_measurement_document_identity.py -q
npm test -- --run src/modules/pdf-takeoff/useMeasurementPersistence.test.ts src/features/takeoff/__tests__/takeoffRoutes.test.ts src/features/takeoff/__tests__/TakeoffPage.deepLink.test.tsx src/features/file-manager/kindModule.test.ts src/features/markups/__tests__/aggregator.test.ts
npm run lint
backend/.venv/bin/python -m ruff check backend/app/modules/projects/file_manager_service.py backend/app/modules/takeoff/service.py backend/tests/unit/test_takeoff_measurement_document_identity.py
NODE_OPTIONS=--max-old-space-size=8192 npm run typecheck
git diff --check upstream/main...HEAD
```

Manual smoke scenarios run locally on 2026-06-16 against the rebased PR branch
in a fresh Docker database:

1. Passed: Project Files PDF opens in Measurements and persists measurements
   after refresh/reopen.
2. Passed: Takeoff upload through the embedded viewer creates/reopens the
   persisted Takeoff document and Project Files mirror.
3. Passed: Reopening a Takeoff-uploaded PDF from its Project Files mirror shows
   the same measurements.
4. Passed: Two projects can each contain `abc.pdf` without measurement leakage.
5. Passed: One project can contain two different Project Files PDFs named
   `abc.pdf` without measurement leakage.
6. Passed: BOQ and Markups deep links reopen the correct PDF measurement
   namespace.

## Author Checklist

- [x] Code follows project style guidelines for touched files
- [x] Tests added/updated for changes
- [ ] All CI checks pass
- [ ] Documentation updated if needed
- [x] No secrets or credentials in code
- [x] i18n: no new user-facing strings requiring translation
- [x] Conventional commit message used

## Reviewer Notes

This PR intentionally does not attempt to merge Project Files and Takeoff
Documents into one model. It only ensures that when both document types can
enter the PDF Measurements viewer, measurement persistence uses stable document
identity rather than filename.

The BOQ source-document icon/popover and "Open source" action already exist
upstream for measurement-linked BOQ positions. This PR only changes the PDF
deep-link target behind that existing action so it reopens the correct
measurement document namespace.

The Project Files duplicate-filename version-history behavior and intermittent
calibration/first-refresh behavior are treated as separate issues.