### PR TITLE
test(takeoff): make export-filename date fixtures timezone-independent

### DIFF
--- a/frontend/src/modules/pdf-takeoff/__tests__/exports.test.ts
+++ b/frontend/src/modules/pdf-takeoff/__tests__/exports.test.ts
@@ -135,7 +135,11 @@ const SAMPLE_MEASUREMENTS: Measurement[] = [
 
 describe('buildExportFilename', () => {
   it('produces takeoff-{slug}-{YYYY-MM-DD}.{ext}', () => {
-    const date = new Date('2026-05-20T10:30:00Z');
+    // Local-time constructor: buildExportFilename formats the user's local
+    // date, so a UTC instant here would assert the wrong day on any
+    // machine that isn't running in UTC (e.g. midnight UTC is the
+    // previous evening in the Americas).
+    const date = new Date(2026, 4, 20, 10, 30);
     expect(buildExportFilename('Berlin · Wohnpark Lichtenberg', 'pdf', date)).toBe(
       'takeoff-berlin_wohnpark_lichtenberg-2026-05-20.pdf',
     );
@@ -145,7 +149,7 @@ describe('buildExportFilename', () => {
   });
 
   it('falls back to "untitled" on empty project name', () => {
-    const date = new Date('2026-01-02T00:00:00Z');
+    const date = new Date(2026, 0, 2);
     expect(buildExportFilename('', 'pdf', date)).toBe('takeoff-untitled-2026-01-02.pdf');
     expect(buildExportFilename('   !!!   ', 'xlsx', date)).toBe(
       'takeoff-untitled-2026-01-02.xlsx',


### PR DESCRIPTION
## Summary

This updates the PDF Takeoff export filename tests so their date fixtures are
constructed in local time instead of as UTC instants.

`buildExportFilename` formats the user's local calendar date. The previous test
fixtures used UTC timestamp strings, which can represent the previous local day
on machines west of UTC. This change keeps the production behavior unchanged
and makes the test assert the intended local-date behavior consistently across
developer timezones.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD or infrastructure change

## Related Issues

N/A

## Changes Made

- Replaced UTC string-based `Date` fixtures in the export filename tests with
  local-time `Date` constructors.
- Added a short comment explaining why the fixtures intentionally use local time:
  the filename builder formats local calendar dates, not UTC dates.

## Author Checklist

- [x] Code follows project style guidelines (ruff, prettier)
- [x] Tests added/updated for changes
- [ ] All CI checks pass
- [x] Documentation updated if needed
- [x] No secrets or credentials in code
- [x] i18n: user-facing strings use translation keys
- [x] Conventional commit message used

## Reviewer Checklist

- [ ] Code is clear and well-structured
- [ ] Tests cover the key scenarios
- [ ] No security concerns
- [ ] No performance regressions

## Verification

Focused test runs:

```bash
cd frontend
npx vitest run src/modules/pdf-takeoff/__tests__/exports.test.ts
TZ=America/Los_Angeles npx vitest run src/modules/pdf-takeoff/__tests__/exports.test.ts
TZ=Pacific/Kiritimati npx vitest run src/modules/pdf-takeoff/__tests__/exports.test.ts
```

All three runs passed: 1 test file, 8 tests.

Preflight:

```bash
git diff --check upstream/main...HEAD
git ls-files --others --exclude-standard
```

`git diff --check` passed and there are no untracked artifacts in the PR
worktree.
