### PR TITLE
chore: v8.8.2 news pages + CI module-capture harness

### DIFF
--- a/.github/workflows/module-captures.yml
+++ b/.github/workflows/module-captures.yml
@@ -1,0 +1,154 @@
+name: Module captures (showcase video/GIF)
+
+# Records a short, deterministic showcase clip per flagship module of the
+# running app and converts each to an optimized GIF, for the marketing module
+# showcase and the in-app docs.
+#
+# The app cannot run on the maintainer's Windows box (it needs Python 3.12) and
+# the production server must never be driven by a recording browser, so the
+# capture runs here in CI where the app boots exactly the way it ships: the
+# backend on embedded PostgreSQL serving the freshly built SPA on :8000, seeded
+# with the demo workspace. The boot sequence mirrors e2e-cross-os.yml.
+#
+# Manual-only (workflow_dispatch). Artifacts (both .webm and .gif) are uploaded
+# as "module-captures"; nothing is committed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      fps:
+        description: "GIF frame rate"
+        default: "12"
+        required: false
+      width:
+        description: "GIF width in px (height auto, aspect preserved)"
+        default: "960"
+        required: false
+
+concurrency:
+  group: module-captures-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  captures:
+    name: Capture module clips
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (single-server SPA)
+        working-directory: frontend
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: npm run build
+
+      - name: Install backend (serves the built SPA + API on :8000)
+        working-directory: backend
+        run: pip install -e .
+
+      - name: Install Playwright chromium (with deps)
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Start backend (embedded PostgreSQL + demo seed)
+        working-directory: backend
+        shell: bash
+        env:
+          OE_DATA_DIR: ${{ runner.temp }}/oe-captures-data
+          SEED_DEMO: "true"
+          APP_ENV: development
+        run: |
+          nohup python -m app.cli serve --port 8000 --data-dir "${{ runner.temp }}/oe-captures-data" \
+            > "${{ runner.temp }}/backend.log" 2>&1 &
+          echo $! > "${{ runner.temp }}/backend.pid"
+          echo "backend launched (pid $(cat "${{ runner.temp }}/backend.pid"))"
+
+      - name: Wait for backend health (seed can take a few minutes)
+        shell: bash
+        run: |
+          for i in $(seq 1 72); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/api/health || true)
+            if [ "$code" = "200" ]; then echo "backend healthy after $((i*5))s"; exit 0; fi
+            sleep 5
+          done
+          echo "::error::backend never became healthy"
+          tail -80 "${{ runner.temp }}/backend.log" || true
+          exit 1
+
+      - name: Record module clips (chromium)
+        working-directory: frontend
+        shell: bash
+        env:
+          OE_TEST_BASE_URL: http://127.0.0.1:8000
+          OE_TEST_API_URL: http://127.0.0.1:8000
+        run: npx playwright test --config=playwright.captures.config.ts --project=chromium
+
+      - name: Convert webm clips to optimized GIFs
+        working-directory: frontend
+        shell: bash
+        env:
+          FPS: ${{ github.event.inputs.fps || '12' }}
+          WIDTH: ${{ github.event.inputs.width || '960' }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          clips=(qa-captures/*.webm)
+          if [ ${#clips[@]} -eq 0 ]; then
+            echo "::warning::no .webm clips were produced; nothing to convert"
+            exit 0
+          fi
+          # ffmpeg is preinstalled on ubuntu-latest. Two-pass for quality:
+          # palettegen builds an optimal per-clip palette, paletteuse applies it
+          # with Floyd-Steinberg dithering. fps + width downscale keep GIFs small.
+          for clip in "${clips[@]}"; do
+            base="$(basename "${clip%.webm}")"
+            gif="qa-captures/${base}.gif"
+            palette="$(mktemp --suffix=.png)"
+            vf="fps=${FPS},scale=${WIDTH}:-1:flags=lanczos"
+            echo "converting ${clip} -> ${gif}"
+            ffmpeg -nostdin -y -i "$clip" -vf "${vf},palettegen=stats_mode=diff" "$palette"
+            ffmpeg -nostdin -y -i "$clip" -i "$palette" \
+              -lavfi "${vf} [x]; [x][1:v] paletteuse=dither=floyd_steinberg:diff_mode=rectangle" \
+              "$gif"
+            rm -f "$palette"
+          done
+          echo "GIF sizes:"
+          ls -la qa-captures/*.gif || true
+
+      - name: Upload module captures (webm + gif)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: module-captures
+          path: |
+            frontend/qa-captures/**/*.webm
+            frontend/qa-captures/**/*.gif
+            frontend/qa-captures/captures.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Dump backend log on failure
+        if: failure()
+        shell: bash
+        run: tail -120 "${{ runner.temp }}/backend.log" || true

--- a/frontend/playwright.captures.config.ts
+++ b/frontend/playwright.captures.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * playwright.captures.config.ts - module showcase video capture.
+ *
+ * Records a short, deterministic clip per flagship module against the
+ * single-server build on :8000 (what actually ships), for the marketing
+ * module showcase and the in-app docs. Chromium only, retina-crisp, single
+ * worker (videos must not interleave). The app must already be running; this
+ * config does NOT auto-start a webServer (CI boots the backend separately,
+ * exactly like e2e-cross-os.yml).
+ *
+ * Per-module .webm files land in frontend/qa-captures/<slug>.webm. The spec
+ * manages its own recording contexts (one per module) so each clip is named;
+ * the project-level `video` option is therefore left off here on purpose.
+ *
+ * Run (against an already-running app on :8000):
+ *   npx playwright test --config=playwright.captures.config.ts
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: ['capture-module-videos.spec.ts'],
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  // Each module records a multi-second clip plus settle time; give the whole
+  // spec generous room since all modules run in a single test body.
+  timeout: 15 * 60_000,
+  reporter: [['list']],
+  outputDir: 'qa-captures/test-results',
+  use: {
+    baseURL: process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000',
+    // The spec creates its own contexts with recordVideo, so leave the
+    // fixture-managed page free of screenshots/video/trace overhead.
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+    ignoreHTTPSErrors: true,
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 2,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 }, deviceScaleFactor: 2 },
+    },
+  ],
+});

--- a/frontend/tests/e2e/capture-module-videos.spec.ts
+++ b/frontend/tests/e2e/capture-module-videos.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * capture-module-videos: record a short, deterministic showcase clip for each
+ * flagship module of the running app, for the marketing module showcase and the
+ * in-app docs.
+ *
+ * For every curated module we:
+ *   - open a fresh browser context that records video to qa-captures/;
+ *   - boot it already logged-in as the demo user with a pinned active project
+ *     (same approach as smoke-all-modules.spec.ts) so real data is on screen;
+ *   - navigate to the route, wait for content to settle, then perform ONE
+ *     simple, robust interaction (a gentle scroll, plus a hover on the first
+ *     toolbar control or data row if one exists) so the clip shows motion;
+ *   - close the context, which flushes the video, then rename the random-hash
+ *     file to qa-captures/<slug>.webm.
+ *
+ * Resilient by design: a module that fails to load is logged and skipped; it
+ * never fails the whole run, so one broken route cannot cost us the other clips.
+ *
+ * Runs against the single-server build on :8000 (what actually ships).
+ * Config: playwright.captures.config.ts
+ */
+import { test, expect, chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const API = process.env.OE_TEST_API_URL ?? process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000';
+const BASE = process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000';
+const DEMO_EMAIL = process.env.OE_TEST_DEMO_EMAIL ?? 'demo@openconstructionerp.com';
+
+const VIEWPORT = { width: 1440, height: 900 };
+// Roughly how long each clip should be. Settle + interaction fill this window.
+const CLIP_MS = 6000;
+
+interface Module {
+  slug: string;
+  path: string;
+  label: string;
+}
+
+// Curated flagship modules for the showcase. Routes are taken verbatim from
+// tests/e2e/smoke-all-modules.spec.ts (the canonical route surface).
+const MODULES: Module[] = [
+  { slug: 'dashboard', path: '/', label: 'Project dashboard' },
+  { slug: 'boq', path: '/boq', label: 'Bill of quantities editor' },
+  { slug: 'bim', path: '/bim', label: 'BIM model viewer' },
+  { slug: 'dwg-takeoff', path: '/dwg-takeoff', label: 'DWG takeoff' },
+  { slug: 'pdf-takeoff', path: '/takeoff', label: 'PDF takeoff' },
+  { slug: 'benchmarks', path: '/benchmarks', label: 'Cost benchmarks' },
+  { slug: 'methodologies', path: '/methodologies', label: 'Estimating methodology cascade' },
+  { slug: 'costmodel-5d', path: '/5d', label: '5D cost model' },
+  { slug: 'schedule', path: '/schedule', label: 'Schedule' },
+  { slug: 'geo-hub', path: '/geo', label: 'Geo hub' },
+  { slug: 'ai-estimator', path: '/ai-estimator', label: 'AI estimator' },
+  { slug: 'risks', path: '/risks', label: 'Cost risk analysis' },
+];
+
+interface Session {
+  token: string;
+  refresh: string;
+  project: { id: string; name: string } | null;
+}
+
+const OUT_DIR = path.join(process.cwd(), 'qa-captures');
+
+function ensureDir(p: string): void {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+/**
+ * Demo-login and pick the first project, mirroring smoke-all-modules.spec.ts.
+ * Returns the tokens + a project to pin so content-heavy modules render data.
+ */
+async function openSession(): Promise<Session> {
+  const res = await fetch(`${API}/api/v1/users/auth/demo-login/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: DEMO_EMAIL }),
+  });
+  if (!res.ok) throw new Error(`demo-login failed: ${res.status} ${await res.text()}`);
+  const j: Record<string, string> = await res.json();
+  const token = j.access_token || j.access || j.token || '';
+  const refresh = j.refresh_token || j.refresh || '';
+  if (!token) throw new Error(`demo-login returned no token: ${JSON.stringify(j).slice(0, 200)}`);
+
+  let project: { id: string; name: string } | null = null;
+  try {
+    const pr = await fetch(`${API}/api/v1/projects/`, { headers: { Authorization: `Bearer ${token}` } });
+    const pd = await pr.json();
+    const items: Array<{ id: string; name: string }> = Array.isArray(pd) ? pd : (pd.items ?? []);
+    if (items.length) project = { id: items[0].id, name: items[0].name };
+  } catch {
+    /* a missing project list is non-fatal; modules still render their chrome */
+  }
+  return { token, refresh, project };
+}
+
+/** Inject a real demo session + pinned active project before app scripts run. */
+async function hydrate(context: BrowserContext, session: Session): Promise<void> {
+  await context.addInitScript(
+    ({ token, refresh, proj }) => {
+      try {
+        localStorage.setItem('oe_access_token', token);
+        if (refresh) localStorage.setItem('oe_refresh_token', refresh);
+        localStorage.setItem('oe_remember', '1');
+        sessionStorage.setItem('oe_access_token', token);
+        if (refresh) sessionStorage.setItem('oe_refresh_token', refresh);
+        if (proj) {
+          localStorage.setItem('oe_active_project', JSON.stringify({ id: proj.id, name: proj.name, boqId: null }));
+        }
+        // Quiet onboarding/tour overlays that would clutter the clip.
+        localStorage.setItem('oe_onboarding_completed', '1');
+        localStorage.setItem('oe_welcome_dismissed', '1');
+        localStorage.setItem('oe_tour_completed', '1');
+      } catch {
+        /* ignore */
+      }
+    },
+    { token: session.token, refresh: session.refresh, proj: session.project },
+  );
+}
+
+/**
+ * One representative, deterministic interaction: a gentle scroll down and back,
+ * plus a hover on the first toolbar button or data row if present. No flaky
+ * assertions, nothing that depends on a specific module's data shape.
+ */
+async function performShowcaseGesture(page: Page): Promise<void> {
+  // Let async data and lazy chunks settle before we start moving.
+  await page.waitForLoadState('networkidle', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1200);
+
+  // Hover the first meaningful control we can find, if any.
+  const hoverTargets = [
+    'main button:visible',
+    '[role="toolbar"] button:visible',
+    '.ag-row:visible',
+    '[role="row"]:visible',
+    'main a:visible',
+  ];
+  for (const sel of hoverTargets) {
+    const el = page.locator(sel).first();
+    if (await el.isVisible({ timeout: 500 }).catch(() => false)) {
+      await el.hover({ timeout: 1500 }).catch(() => {});
+      break;
+    }
+  }
+  await page.waitForTimeout(600);
+
+  // Gentle scroll down then back up so the clip shows the page content.
+  await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+  await page.mouse.wheel(0, 700);
+  await page.waitForTimeout(900);
+  await page.mouse.wheel(0, -700);
+  await page.waitForTimeout(700);
+}
+
+/** Capture one module's clip into qa-captures/<slug>.webm. Throws on failure. */
+async function captureModule(browser: Browser, session: Session, mod: Module): Promise<void> {
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    baseURL: BASE,
+    ignoreHTTPSErrors: true,
+    recordVideo: { dir: OUT_DIR, size: VIEWPORT },
+  });
+  await hydrate(context, session);
+
+  const page = await context.newPage();
+  let video = page.video();
+  try {
+    await page.goto(mod.path, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    const start = Date.now();
+    await performShowcaseGesture(page);
+    // Pad to a consistent clip length so every module reads at a steady pace.
+    const remaining = CLIP_MS - (Date.now() - start);
+    if (remaining > 0) await page.waitForTimeout(remaining);
+    video = page.video();
+  } finally {
+    // Closing the context flushes and finalizes the video file.
+    await context.close();
+  }
+
+  // Rename the random-hash webm to <slug>.webm.
+  if (video) {
+    const raw = await video.path().catch(() => '');
+    if (raw && fs.existsSync(raw)) {
+      const dest = path.join(OUT_DIR, `${mod.slug}.webm`);
+      try {
+        fs.rmSync(dest, { force: true });
+      } catch {
+        /* ignore */
+      }
+      fs.renameSync(raw, dest);
+      return;
+    }
+  }
+  throw new Error(`no video produced for ${mod.slug}`);
+}
+
+test('capture flagship module showcase clips', async () => {
+  test.setTimeout(14 * 60_000);
+  ensureDir(OUT_DIR);
+
+  const session = await openSession();
+  const browser = await chromium.launch();
+
+  const ok: string[] = [];
+  const failed: Array<{ slug: string; error: string }> = [];
+  try {
+    for (const mod of MODULES) {
+      try {
+        await captureModule(browser, session, mod);
+        ok.push(mod.slug);
+        // eslint-disable-next-line no-console
+        console.log(`captured ${mod.slug} -> qa-captures/${mod.slug}.webm`);
+      } catch (e) {
+        const error = String(e).slice(0, 300);
+        failed.push({ slug: mod.slug, error });
+        // eslint-disable-next-line no-console
+        console.warn(`skipped ${mod.slug}: ${error}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  // Write a small manifest so downstream tooling knows what was captured.
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    baseURL: BASE,
+    project: session.project?.name ?? null,
+    captured: ok,
+    failed,
+    modules: MODULES.map((m) => ({ slug: m.slug, path: m.path, label: m.label })),
+  };
+  fs.writeFileSync(path.join(OUT_DIR, 'captures.json'), JSON.stringify(manifest, null, 2));
+  // eslint-disable-next-line no-console
+  console.log(`module captures done: ${ok.length} ok, ${failed.length} skipped`);
+
+  // The run is a success as long as we captured at least one clip; individual
+  // module failures are recorded in captures.json, not fatal to the harness.
+  expect(ok.length, `no module clips were captured at all (base=${BASE})`).toBeGreaterThan(0);
+});

--- a/marketing-site/news.html
+++ b/marketing-site/news.html
@@ -696,6 +696,227 @@
         </a>
       </article>
 
+      <!-- v8.8.2 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-8-2.html" aria-label="Read: v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M12 8v5"/><path d="M9.5 10.5 12 13l2.5-2.5"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-21</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~4 min read</span>
+            </div>
+            <h2>v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals.</h2>
+            <p class="excerpt">
+              No more Settings detour to get a converter. The first time you
+              upload an .rvt, .ifc, .dwg or .dgn file, the matching converter is
+              fetched and provisioned in the background, trying several install
+              methods in turn so it works across the widest range of hosts, with
+              downloads that resume and a binary that self-tests after install.
+              And bill-of-quantities exports and side-by-side comparison now
+              convert foreign-currency amounts into the project's base currency
+              before totalling, so a mixed-currency total reconciles.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.8.1 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-8-1.html" aria-label="Read: v8.8.1 - a takeoff PDF now stays attached to its project after a reload">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/><path d="M9 15l2 2 4-4"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-21</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~2 min read</span>
+            </div>
+            <h2>v8.8.1 - A takeoff PDF now stays attached to its project after a reload.</h2>
+            <p class="excerpt">
+              A small, targeted fix. A PDF uploaded for quantity takeoff now stays
+              attached to the active project, so it remains in the document list
+              after a page reload instead of vanishing. Previously the upload was
+              saved with no project, so the project-filtered document list dropped
+              it on refresh. The server already verified the caller's access to
+              the project before storing the file, and it still does.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.8.0 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-8-0.html" aria-label="Read: v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 16c2-6 4-8 6-8s2 4 4 4 2-4 4-6"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-21</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~5 min read</span>
+            </div>
+            <h2>v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub.</h2>
+            <p class="excerpt">
+              A single number hides the risk in an estimate. A new Monte-Carlo
+              cost-risk analysis runs thousands of correlated, PERT-distributed
+              iterations over a bill of quantities to produce a full cost
+              distribution: P5 to P95 bands, a probability S-curve, a recommended
+              contingency at your confidence level and a tornado of what drives
+              the variance. An in-app How it works hub explains every module in
+              all 27 languages, the Geo Hub gains lightweight 2D maps, cost
+              benchmarks gain a DIN 276 element breakdown, and takeoff can count
+              by example.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.7.1 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-7-1.html" aria-label="Read: v8.7.1 - a calmer screen on a busy server, and several takeoff and estimator fixes">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-20</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~3 min read</span>
+            </div>
+            <h2>v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes.</h2>
+            <p class="excerpt">
+              A maintenance release that smooths the rough edges of 8.7.0. The
+              recurring "Request timed out" message no longer floods the screen
+              on a busy or slow server, an interrupted CAD conversion stops
+              spinning forever and reports a clear error, and the AI Estimator no
+              longer analyses a source twice. The transmittals page reflects the
+              real lifecycle, the guided AI form drops its raw labels, and the AI
+              agent tools now verify project access before reading anything.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.7.0 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-7-0.html" aria-label="Read: v8.7.0 - packs that carry their own estimating methodology, and a broad hardening pass">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><path d="M3.27 6.96 12 12.01l8.73-5.05"/><path d="M12 22.08V12"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-20</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~5 min read</span>
+            </div>
+            <h2>v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass.</h2>
+            <p class="excerpt">
+              The methodology engine meets the country packs. A pack can now
+              carry its own estimating methodology and apply it automatically, so
+              installing one starts its demo project and any new project on the
+              local cascade (United States, United Kingdom, India, Germany or
+              Australia) instead of the generic method. Methodology estimates
+              export to PDF and Excel, point cloud scans in LAS, LAZ and COPC read
+              directly, several capabilities surface in the interface, and a broad
+              security and data-integrity pass spans many modules.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.6.0 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-6-0.html" aria-label="Read: v8.6.0 - a data-driven estimating methodology engine you build in the app">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-18</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~4 min read</span>
+            </div>
+            <h2>v8.6.0 - A data-driven estimating methodology engine you build in the app.</h2>
+            <p class="excerpt">
+              One fixed markup chain does not fit every country or every kind of
+              work. A new data-driven methodology engine lets a project follow a
+              named methodology you build and edit in the app: a typed BOQ
+              hierarchy, analytical dimensions, named funding sources and a
+              cascade of markups that build on one another. Country and industry
+              templates ship ready to install, the cascade editor reconciles its
+              arithmetic against the server, and construction machinery is now
+              costed separately from installed equipment.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.5.0 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-5-0.html" aria-label="Read: v8.5.0 - a full vector takeoff for CAD drawings, and a drawing-tool PDF viewer">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12h2l3-9 4 18 3-9h6"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-18</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~5 min read</span>
+            </div>
+            <h2>v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer.</h2>
+            <p class="excerpt">
+              Takeoff grows up. DWG and DXF takeoff is now a full vector takeoff:
+              because a drawing is exact geometry rather than pixels, one click
+              produces a per-layer quantity table with the right unit for each
+              layer, plus a count-by-block rollup and a one-click Excel export.
+              The PDF takeoff viewer gains a thumbnail sidebar, find-on-sheet
+              search, fit and zoom controls and an orthogonal lock, PDF takeoff
+              can detect the printed drawing scale, and structural steel can be
+              priced by mass.
+            </p>
+          </div>
+        </a>
+      </article>
+
+      <!-- v8.4.0 release -->
+      <article class="card">
+        <a class="card-link" href="/news/v8-4-0.html" aria-label="Read: v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand">
+          <div class="card-media placeholder" aria-hidden="true">
+            <svg class="ph-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3h18v18H3z"/><path d="M3 9h18"/><path d="M9 21V9"/><path d="M13 14l2 2 4-4"/></svg>
+          </div>
+          <div class="card-body">
+            <div class="card-meta">
+              <span class="chip release" data-i18n="page.news.chip_release">Release</span>
+              <span class="card-date">2026-06-17</span>
+              <span class="card-date">·</span>
+              <span class="card-date">~3 min read</span>
+            </div>
+            <h2>v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand.</h2>
+            <p class="excerpt">
+              A focused fix release. PDF takeoff measurements are now scoped to
+              the project and the exact document they were drawn on, so two files
+              that share a name never surface each other's measurements again. The
+              resources under a bill-of-quantities position open on the first
+              click of the chevron, and the public hosted demo keeps its bundled
+              cost databases read-only, with a clear note that points to
+              self-hosting.
+            </p>
+          </div>
+        </a>
+      </article>
+
       <!-- v8.3.0 release -->
       <article class="card">
         <a class="card-link" href="/news/v8-3-0.html" aria-label="Read: v8.3.0 - a South Africa construction pack, the first of our African coverage">

--- a/marketing-site/news/assets/related-articles.js
+++ b/marketing-site/news/assets/related-articles.js
@@ -14,6 +14,78 @@
   // for "draw the on-brand SVG placeholder".
   var ARTICLES = [
     {
+      slug: 'v8-8-2',
+      href: '/news/v8-8-2.html',
+      title: 'v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals.',
+      date: '2026-06-21',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-8-1',
+      href: '/news/v8-8-1.html',
+      title: 'v8.8.1 - A takeoff PDF now stays attached to its project after a reload.',
+      date: '2026-06-21',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-8-0',
+      href: '/news/v8-8-0.html',
+      title: 'v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub.',
+      date: '2026-06-21',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-7-1',
+      href: '/news/v8-7-1.html',
+      title: 'v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes.',
+      date: '2026-06-20',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-7-0',
+      href: '/news/v8-7-0.html',
+      title: 'v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass.',
+      date: '2026-06-20',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-6-0',
+      href: '/news/v8-6-0.html',
+      title: 'v8.6.0 - A data-driven estimating methodology engine you build in the app.',
+      date: '2026-06-18',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-5-0',
+      href: '/news/v8-5-0.html',
+      title: 'v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer.',
+      date: '2026-06-18',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
+      slug: 'v8-4-0',
+      href: '/news/v8-4-0.html',
+      title: 'v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand.',
+      date: '2026-06-17',
+      tag: 'Release',
+      tagClass: 'release',
+      thumb: null
+    },
+    {
       slug: 'v8-3-0',
       href: '/news/v8-3-0.html',
       title: 'v8.3.0 - A South Africa construction pack, the first of our African coverage.',

--- a/marketing-site/news/v8-4-0.html
+++ b/marketing-site/news/v8-4-0.html
@@ -1,0 +1,530 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.4.0 scopes PDF takeoff measurements to the project and the exact document they were drawn on, so two files that share a name no longer surface each other's measurements. Resources under a BOQ position now expand on the first click, and the hosted demo keeps its bundled cost databases read-only. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-4-0.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-4-0.html" />
+  <meta property="og:title" content="v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand" />
+  <meta property="og:description" content="PDF takeoff measurements are now scoped to the project and the exact document they were drawn on, the resources under a BOQ position expand on the first click, and the hosted demo keeps its bundled cost databases read-only. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-17T12:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand" />
+  <meta name="twitter:description" content="PDF takeoff measurements are now scoped to the project and the exact document, the resources under a BOQ position expand on the first click, and the hosted demo keeps its bundled cost databases read-only. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand",
+    "datePublished": "2026-06-17",
+    "dateModified": "2026-06-17",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-4-0.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.4.0 - PDF takeoff measurements scoped to the document, and a one-click resource expand</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 17, 2026</span>
+      <span class="pill-meta">~3 min read</span>
+    </div>
+    <h1>v8.4.0 - PDF takeoff measurements scoped to the <span class="accent">document</span>, and a one-click resource expand.</h1>
+    <p class="lede">
+      A focused fix release. PDF takeoff measurements are now scoped to the
+      project and the exact document they were drawn on, so two files that share
+      a name never surface each other's measurements again. The resources under a
+      bill-of-quantities position open on the first click of the chevron, and the
+      public hosted demo keeps its bundled cost databases read-only.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.4.0 is a small, precise release that removes two everyday frictions in
+      takeoff and the bill of quantities, and tightens how the public demo
+      behaves on a shared server. Nothing here changes how you work; it changes
+      how reliably the things you already do behave when files share a name or
+      when you click an expander once and expect it to open.
+    </p>
+
+    <h2>What is new in version 8.4.0</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>PDF takeoff measurements scoped to the document.</strong> Measurements are now tied to the project and the specific document they were drawn on, rather than keyed by the document's file name. Two files that share a name, in the same project or across projects, no longer surface each other's measurements.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Resources expand on the first click.</strong> The resources under a bill-of-quantities position now expand on the first click of the chevron instead of needing a second click, the way every other expander in the grid already did.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>The hosted demo keeps its cost databases read-only.</strong> Each regional catalogue is several hundred megabytes and the public demo runs on a small shared server, so installing a catalogue there is now disabled with a clear note that points to self-hosting. Browsing every catalogue the full product ships is unchanged, and nothing is restricted on your own machine or server.
+      </li>
+    </ul>
+
+    <h2>Measurements that stay with their drawing</h2>
+    <p>
+      When you mark up a PDF in takeoff, every measurement belongs to one
+      drawing. Until now those measurements were keyed by the document's file
+      name, which is fine until two drawings share a name - a common thing when
+      a revision keeps the same file name, or two projects each have a
+      <code>GA-Plan.pdf</code>. In that case the measurements drawn on one could
+      appear on the other, which is exactly the kind of quiet mix-up that erodes
+      trust in a quantity.
+    </p>
+    <p>
+      8.4.0 scopes measurements to the project and the specific document they
+      were drawn on, so a shared name is no longer a collision. Each drawing
+      carries its own measurements and nothing else, whether the matching name
+      sits in the same project or another one. This was reported as
+      <a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/238" target="_blank" rel="noopener">issue #238</a>.
+    </p>
+
+    <h2>One click, not two</h2>
+    <p>
+      In the bill-of-quantities grid, every row with detail behind it opens on a
+      single click of the chevron - except the resources under a position, which
+      used to need a second click to open. That inconsistency is gone: resources
+      now expand on the first click like everything else in the grid, so the
+      drill from a position into the labour, material and equipment under it is
+      one motion instead of two.
+    </p>
+
+    <h2>A demo that stays light on a shared server</h2>
+    <p>
+      The public hosted demo runs on a small, shared machine so anyone can try
+      the platform without installing anything. Each regional cost catalogue,
+      though, is several hundred megabytes, and letting visitors install them on
+      that shared box was never going to be practical. Installing a catalogue on
+      the public demo is now disabled, with a clear note that points to
+      self-hosting if you want the priced data. Browsing every catalogue the full
+      product ships is unchanged, and on your own machine or server nothing is
+      restricted at all.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">#238</p><p class="stat-label">the community report this release closes for filename-keyed takeoff measurements.</p></div>
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">click now opens the resources under a BOQ position, down from two.</p></div>
+      <div class="stat-card"><p class="stat-num">2 GB</p><p class="stat-label">of RAM is all a full self-hosted instance needs to run.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.4.0 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-5-0.html
+++ b/marketing-site/news/v8-5-0.html
@@ -1,0 +1,552 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.5.0 turns DWG and DXF takeoff into a full vector takeoff: one click produces a per-layer quantity table with the right unit for each layer. The PDF takeoff viewer gains a thumbnail sidebar, find-on-sheet search, fit and zoom controls and an orthogonal lock, PDF takeoff can detect the drawing scale, and structural steel can be priced by mass. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-5-0.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-5-0.html" />
+  <meta property="og:title" content="v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer" />
+  <meta property="og:description" content="DWG and DXF takeoff becomes a full vector takeoff with a per-layer quantity table, the PDF viewer gains thumbnails, find-on-sheet search, fit and zoom controls and an orthogonal lock, PDF takeoff can detect the drawing scale, and structural steel can be priced by mass. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-18T12:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer" />
+  <meta name="twitter:description" content="DWG and DXF takeoff becomes a full vector takeoff with a per-layer quantity table, the PDF viewer gains thumbnails, find-on-sheet search, fit and zoom controls, PDF takeoff can detect the drawing scale, and steel can be priced by mass. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer",
+    "datePublished": "2026-06-18",
+    "dateModified": "2026-06-18",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-5-0.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.5.0 - A full vector takeoff for CAD drawings, and a drawing-tool PDF viewer</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 18, 2026</span>
+      <span class="pill-meta">~5 min read</span>
+    </div>
+    <h1>v8.5.0 - a full <span class="accent">vector takeoff</span> for CAD drawings, and a drawing-tool PDF viewer.</h1>
+    <p class="lede">
+      Takeoff grows up. DWG and DXF takeoff is now a full vector takeoff: because
+      a drawing is exact geometry rather than pixels, one click produces a
+      per-layer quantity table with the right unit for each layer. The PDF takeoff
+      viewer works much more like a real drawing tool, PDF takeoff can read the
+      scale printed on the sheet, and structural steel can finally be priced by
+      mass.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.5.0 is the release where takeoff stops being a viewer with a ruler and
+      becomes a measuring instrument. A CAD drawing is exact vector geometry, so
+      the quantities are already in the file; this version reads them out
+      directly. The PDF side gains the navigation and precision of a proper
+      drawing tool, scale detection removes a calibration step, and steel sold by
+      weight is estimated the way it is actually bought. The new and reworded
+      interface text in this release is translated into all 26 other languages.
+    </p>
+
+    <h2>What is new in version 8.5.0</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A full vector takeoff for DWG and DXF.</strong> Because a drawing is exact vector geometry rather than pixels, every wall, slab and pipe already carries its true length and area, so one click produces a per-layer quantity table with the right unit for each layer - area, length or a simple count - and it measures arcs, ellipses and hatched fills as well. A count tool adds a count-by-block rollup for repeated symbols, and the whole table exports to Excel in one click. You can also search the drawing text: TEXT and MTEXT labels are found, highlighted and framed with zoom-to-match.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A PDF viewer that works like a drawing tool.</strong> A page-thumbnail sidebar lets you move between sheets at a glance, find-on-sheet searches the text layer and jumps to each hit, and the viewer gained fit-to-page and fit-to-width, zoom-to-selection, panning, an orthogonal lock for straight measurements, a live measurement readout and a hover tooltip. Large sheets now fit correctly the first time they open.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>PDF takeoff can detect the drawing scale.</strong> It reads the scale printed in the drawing's text layer, for example 1:100, and offers it for one-click confirmation, so measurements are calibrated without first tracing a known dimension. The detected value is always shown for you to confirm and is never applied on its own.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Structural steel priced by mass.</strong> A cost item can carry a mass per unit and a structural category, and a member priced by length is converted to mass on its way into a bill of quantities, so steel that is sold by weight is estimated correctly. Custom cost items also group under a "My categories" heading in the costs sidebar, so a category you created, such as "Structural Steel", is browsable directly instead of being reachable only through search.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Smaller touches and two fixes.</strong> The point cloud reader is now an installable extra, and scans can be deleted from the workspace. A short video introducing the platform is linked from the left sidebar. Local AI providers that do not need an API key no longer ask for one (<a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/244" target="_blank" rel="noopener">#244</a>), and the 3D viewer now degrades gracefully instead of failing when the browser cannot create a full-quality context.
+      </li>
+    </ul>
+
+    <h2>The quantities are already in the drawing</h2>
+    <p>
+      A scanned plan is pixels, so measuring it means tracing. A CAD drawing is
+      not pixels: every wall, slab and pipe is exact geometry that already knows
+      its own length and area. 8.5.0 reads that geometry directly, so a DWG or
+      DXF takeoff is now a full vector takeoff. One click produces a per-layer
+      quantity table, and each layer gets the right unit on its own - area for a
+      slab layer, length for a pipe run, a count for a layer of repeated symbols.
+      It measures the awkward shapes too: arcs, ellipses and hatched fills are
+      handled, not skipped.
+    </p>
+    <p>
+      For repeated symbols a count tool adds a count-by-block rollup, so a
+      drawing full of identical fittings becomes a single number per block type.
+      The whole table exports to Excel in one click, and the drawing text is
+      searchable: TEXT and MTEXT labels are found, highlighted and framed with
+      zoom-to-match, so a room name or a tag is a search away rather than a hunt.
+    </p>
+
+    <h2>A PDF viewer that behaves like a drawing tool</h2>
+    <p>
+      Not every drawing arrives as CAD, so the PDF takeoff viewer got the
+      treatment too. A page-thumbnail sidebar turns a long set into something you
+      can move through at a glance, and find-on-sheet searches the text layer and
+      jumps to each hit. For measuring, the viewer gained fit-to-page and
+      fit-to-width, zoom-to-selection, panning, an orthogonal lock for straight
+      runs, a live measurement readout and a hover tooltip. Large sheets now fit
+      correctly the first time they open, instead of needing a manual zoom to
+      find the drawing.
+    </p>
+    <p>
+      Calibration is easier as well. PDF takeoff can detect the drawing scale by
+      reading the value printed in the sheet's text layer, for example 1:100, and
+      offer it for one-click confirmation - so you no longer have to trace a known
+      dimension before you can measure. The detected value is always shown for
+      you to confirm and is never applied on its own, so a mislabelled sheet can
+      never quietly skew every measurement on it.
+    </p>
+
+    <h2>Steel, priced the way it is bought</h2>
+    <p>
+      Structural steel is sold by weight, but a beam on a drawing is a length. A
+      cost item can now carry a mass per unit and a structural category, and a
+      member priced by length is converted to mass on its way into a bill of
+      quantities, so the estimate matches the way the steel is actually
+      purchased. Alongside it, custom cost items group under a "My categories"
+      heading in the costs sidebar, so a category you created - "Structural
+      Steel", say - is browsable directly instead of being reachable only through
+      search.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">click turns a CAD drawing into a per-layer quantity table with the right unit per layer.</p></div>
+      <div class="stat-card"><p class="stat-num">1:100</p><p class="stat-label">a printed scale PDF takeoff can detect and offer for one-click confirmation.</p></div>
+      <div class="stat-card"><p class="stat-num">26</p><p class="stat-label">other languages the new and reworded interface text is translated into.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.5.0 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-6-0.html
+++ b/marketing-site/news/v8-6-0.html
@@ -1,0 +1,532 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.6.0 - A data-driven estimating methodology engine you build in the app - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.6.0 adds a data-driven estimating methodology engine. Instead of one fixed markup chain, a project can follow a named methodology you build and edit in the app: a typed BOQ hierarchy, analytical dimensions, named funding sources and a cascade of markups that build on one another. Country and industry templates ship ready to install, and machinery is now costed separately from installed equipment. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-6-0.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-6-0.html" />
+  <meta property="og:title" content="v8.6.0 - A data-driven estimating methodology engine you build in the app" />
+  <meta property="og:description" content="A data-driven estimating methodology engine: a typed BOQ hierarchy, analytical dimensions, named funding sources and a cascade of markups that build on one another, with country and industry templates ready to install. Construction machinery is now costed separately from installed equipment. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-18T12:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.6.0 - A data-driven estimating methodology engine you build in the app" />
+  <meta name="twitter:description" content="A data-driven estimating methodology engine: a typed BOQ hierarchy, analytical dimensions, named funding sources and a cascade of markups, with country and industry templates ready to install. Machinery is now costed separately from installed equipment. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.6.0 - A data-driven estimating methodology engine you build in the app",
+    "datePublished": "2026-06-18",
+    "dateModified": "2026-06-18",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-6-0.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.6.0 - A data-driven estimating methodology engine you build in the app</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 18, 2026</span>
+      <span class="pill-meta">~4 min read</span>
+    </div>
+    <h1>v8.6.0 - a data-driven <span class="accent">estimating methodology</span> engine you build in the app.</h1>
+    <p class="lede">
+      One fixed markup chain does not fit every country or every kind of work.
+      8.6.0 adds a data-driven methodology engine: a project can follow a named
+      methodology you build and edit in the app - a typed bill-of-quantities
+      hierarchy, analytical dimensions, named funding sources, and a cascade of
+      markups that build on one another - with country and industry templates
+      ready to install, and machinery now costed separately from installed
+      equipment.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      Estimating convention is not universal. The way costs are grouped, what
+      counts as overhead, how machinery sits against installed equipment, the
+      order in which markups apply - all of it varies by country, by sector and
+      by company. 8.6.0 stops hard-coding one chain and lets a project follow a
+      named methodology that you can build, edit and switch, while the existing
+      international method stays available for anyone who wants it.
+    </p>
+
+    <h2>What is new in version 8.6.0</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A data-driven estimating methodology engine.</strong> Instead of one fixed markup chain, a project can follow a named methodology that you build and edit in the app: a typed bill-of-quantities hierarchy, analytical dimensions, named funding sources, and a cascade of markups that build on one another. Every methodology coexists with, and is switchable against, the existing international method.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Country and industry templates, ready to install.</strong> Templates ship ready to use - including a Uzbekistan cascade and a railway breakdown that price construction machinery inside the works base while keeping installed equipment as a separate base - so a local methodology is a starting point, not a blank page.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A cascade editor that reconciles with the server.</strong> The cascade editor shows a live preview and reconciles its arithmetic against the server, so the figures you see while you build the methodology are exactly the figures that are stored.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Machinery costed separately from equipment.</strong> A resource typed as machinery used to be folded into the equipment category, which understated the works base and overstated equipment for methodologies that price the two differently. The breakdown now reports a distinct Machinery category; a methodology that does not separate the two is unaffected.
+      </li>
+    </ul>
+
+    <h2>A methodology you build, not one you are given</h2>
+    <p>
+      The methodology engine treats an estimating method as data you own rather
+      than logic baked into the product. A methodology is a typed
+      bill-of-quantities hierarchy with analytical dimensions and named funding
+      sources, finished by a cascade of markups that build on one another - each
+      step taking the running total from the one before. You build it in the app,
+      edit it as your practice changes, and switch a project between methodologies
+      without leaving the international method behind for projects that prefer it.
+    </p>
+    <p>
+      Because the cascade editor shows a live preview and reconciles its
+      arithmetic against the server, there is no gap between the figure on screen
+      and the figure that is stored. The numbers you tune are the numbers the
+      estimate uses, which is the whole point of letting you shape the method
+      yourself.
+    </p>
+
+    <h2>Templates that already know the local convention</h2>
+    <p>
+      Nobody wants to rebuild a national costing convention from scratch, so
+      8.6.0 ships country and industry templates ready to install. Among them are
+      a Uzbekistan cascade and a railway breakdown that follow a specific
+      convention: construction machinery is priced inside the works base, while
+      installed equipment stays a separate base. That distinction matters,
+      because folding machinery into equipment understates the works and
+      overstates equipment for methodologies built this way.
+    </p>
+    <p>
+      The breakdown now reports a distinct Machinery category to make that split
+      real, so a resource typed as machinery is costed where the methodology
+      expects it. Methodologies that do not separate the two are unaffected -
+      nothing changes for them.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">new methodology engine, switchable against the existing international method.</p></div>
+      <div class="stat-card"><p class="stat-num">2</p><p class="stat-label">ready-to-install templates lead the set: a Uzbekistan cascade and a railway breakdown.</p></div>
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">distinct Machinery category, no longer folded into installed equipment.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.6.0 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-7-0.html
+++ b/marketing-site/news/v8-7-0.html
@@ -1,0 +1,560 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.7.0 lets a country or industry pack carry its own estimating methodology and apply it automatically, so new projects follow local convention out of the box. Methodology estimates export to PDF and Excel, point cloud scans in LAS, LAZ and COPC can be read directly, several existing capabilities are surfaced in the interface, and a broad security and data-integrity pass spans many modules. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-7-0.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-7-0.html" />
+  <meta property="og:title" content="v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass" />
+  <meta property="og:description" content="A country or industry pack can carry its own estimating methodology and apply it automatically, methodology estimates export to PDF and Excel, point cloud scans in LAS, LAZ and COPC can be read directly, and a broad security and data-integrity pass spans many modules. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-20T12:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass" />
+  <meta name="twitter:description" content="A country or industry pack can carry its own estimating methodology and apply it automatically, methodology estimates export to PDF and Excel, point cloud scans in LAS, LAZ and COPC can be read directly, and a broad security and data-integrity pass spans many modules. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass",
+    "datePublished": "2026-06-20",
+    "dateModified": "2026-06-20",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-7-0.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.7.0 - Packs that carry their own estimating methodology, and a broad hardening pass</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 20, 2026</span>
+      <span class="pill-meta">~5 min read</span>
+    </div>
+    <h1>v8.7.0 - packs that carry their own <span class="accent">estimating methodology</span>, and a broad hardening pass.</h1>
+    <p class="lede">
+      The methodology engine meets the country packs. A pack can now carry its
+      own estimating methodology and apply it automatically, so the moment you
+      install one, its demo project and any new project you start follow local
+      convention instead of the generic method. Methodology estimates export to
+      PDF and Excel, point cloud scans read directly, several existing
+      capabilities surface in the interface, and a broad security and
+      data-integrity pass runs across many modules.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.7.0 connects two earlier pieces of work. The methodology engine gave a
+      project a method you could build and switch; the country packs gave it
+      local measurement, grading and procurement rules. Now a pack carries its
+      methodology with it and applies it on install, so a United States, United
+      Kingdom, India, German or Australian project starts on the right cascade
+      without a manual step. Around that headline, a wide hardening pass closes
+      cross-tenant gaps, guards monetary inputs and stops partial edits dropping
+      fields - the unglamorous work that keeps shared data trustworthy.
+    </p>
+
+    <h2>What is new in version 8.7.0</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Packs carry and apply their own methodology.</strong> When you install a country or industry pack, its demo project - and any new project you create while that pack is active - starts on the pack's methodology (for example the United States, United Kingdom, India, Germany or Australia cascade) instead of the generic international method, so estimates follow local convention out of the box.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Methodology estimates export, and the gallery opens without a project.</strong> Estimates built with the methodology engine export to PDF and Excel, and the methodologies page shows its template gallery even when no project is open, so you can browse what ships before starting one.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Point cloud scans read directly.</strong> Scans in LAS, LAZ and COPC formats can be read directly. The reader is an installable extra and the supported formats are stated up front, so an unsupported file - such as E57, which needs the additional package - is reported clearly instead of failing silently.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Existing capabilities, now surfaced in the interface.</strong> A dedicated viewer for 360-degree panorama photos, data-validation results that export to Excel, 4D and earned-value progress in the schedule view, a scan-versus-design overlay, an offline pending-changes indicator, and a single approvals inbox. Clash results can also be suppressed in bulk, and file-manager uploads are routed by file kind.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A broad security, integrity and quality pass.</strong> Cross-tenant access gaps were closed across portfolio analytics, cross-project similarity, collaboration viewpoints and others; monetary inputs are validated so one bad entry cannot corrupt a total; financial roll-ups no longer blend currencies; and a deep-quality pass across the BOQ, clash, procurement, RFI and schedule modules fixed more than 150 issues.
+      </li>
+    </ul>
+
+    <h2>Install a pack, get the right method with it</h2>
+    <p>
+      A country pack already brought local measurement standards, contractor
+      grading and procurement rules. What it could not do was set the way costs
+      are marked up, so even with the right pack installed, a new project still
+      started on the generic international method and someone had to switch it by
+      hand. 8.7.0 closes that gap: a pack carries its own estimating methodology
+      and applies it automatically. Install the United States, United Kingdom,
+      India, German or Australian pack and its demo project - plus any project you
+      create while it is active - starts on that pack's cascade.
+    </p>
+    <p>
+      Estimates built with the methodology engine now export to PDF and Excel, so
+      a methodology-based number leaves the app in the formats a client or a
+      tender expects. And the methodologies page shows its template gallery even
+      when no project is open, so you can see exactly what a pack will apply
+      before you commit a project to it.
+    </p>
+
+    <h2>Reality capture, read where it lands</h2>
+    <p>
+      Point cloud scans in LAS, LAZ and COPC can be read directly. The reader is
+      an installable extra, and the supported formats are stated up front, so a
+      file the base install cannot read - E57, for instance, which needs the
+      additional package - is reported clearly rather than failing in a way that
+      leaves you guessing. Alongside it, several capabilities that already existed
+      under the hood are now reachable in the interface: a viewer for 360-degree
+      panorama photos, validation results that export to Excel, 4D and
+      earned-value progress in the schedule, a scan-versus-design overlay, an
+      offline pending-changes indicator, and a single approvals inbox.
+    </p>
+
+    <h2>The quiet work that keeps shared data honest</h2>
+    <p>
+      A platform several teams share has to be strict about who can see what and
+      what counts as a valid number. 8.7.0 runs a broad security and
+      data-integrity pass: cross-tenant access gaps were closed so portfolio
+      analytics, cross-project similarity, collaboration viewpoints,
+      accommodation and others scope strictly to the projects you may access.
+      Monetary inputs across change orders, risk, QMS, punch lists and bids now
+      reject invalid values - not-a-number, infinity, absurd magnitudes - so one
+      bad entry can no longer corrupt a project-wide total or crash a report, and
+      financial roll-ups no longer blend different currencies into a single
+      mislabelled figure.
+    </p>
+    <p>
+      Partial edits no longer silently drop the fields they did not mention, a
+      shared tenant-scope and money-handling layer was added, and a
+      continuous-integration check keeps these from regressing. On top of the
+      security work, a deep-quality pass across the bill-of-quantities, clash,
+      procurement, RFI and schedule modules fixed more than 150 correctness,
+      performance and usability issues, including locale-aware parsing of
+      European-formatted amounts in GAEB import and faster critical-path
+      scheduling. A BIM model with no 3D geometry now shows a clear "No 3D
+      geometry" notice (<a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/59" target="_blank" rel="noopener">#59</a>), and the 3D viewer releases its graphics context when you navigate away so opening several models in one session no longer exhausts the browser.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">5</p><p class="stat-label">pack cascades apply on install: United States, United Kingdom, India, Germany and Australia.</p></div>
+      <div class="stat-card"><p class="stat-num">150+</p><p class="stat-label">correctness, performance and usability issues fixed in the deep-quality pass.</p></div>
+      <div class="stat-card"><p class="stat-num">3</p><p class="stat-label">point cloud formats read directly: LAS, LAZ and COPC.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.7.0 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-7-1.html
+++ b/marketing-site/news/v8-7-1.html
@@ -1,0 +1,522 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.7.1 stops the recurring timeout message flooding the screen on a busy or slow server, clears the never-ending Converting spinner for an interrupted CAD conversion, stops the AI Estimator analysing a source twice, and aligns the transmittals page with the real lifecycle. The AI agent tools now verify project access before reading anything. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-7-1.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-7-1.html" />
+  <meta property="og:title" content="v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes" />
+  <meta property="og:description" content="The recurring timeout message no longer floods the screen on a busy server, an interrupted CAD conversion stops spinning forever, the AI Estimator no longer analyses a source twice, and the AI agent tools now verify project access before reading anything. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-20T18:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes" />
+  <meta name="twitter:description" content="The recurring timeout message no longer floods the screen on a busy server, an interrupted CAD conversion stops spinning forever, the AI Estimator no longer analyses a source twice, and the AI agent tools now verify project access before reading anything. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes",
+    "datePublished": "2026-06-20",
+    "dateModified": "2026-06-20",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-7-1.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.7.1 - A calmer screen on a busy server, and several takeoff and estimator fixes</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 20, 2026</span>
+      <span class="pill-meta">~3 min read</span>
+    </div>
+    <h1>v8.7.1 - a <span class="accent">calmer screen</span> on a busy server, and several takeoff and estimator fixes.</h1>
+    <p class="lede">
+      A maintenance release that smooths the rough edges of 8.7.0. The recurring
+      timeout message no longer floods the screen on a busy or slow server, an
+      interrupted CAD conversion stops spinning forever, the AI Estimator no
+      longer analyses a source twice, and the transmittals page reflects the real
+      transmittal lifecycle. The AI agent tools also now verify project access
+      before reading anything.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.7.1 is the follow-up that catches what only shows up once people use a
+      release in earnest: a notice that piles up under load, a spinner that never
+      resolves after a restart, a first estimate step that ran twice, a status
+      filter that listed states the system never produced. None of it changes how
+      the app works - it makes the app behave the way you already expected it to.
+    </p>
+
+    <h2>What is fixed in version 8.7.1</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>No more timeout-message flood.</strong> The recurring "Request timed out" message no longer floods the screen on a busy or slow server. Repeated timeout notices are coalesced to one, a timed-out request is no longer retried (which previously produced a second notice), and the request budget was raised so a slow-but-valid response now succeeds instead of being cancelled.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>An interrupted conversion stops spinning.</strong> A CAD drawing whose conversion was interrupted by a server restart or update no longer shows a "Converting..." spinner forever. The interrupted conversion is detected and reported as a clear, actionable error, so you can remove the drawing and upload it again instead of waiting indefinitely.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>The AI Estimator runs its first step once.</strong> The AI Estimator no longer runs its source-analysis step twice when you start a new estimate, halving the time and cost of that first stage.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Transmittals, the guided form and a few more.</strong> The transmittals page now reflects the real lifecycle (draft, issued, responded) instead of statuses that were never produced. The guided AI estimate form no longer shows raw internal labels and its Yes/No answers are translated, point cloud files with the .copc.laz double extension are recognised as COPC, and the Geo Hub "auto-anchor all projects" action waits for every project to be placed instead of giving up early.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>AI agent tools verify project access.</strong> The AI agent tools that read a project's documents, cost summary or bill of quantities now verify that the person running the agent has access to the target project before reading anything. A denied or unknown target returns the same "not found" result as a missing one, so neither data nor a resource's existence is leaked, and scheduled or event-triggered runs are confined to projects their owner can access.
+      </li>
+    </ul>
+
+    <h2>A screen that stays readable under load</h2>
+    <p>
+      On a busy or slow server, a single timeout used to multiply: each request
+      that ran long raised its own "Request timed out" notice, a retry produced a
+      second, and several parallel requests stacked the banners until the screen
+      was hard to read. 8.7.1 coalesces repeated timeout notices to one, stops
+      retrying a request that already timed out, and raises the request budget so
+      a response that is merely slow now completes instead of being cancelled. The
+      result is a screen that tells you about a problem once, clearly, rather than
+      burying you in copies of the same message.
+    </p>
+
+    <h2>Spinners that resolve, and a first step that runs once</h2>
+    <p>
+      A CAD conversion that was cut off by a server restart or update used to
+      leave a "Converting..." spinner running with nothing behind it. That state
+      is now detected and reported as a clear, actionable error, so you can remove
+      the drawing and upload it again instead of waiting on a job that will never
+      finish. And the AI Estimator, which had been running its source-analysis
+      step twice at the start of a new estimate, now runs it once - halving the
+      time and the cost of that first stage.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">timeout notice now, however many requests run long - coalesced from a flood.</p></div>
+      <div class="stat-card"><p class="stat-num">2x</p><p class="stat-label">faster and cheaper first AI estimate step, no longer run twice.</p></div>
+      <div class="stat-card"><p class="stat-num">3</p><p class="stat-label">real transmittal states the page now shows: draft, issued, responded.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.7.1 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-8-0.html
+++ b/marketing-site/news/v8-8-0.html
@@ -1,0 +1,564 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.8.0 adds Monte-Carlo cost-risk analysis for a bill of quantities: thousands of correlated iterations produce a full cost distribution with P5 to P95 bands, a probability S-curve, a recommended contingency and a variance tornado. An in-app How it works hub explains every module in all 27 languages, the Geo Hub gains lightweight 2D maps, and count-by-example arrives in takeoff. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-8-0.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-8-0.html" />
+  <meta property="og:title" content="v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub" />
+  <meta property="og:description" content="Monte-Carlo cost-risk analysis for a bill of quantities produces a full cost distribution with P5 to P95 bands, a probability S-curve, a recommended contingency and a variance tornado. An in-app How it works hub explains every module in all 27 languages, the Geo Hub gains lightweight 2D maps, and count-by-example arrives in takeoff. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-21T12:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub" />
+  <meta name="twitter:description" content="Monte-Carlo cost-risk analysis for a bill of quantities produces a full cost distribution with P5 to P95 bands, a probability S-curve, a recommended contingency and a variance tornado. An in-app How it works hub explains every module, and count-by-example arrives in takeoff. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub",
+    "datePublished": "2026-06-21",
+    "dateModified": "2026-06-21",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-8-0.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.8.0 - Monte-Carlo cost-risk for a bill of quantities, and an in-app How it works hub</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 21, 2026</span>
+      <span class="pill-meta">~5 min read</span>
+    </div>
+    <h1>v8.8.0 - <span class="accent">Monte-Carlo cost-risk</span> for a bill of quantities, and an in-app How it works hub.</h1>
+    <p class="lede">
+      A single number hides the risk in an estimate. 8.8.0 adds Monte-Carlo
+      cost-risk analysis for a bill of quantities: thousands of correlated
+      iterations produce a full cost distribution, with P5 to P95 bands, a
+      probability S-curve, a recommended contingency at your confidence level and
+      a tornado of what drives the variance. An in-app How it works hub explains
+      every module in all 27 languages, the Geo Hub gains 2D maps, and takeoff can
+      count by example.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      An estimate that resolves to one figure tells you what you expect to spend,
+      but not how confident you should be in it. 8.8.0 answers the second
+      question. Its headline is a Monte-Carlo cost-risk analysis that turns a bill
+      of quantities into a distribution rather than a point, so you can talk about
+      a confidence level and a contingency instead of a single guess. Alongside
+      it, a How it works hub puts a plain-language guide to every module inside
+      the app, and a clutch of smaller additions and fixes round out the release.
+    </p>
+
+    <h2>What is new in version 8.8.0</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Monte-Carlo cost-risk for a bill of quantities.</strong> It runs thousands of correlated, PERT-distributed iterations to produce a full cost distribution rather than a single point estimate: P5 to P95 percentile bands, mean and standard deviation, a probability S-curve (the chance the total lands at or under any given figure), a recommended contingency at your target confidence level, and a tornado chart showing which positions drive the most variance. A one-factor correlation keeps systemic risk from cancelling out across lines.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>An in-app How it works hub.</strong> Reachable from the Help menu, it explains every module - what it does, the main steps to use it, and a few practical tips - translated into all 27 languages.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Lightweight 2D maps in the Geo Hub.</strong> A basemap switcher lets you place and review project locations without loading the full 3D globe.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A DIN 276 element breakdown in cost benchmarks.</strong> With a short, plain-language guide to reading it.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Count by example in takeoff.</strong> Pick one symbol on a drawing and the tool finds and counts the matching symbols across the sheet.
+      </li>
+    </ul>
+
+    <h2>An estimate as a distribution, not a single number</h2>
+    <p>
+      Every line in a bill of quantities carries uncertainty, and those
+      uncertainties do not simply average out - some move together. The new
+      Monte-Carlo cost-risk analysis takes that seriously. It runs thousands of
+      correlated, PERT-distributed iterations across the bill and produces a full
+      cost distribution: the P5 to P95 percentile bands that frame the likely
+      range, the mean and standard deviation, and a probability S-curve that reads
+      off the chance the total lands at or under any figure you point at.
+    </p>
+    <p>
+      From there it answers the question a client actually asks - how much
+      contingency - by recommending one at your target confidence level, and it
+      shows a tornado chart of which positions drive the most variance, so you
+      know where to tighten the estimate first. A one-factor correlation keeps
+      systemic risk from cancelling out across lines, which is the failure mode of
+      a naive simulation that treats every line as independent. The result is a
+      risk picture you can defend, not a single number with a gut-feel margin
+      bolted on.
+    </p>
+
+    <h2>The whole platform, explained from inside it</h2>
+    <p>
+      A platform with this many modules needs a way to learn it that does not mean
+      leaving it. The new How it works hub, reachable from the Help menu, explains
+      every module in plain language - what it does, the main steps to use it, and
+      a few practical tips - and it is translated into all 27 languages, so the
+      guidance reads correctly whichever language a team works in. It turns the
+      app into something you can explore with the manual open in the same window.
+    </p>
+    <p>
+      Three smaller additions round out the release. The Geo Hub gains lightweight
+      2D maps with a basemap switcher, so you can place and review project
+      locations without spinning up the full 3D globe. Cost benchmarks gain a DIN
+      276 element breakdown with a short guide to reading it. And takeoff can count
+      by example: pick one symbol on a drawing and the tool finds and counts the
+      matching symbols across the sheet.
+    </p>
+
+    <h2>Fixes and hardening</h2>
+    <p>
+      A bill-of-quantities parent position now rolls its children's progress up as
+      a quantity-weighted average - falling back to a simple average when the
+      children carry no quantity - so a parent's percent-complete reflects the
+      relative size of its parts instead of treating every child equally. Contract
+      cumulative completed value is recomputed on the server, so progress claims
+      always reconcile to the stored line items, and a quality pass across the
+      lower-traffic modules fixed currency display, action-button gating and
+      several save and persistence issues.
+    </p>
+    <p>
+      Installing a BIM or CAD converter no longer fails with "signal timed out" on
+      a slow server: the download now runs in the background and the panel updates
+      when it finishes, instead of the request being cancelled mid-download. On
+      the security side, the ERP chat assistant and the project-intelligence
+      advisor now honour project team membership when checking access, the
+      property-development broker leaderboard scopes strictly to the caller's own
+      brokers, and the bundled build-time dependencies were updated to clear all
+      known advisories - twelve in total, five high-severity, none of which ship
+      in the running application.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">P5-P95</p><p class="stat-label">percentile bands the Monte-Carlo analysis frames the likely cost range with.</p></div>
+      <div class="stat-card"><p class="stat-num">27</p><p class="stat-label">languages the How it works hub explains every module in.</p></div>
+      <div class="stat-card"><p class="stat-num">12</p><p class="stat-label">build-time advisories cleared, five of them high-severity.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.8.0 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-8-1.html
+++ b/marketing-site/news/v8-8-1.html
@@ -1,0 +1,499 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.8.1 - A takeoff PDF now stays attached to its project after a reload - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.8.1 keeps a PDF uploaded for quantity takeoff attached to the active project, so it stays in the document list after a page reload instead of disappearing. The server still verifies the caller's access to the project before storing the file. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-8-1.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-8-1.html" />
+  <meta property="og:title" content="v8.8.1 - A takeoff PDF now stays attached to its project after a reload" />
+  <meta property="og:description" content="A PDF uploaded for quantity takeoff now stays attached to the active project, so it remains in the document list after a page reload instead of disappearing. The server still verifies access before storing the file. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-21T18:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.8.1 - A takeoff PDF now stays attached to its project after a reload" />
+  <meta name="twitter:description" content="A PDF uploaded for quantity takeoff now stays attached to the active project, so it remains in the document list after a page reload instead of disappearing. The server still verifies access before storing the file. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.8.1 - A takeoff PDF now stays attached to its project after a reload",
+    "datePublished": "2026-06-21",
+    "dateModified": "2026-06-21",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-8-1.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.8.1 - A takeoff PDF now stays attached to its project after a reload</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 21, 2026</span>
+      <span class="pill-meta">~2 min read</span>
+    </div>
+    <h1>v8.8.1 - a takeoff PDF now <span class="accent">stays attached</span> to its project after a reload.</h1>
+    <p class="lede">
+      A small, targeted fix. A PDF uploaded for quantity takeoff now stays
+      attached to the active project, so it remains in the document list after a
+      page reload instead of vanishing. The server already verified the caller's
+      access to the project before storing the file, and it still does.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.8.1 fixes one frustrating thing: a PDF you uploaded for takeoff could
+      disappear from the document list the moment you reloaded the page. This
+      release makes the upload stick to the project it was added to, so it is
+      still there when you come back.
+    </p>
+
+    <h2>What is fixed in version 8.8.1</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>A takeoff PDF stays attached to its project.</strong> A PDF uploaded for quantity takeoff now stays attached to the active project, so it remains in the document list after a page reload. Previously the upload was saved with no project; because the takeoff document list is filtered by the active project, the freshly uploaded file disappeared on refresh. The server already verifies the caller's access to the project before storing the file. Reported as <a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/242" target="_blank" rel="noopener">issue #242</a>.
+      </li>
+    </ul>
+
+    <h2>Why the file used to vanish</h2>
+    <p>
+      The takeoff document list shows the documents that belong to the project you
+      are working in - it is filtered by the active project, the way the rest of
+      the app scopes what you see. The upload, though, was being saved with no
+      project attached. While the page stayed open, the freshly uploaded file was
+      still in view, so nothing looked wrong; but the moment you reloaded, the
+      filter ran against the stored records, found a file with no project, and
+      left it out. The file was never lost - it simply did not match the list it
+      was supposed to appear in.
+    </p>
+    <p>
+      8.8.1 attaches the upload to the active project at the point it is stored,
+      so it satisfies that same filter on the next load and stays where you put
+      it. The access check was never the issue and has not changed: the server
+      still verifies that the caller can reach the project before it stores the
+      file.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">#242</p><p class="stat-label">the community report this release closes for vanishing takeoff uploads.</p></div>
+      <div class="stat-card"><p class="stat-num">1</p><p class="stat-label">project a takeoff PDF is now attached to, so it survives a page reload.</p></div>
+      <div class="stat-card"><p class="stat-num">2 GB</p><p class="stat-label">of RAM is all a full self-hosted instance needs to run.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.8.1 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>

--- a/marketing-site/news/v8-8-2.html
+++ b/marketing-site/news/v8-8-2.html
@@ -1,0 +1,529 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+
+  <!-- Google Analytics with Consent Mode v2 (GDPR-compliant) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JYQXK2652T"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    // Default: deny all until user makes a choice
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+      'wait_for_update': 500
+    });
+    // Restore prior consent if user already chose
+    try {
+      var prior = localStorage.getItem('oce-cookie-consent');
+      if (prior === 'granted') {
+        gtag('consent', 'update', { 'analytics_storage': 'granted' });
+      }
+    } catch (e) {}
+    gtag('js', new Date());
+    gtag('config', 'G-JYQXK2652T', { 'anonymize_ip': true });
+  </script>
+
+  <title>v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals - OpenConstructionERP</title>
+  <meta name="description" content="OpenConstructionERP v8.8.2 makes the BIM and CAD converters install themselves with no manual steps: the first time you upload an .rvt, .ifc, .dwg or .dgn file, the matching converter is fetched and provisioned in the background, trying several methods so it works across the widest range of hosts. Bill-of-quantities exports and side-by-side comparison now convert foreign-currency amounts into the project's base currency before totalling. Open-source, self-hosted." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://openconstructionerp.com/news/v8-8-2.html" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="OpenConstructionERP" />
+  <meta property="og:url" content="https://openconstructionerp.com/news/v8-8-2.html" />
+  <meta property="og:title" content="v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals" />
+  <meta property="og:description" content="The BIM and CAD converters now install themselves with no manual steps, trying several methods so they work across the widest range of hosts. Bill-of-quantities exports and side-by-side comparison now convert foreign-currency amounts into the project's base currency before totalling. Open-source, self-hosted." />
+  <meta property="article:published_time" content="2026-06-21T20:00:00Z" />
+  <meta property="article:author" content="Artem Boiko" />
+  <meta property="article:tag" content="Release" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals" />
+  <meta name="twitter:description" content="The BIM and CAD converters now install themselves with no manual steps, trying several methods so they work across the widest range of hosts. BOQ exports and comparison now convert foreign-currency amounts into the project's base currency before totalling. Open-source, self-hosted." />
+
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <meta name="theme-color" content="#2d5e8e" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <script>
+    (function () { try { var t = localStorage.getItem('oce-theme') || 'light'; document.documentElement.dataset.theme = t; } catch (e) { document.documentElement.dataset.theme = 'light'; } })();
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "headline": "v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals",
+    "datePublished": "2026-06-21",
+    "dateModified": "2026-06-21",
+    "author": { "@type": "Person", "name": "Artem Boiko" },
+    "publisher": { "@type": "Organization", "name": "DataDrivenConstruction", "logo": { "@type": "ImageObject", "url": "https://openconstructionerp.com/favicon.svg" } },
+    "mainEntityOfPage": "https://openconstructionerp.com/news/v8-8-2.html"
+  }
+  </script>
+
+  <style>
+    :root { --bg-0: #f1f2f3; --bg-1: #ebeced; --bg-2: #e4e5e7; --ink-0: #0b1220; --ink-1: #1e293b; --ink-2: #475569; --ink-3: #94a3b8; --line-0: rgba(15, 23, 42, 0.05); --line-1: rgba(15, 23, 42, 0.09); --line-2: rgba(15, 23, 42, 0.14); --card: #ffffff; --code-bg: #0f172a; --code-fg: #e2e8f0; --accent: #2d5e8e; --accent-2: #3c6fa0; --accent-3: #244c74; --accent-4: #2d5e8e; --accent-5: #3c6fa0; }
+    [data-theme="dark"] { --bg-0: #0b1220; --bg-1: #111a2c; --bg-2: #152238; --ink-0: #eff6ff; --ink-1: #cfe0f5; --ink-2: #94a3b8; --ink-3: #64748b; --line-0: rgba(255,255,255,0.06); --line-1: rgba(255,255,255,0.10); --line-2: rgba(255,255,255,0.16); --card: #111a2c; --code-bg: #0a0f1c; --code-fg: #e2e8f0; --accent: #6ba2d8; --accent-2: #84b3e2; --accent-3: #5a90c8; }
+    *, *::before, *::after { box-sizing: border-box; } html { scroll-behavior: smooth; }
+    body { margin: 0; background: radial-gradient(60% 50% at 50% 0%, color-mix(in oklab, var(--accent) 7%, transparent) 0%, transparent 70%), var(--bg-0); color: var(--ink-0); font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; font-size: 17px; line-height: 1.65; -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; overflow-x: hidden; }
+    a { color: inherit; text-decoration: none; } a:hover { color: var(--accent); }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .narrow { max-width: 720px; margin: 0 auto; padding: 0 clamp(20px, 4vw, 48px); }
+    .nav { position: sticky; top: 0; z-index: 50; background: color-mix(in oklab, var(--bg-0) 88%, transparent); -webkit-backdrop-filter: blur(14px) saturate(1.4); backdrop-filter: blur(14px) saturate(1.4); border-bottom: 1px solid var(--line-1); }
+    .nav-inner { max-width: 1300px; margin: 0 auto; padding: 12px clamp(20px, 4vw, 48px); display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+    .nav-left, .nav-right { display: flex; align-items: center; gap: 10px; }
+    .brand { display: inline-flex; align-items: baseline; font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: 17px; letter-spacing: -0.015em; }
+    .brand-seg-1 { color: var(--ink-0); } .brand-seg-2 { color: var(--ink-2); } .brand-seg-3 { color: var(--accent); font-weight: 800; }
+    .nav-icon-btn { width: 36px; height: 36px; display: grid; place-items: center; border-radius: 9px; border: 1px solid var(--line-2); background: transparent; color: var(--ink-2); cursor: pointer; transition: border-color 0.15s ease, color 0.15s ease; }
+    .nav-icon-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-icon-btn .icon-moon { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-sun { display: none; }
+    [data-theme="dark"] .nav-icon-btn .icon-moon { display: block; }
+    .nav-links { display: flex; gap: clamp(10px, 1.6vw, 22px); align-items: center; font-size: 14px; }
+    .nav-links a { color: var(--ink-2); font-weight: 500; padding: 6px 4px; transition: color 0.15s ease; }
+    .nav-links a:hover, .nav-links a.is-active { color: var(--accent); }
+    .nav-links a.is-active { font-weight: 600; }
+    .nav-pill { display: inline-flex; align-items: center; gap: 7px; padding: 8px 14px; border-radius: 999px; font-size: 13px; font-weight: 600; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease; }
+    .nav-pill.github { border: 1px solid var(--line-2); color: var(--ink-1); background: transparent; }
+    .nav-pill.github:hover { border-color: var(--accent); color: var(--accent); }
+    .nav-pill.cta { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 8px 18px -8px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .nav-pill.cta:hover { transform: translateY(-1px); color: #fff; }
+    .nav-pill .arrow { transition: transform 0.15s ease; } .nav-pill:hover .arrow { transform: translateX(2px); }
+    @media (max-width: 980px) { .nav-links a:not(.news-link), .nav-pill.github { display: none; } }
+    .article-hero { position: relative; padding: clamp(48px, 7vw, 96px) 0 clamp(32px, 5vw, 48px); overflow: hidden; }
+    .article-hero::before { content: ""; position: absolute; inset: 0; background-image: linear-gradient(to right, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px), linear-gradient(to bottom, color-mix(in oklab, var(--accent) 7%, transparent) 1px, transparent 1px); background-size: 56px 56px; -webkit-mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); mask-image: radial-gradient(ellipse 75% 60% at 50% 35%, black 30%, transparent 78%); pointer-events: none; opacity: 0.5; }
+    .article-hero > * { position: relative; }
+    .crumbs { font-family: 'Inter Tight', sans-serif; font-size: 13px; color: var(--ink-3); margin-bottom: 18px; }
+    .crumbs a:hover { color: var(--accent); } .crumbs .sep { margin: 0 8px; opacity: 0.5; }
+    .pill-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-bottom: 22px; }
+    .chip { display: inline-flex; align-items: center; padding: 3px 10px; border-radius: 999px; font-family: 'Inter Tight', sans-serif; font-size: 11.5px; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; }
+    .chip.release { background: color-mix(in oklab, var(--accent) 10%, transparent); color: var(--accent); border: 1px solid color-mix(in oklab, var(--accent) 24%, transparent); }
+    .chip.stable { background: color-mix(in oklab, #16a34a 12%, transparent); color: #16a34a; border: 1px solid color-mix(in oklab, #16a34a 28%, transparent); }
+    [data-theme="dark"] .chip.stable { color: #4ade80; border-color: color-mix(in oklab, #4ade80 32%, transparent); }
+    .pill-meta { font-family: 'JetBrains Mono', monospace; font-size: 13px; color: var(--ink-2); letter-spacing: 0.01em; }
+    .pill-meta + .pill-meta::before { content: "·"; margin: 0 8px; opacity: 0.5; }
+    .article-hero h1 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(34px, 5.6vw, 60px); line-height: 1.05; letter-spacing: -0.025em; margin: 0 0 22px; }
+    .article-hero h1 .accent { color: var(--accent); }
+    .article-hero p.lede { font-size: clamp(17px, 1.6vw, 21px); line-height: 1.55; color: var(--ink-2); max-width: 680px; margin: 0 0 28px; }
+    .article { padding: clamp(8px, 2vw, 24px) 0 clamp(48px, 6vw, 80px); }
+    .article p, .article ul, .article ol { font-size: 17px; line-height: 1.7; color: var(--ink-1); margin: 0 0 18px; }
+    .article ul, .article ol { padding-left: 22px; } .article ul li, .article ol li { margin-bottom: 6px; }
+    .article h2 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(24px, 2.6vw, 32px); line-height: 1.15; letter-spacing: -0.02em; margin: 56px 0 18px; color: var(--ink-0); }
+    .article h2:first-child { margin-top: 0; }
+    .article h3 { font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 19px; letter-spacing: -0.01em; margin: 28px 0 10px; color: var(--ink-0); }
+    .article a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in oklab, var(--accent) 32%, transparent); transition: border-color 0.15s ease; }
+    .article a:hover { border-bottom-color: var(--accent); }
+    .article .btn, .article .btn:hover { border-bottom: none; }
+    .article .btn-primary, .article .btn-primary:hover { color: #fff; }
+    .article .btn-ghost { color: var(--ink-0); }
+    .article .btn-ghost:hover { color: var(--accent); }
+    .article strong { color: var(--ink-0); font-weight: 600; }
+    .article code { font-family: 'JetBrains Mono', monospace; font-size: 0.92em; padding: 1px 6px; border-radius: 5px; background: color-mix(in oklab, var(--accent) 8%, var(--bg-1)); border: 1px solid color-mix(in oklab, var(--accent) 14%, var(--line-1)); color: var(--ink-0); }
+    .checklist { list-style: none; padding: 0; margin: 14px 0 28px; display: grid; gap: 12px; }
+    .checklist li { position: relative; padding: 16px 18px 16px 52px; background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; font-size: 16px; line-height: 1.6; color: var(--ink-1); transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .checklist li:hover { border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .checklist li::before { content: ""; position: absolute; left: 16px; top: 18px; width: 22px; height: 22px; border-radius: 7px; background: color-mix(in oklab, var(--accent) 12%, transparent); }
+    .checklist li svg { position: absolute; left: 20px; top: 22px; width: 14px; height: 14px; color: var(--accent); }
+    .statband { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 18px 0 30px; }
+    @media (max-width: 720px) { .statband { grid-template-columns: 1fr 1fr; } }
+    @media (max-width: 420px) { .statband { grid-template-columns: 1fr; } }
+    .stat-card { background: var(--card); border: 1px solid var(--line-1); border-radius: 14px; padding: 22px 20px; transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease; }
+    .stat-card:hover { transform: translateY(-2px); border-color: color-mix(in oklab, var(--accent) 35%, var(--line-1)); box-shadow: 0 14px 28px -16px rgba(2, 90, 160, 0.18); }
+    .stat-card .stat-num { font-family: 'Inter Tight', sans-serif; font-weight: 800; font-size: clamp(30px, 4vw, 40px); line-height: 1; letter-spacing: -0.03em; color: var(--accent); margin: 0 0 8px; }
+    .stat-card .stat-label { font-size: 14px; line-height: 1.5; color: var(--ink-2); margin: 0; }
+    .codewrap { position: relative; background: var(--code-bg); color: var(--code-fg); border-radius: 14px; padding: 22px 24px; margin: 14px 0 30px; font-family: 'JetBrains Mono', monospace; font-size: 14px; line-height: 1.7; overflow-x: auto; border: 1px solid rgba(107, 162, 216, 0.09); box-shadow: 0 18px 40px -20px rgba(2, 90, 160, 0.25); }
+    .codewrap .cmd::before { content: "$ "; color: #64748b; user-select: none; }
+    .codewrap .tok-cmd { color: #84b3e2; } .codewrap .tok-arg { color: #e2e8f0; } .codewrap .tok-flag { color: #fbbf24; } .codewrap .tok-amp { color: #64748b; padding: 0 4px; }
+    .copy-btn { position: absolute; top: 14px; right: 14px; padding: 6px 12px; border-radius: 8px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.14); color: #e2e8f0; font-family: 'Inter Tight', sans-serif; font-size: 12px; font-weight: 600; cursor: pointer; transition: background 0.15s ease, border-color 0.15s ease; }
+    .copy-btn:hover { background: rgba(107, 162, 216, 0.09); border-color: rgba(107, 162, 216, 0.09); }
+    .copy-btn.is-copied { background: rgba(34, 197, 94, 0.18); border-color: rgba(34, 197, 94, 0.4); color: #86efac; }
+    .cta-block { margin: 56px auto 0; padding: clamp(28px, 4vw, 44px); background: radial-gradient(80% 100% at 0% 0%, color-mix(in oklab, var(--accent) 14%, transparent), transparent 60%), radial-gradient(80% 100% at 100% 100%, color-mix(in oklab, var(--accent-3) 14%, transparent), transparent 60%), var(--card); border: 1px solid color-mix(in oklab, var(--accent) 25%, var(--line-1)); border-radius: 20px; text-align: center; }
+    .cta-block h3 { font-family: 'Inter Tight', sans-serif; font-weight: 700; font-size: clamp(22px, 2.4vw, 28px); letter-spacing: -0.015em; margin: 0 0 8px; color: var(--ink-0); }
+    .cta-block p { color: var(--ink-2); font-size: 15px; margin: 0 0 22px; }
+    .cta-row { display: inline-flex; gap: 12px; flex-wrap: wrap; justify-content: center; }
+    .btn { display: inline-flex; align-items: center; gap: 8px; padding: 11px 20px; border-radius: 12px; font-family: 'Inter Tight', sans-serif; font-weight: 600; font-size: 14.5px; letter-spacing: -0.005em; transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+    .btn .arrow { transition: transform 0.15s ease; } .btn:hover .arrow { transform: translateX(3px); }
+    .btn-primary { background: linear-gradient(135deg, var(--accent) 0%, var(--accent-3) 100%); color: #fff; box-shadow: 0 1px 0 rgba(255,255,255,0.3) inset, 0 10px 22px -10px color-mix(in oklab, var(--accent) 60%, transparent); }
+    .btn-primary:hover { transform: translateY(-1px); color: #fff; }
+    .btn-ghost { background: transparent; border: 1px solid var(--line-2); color: var(--ink-0); }
+    .btn-ghost:hover { border-color: var(--accent); color: var(--accent); }
+    .pagefoot { border-top: 1px solid var(--line-1); padding: 28px 0; margin-top: 24px; color: var(--ink-2); font-size: 13px; }
+    .pagefoot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+    .pagefoot a { color: var(--ink-2); } .pagefoot a:hover { color: var(--accent); }
+    @media (max-width: 540px) { .article p, .article ul, .article ol { font-size: 16px; } .checklist li { font-size: 15px; } }
+
+    /* ================================================================ */
+    /* COOKIE BANNER - GDPR-compliant consent dialog                     */
+    /* ================================================================ */
+    .cookie-banner {
+      position: fixed;
+      left: 50%;
+      bottom: 20px;
+      transform: translateX(-50%) translateY(14px);
+      width: min(720px, calc(100vw - 32px));
+      z-index: 9999;
+      background: color-mix(in oklab, #ffffff 88%, transparent);
+      border: 1px solid var(--line-1);
+      border-radius: 18px;
+      backdrop-filter: blur(22px) saturate(180%);
+      -webkit-backdrop-filter: blur(22px) saturate(180%);
+      box-shadow: 0 24px 64px -28px rgba(15, 23, 42, 0.35);
+      padding: 18px 22px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+    }
+    [data-theme="dark"] .cookie-banner {
+      background: color-mix(in oklab, #111a2c 88%, transparent);
+      box-shadow: 0 24px 64px -28px rgba(0, 0, 0, 0.7);
+    }
+    .cookie-banner.is-visible {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translateX(-50%) translateY(0);
+    }
+    .cookie-banner-inner {
+      display: grid;
+      grid-template-columns: 32px 1fr auto;
+      grid-gap: 16px;
+      align-items: center;
+    }
+    .cookie-banner-icon {
+      font-size: 22px;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+    }
+    .cookie-banner-body { min-width: 0; }
+    .cookie-banner-title {
+      font-family: 'Inter Tight', 'Inter', sans-serif;
+      font-weight: 650;
+      font-size: 14px;
+      color: var(--ink-0);
+      margin: 0 0 3px;
+      letter-spacing: -0.01em;
+    }
+    .cookie-banner-text {
+      font-size: 12.5px;
+      line-height: 1.5;
+      color: var(--ink-2);
+      margin: 0;
+    }
+    .cookie-banner-text a {
+      color: var(--accent);
+      text-decoration: none;
+      font-weight: 500;
+      border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+    }
+    .cookie-banner-text a:hover { border-bottom-color: var(--accent); }
+    .cookie-banner-actions {
+      display: inline-flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: nowrap;
+    }
+    .cookie-btn {
+      padding: 9px 16px;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: 12.5px;
+      font-weight: 600;
+      letter-spacing: 0.01em;
+      cursor: pointer;
+      white-space: nowrap;
+      transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .cookie-btn-reject {
+      background: transparent;
+      border: 1px solid var(--line-1);
+      color: var(--ink-1);
+    }
+    .cookie-btn-reject:hover {
+      border-color: color-mix(in oklab, var(--ink-0) 30%, var(--line-1));
+      background: color-mix(in oklab, var(--ink-0) 4%, transparent);
+    }
+    .cookie-btn-accept {
+      background: var(--accent);
+      border: 1px solid var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px -6px color-mix(in oklab, var(--accent) 55%, transparent);
+    }
+    .cookie-btn-accept:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 20px -6px color-mix(in oklab, var(--accent) 70%, transparent);
+    }
+    @media (max-width: 640px) {
+      .cookie-banner-inner {
+        grid-template-columns: 28px 1fr;
+        grid-gap: 12px;
+      }
+      .cookie-banner-actions {
+        grid-column: 1 / -1;
+        margin-top: 4px;
+      }
+      .cookie-btn { flex: 1; text-align: center; }
+    }
+  </style>
+</head>
+<body>
+
+<nav class="nav" aria-label="Primary">
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a class="brand" href="/"><span class="brand-name"><span class="brand-seg-1">Open</span><span class="brand-seg-2">Construction</span><span class="brand-seg-3">ERP</span></span></a>
+      <button type="button" class="nav-icon-btn" id="theme-toggle" aria-label="Toggle theme" title="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79Z"/></svg>
+      </button>
+    </div>
+    <div class="nav-links">
+      <a href="/services.html">Practices</a>
+      <a href="/industries.html">Industries</a>
+      <a href="/standards.html">Standards</a>
+      <a href="/maturity.html">Maturity</a>
+      <a href="/#pricing">Pricing</a>
+      <a href="/partners.html">Partners</a>
+      <a href="/news.html" class="news-link is-active">News</a>
+      <a href="/docs.html">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a class="nav-pill github" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+        <span>GitHub</span>
+      </a>
+      <a class="nav-pill cta" href="/demo"><span>Try demo</span><svg class="arrow" viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+    </div>
+  </div>
+</nav>
+
+<section class="article-hero">
+  <div class="narrow">
+    <div class="crumbs">
+      <a href="/">Home</a><span class="sep">/</span>
+      <a href="/news.html">News</a><span class="sep">/</span>
+      <span>v8.8.2 - BIM and CAD converters that install themselves, and currency-correct BOQ totals</span>
+    </div>
+    <div class="pill-row">
+      <span class="chip release">Release</span>
+      <span class="chip stable">Stable</span>
+      <span class="pill-meta">June 21, 2026</span>
+      <span class="pill-meta">~4 min read</span>
+    </div>
+    <h1>v8.8.2 - BIM and CAD converters that <span class="accent">install themselves</span>, and currency-correct BOQ totals.</h1>
+    <p class="lede">
+      No more Settings detour to get a converter. From 8.8.2, the first time you
+      upload an .rvt, .ifc, .dwg or .dgn file, the matching converter is fetched
+      and provisioned in the background, trying several methods in turn so it
+      works across the widest range of hosts. And bill-of-quantities exports and
+      side-by-side comparison now convert foreign-currency amounts into the
+      project's base currency before totalling, so a mixed-currency total
+      reconciles.
+    </p>
+  </div>
+</section>
+
+<article class="article">
+  <div class="narrow">
+
+    <p>
+      8.8.2 removes a setup step and closes a money bug. The BIM and CAD
+      converters used to need a manual install from the Settings screen before a
+      native file would convert; now they install themselves on first use,
+      quietly and across a wide range of server types. And the bill-of-quantities
+      exports and the compare view, which used to add raw figures from different
+      currencies together, now convert everything to the project's base currency
+      first, so the totals are right.
+    </p>
+
+    <h2>What is new in version 8.8.2</h2>
+
+    <ul class="checklist">
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Converters install themselves, with no manual steps.</strong> The first time you upload an .rvt, .ifc, .dwg or .dgn file, the matching converter is fetched and provisioned in the background, with an inline notice showing progress; you no longer have to open Settings and click Install. The install tries several methods in turn so it works across the widest range of hosts, downloads resume and retry on slow or flaky links, and the binary is self-tested after install.
+      </li>
+      <li>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+        <strong>Currency-correct bill-of-quantities totals.</strong> Bill-of-quantities exports and side-by-side comparison now convert foreign-currency amounts into the project's base currency before totalling, at both the position and the resource level. An export that mixed currencies previously added the raw figures together; the Excel and PDF exports and the compare view now apply the project exchange rates so the totals reconcile. Reported as <a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/150" target="_blank" rel="noopener">issue #150</a>.
+      </li>
+    </ul>
+
+    <h2>The converter is just there when you need it</h2>
+    <p>
+      Converting a native CAD or BIM file - an .rvt, .ifc, .dwg or .dgn - used to
+      mean a detour: open Settings, find the right converter, click Install, wait,
+      then go back and upload. 8.8.2 removes the detour. The first time you upload
+      one of those files, the matching converter is fetched and provisioned in the
+      background, with an inline notice showing progress, so the work starts from
+      the upload you were already making.
+    </p>
+    <p>
+      Getting that to work everywhere is the hard part, because servers differ.
+      The install tries several methods in turn: a system package install when the
+      service runs with the right privileges, a rootless unpack into the app's own
+      data directory when it does not, and a built-in pure-Python reader for the
+      package format when neither system tool is present - the case on minimal
+      containers and non-Debian distributions. Downloads resume and retry on slow
+      or flaky links, and the binary is self-tested after install, so a converter
+      that reports itself ready actually runs. Terminal install steps remain
+      documented for locked-down networks, but only as a genuine last resort.
+    </p>
+
+    <h2>Totals that add up across currencies</h2>
+    <p>
+      A bill of quantities can carry costs in more than one currency - an imported
+      rate here, a supplier quote there. When those amounts were exported or
+      compared, the totals were simply summing the raw figures, which means adding
+      numbers that are not in the same unit. The result was a total that looked
+      precise and was wrong.
+    </p>
+    <p>
+      8.8.2 fixes this at the source. Bill-of-quantities exports and the
+      side-by-side comparison now convert every foreign-currency amount into the
+      project's base currency before totalling, at both the position and the
+      resource level, using the project's exchange rates. The Excel export, the
+      PDF export and the compare view all reconcile now, so a mixed-currency bill
+      adds up to a figure you can hand to a client. This was reported as
+      <a href="https://github.com/datadrivenconstruction/OpenConstructionERP/issues/150" target="_blank" rel="noopener">issue #150</a>.
+    </p>
+
+    <h2>By the numbers</h2>
+    <div class="statband">
+      <div class="stat-card"><p class="stat-num">4</p><p class="stat-label">native file types whose converter now installs itself on first upload: RVT, IFC, DWG, DGN.</p></div>
+      <div class="stat-card"><p class="stat-num">3</p><p class="stat-label">install methods tried in turn so it works across the widest range of hosts.</p></div>
+      <div class="stat-card"><p class="stat-num">#150</p><p class="stat-label">the community report this release closes for mixed-currency BOQ totals.</p></div>
+    </div>
+
+    <h2>Install or upgrade</h2>
+
+    <div class="codewrap">
+      <button type="button" class="copy-btn" id="copy-upgrade" aria-label="Copy upgrade command">Copy</button>
+<pre><span class="cmd"><span class="tok-cmd">pip</span> <span class="tok-arg">install</span> <span class="tok-flag">--upgrade</span> <span class="tok-arg">openconstructionerp</span></span></pre>
+    </div>
+
+    <p>
+      The desktop installers for Windows, macOS and Linux carry the same
+      one-installer setup, and the Linux build includes the CAD and BIM
+      converters for AutoCAD, Revit and IFC. You can grab the latest installers
+      from
+      <a href="https://openconstructionerp.com/download">openconstructionerp.com/download</a>.
+      If you run an external PostgreSQL through <code>DATABASE_URL</code>,
+      nothing about that connection changes. Questions or trouble upgrading,
+      write to
+      <a href="mailto:info@datadrivenconstruction.io">info@datadrivenconstruction.io</a>.
+    </p>
+
+    <div class="cta-block">
+      <h3>Try v8.8.2 today.</h3>
+      <p>Live demo in your browser, or self-host in five minutes. AGPL-3.0, no signup required.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="/demo"><span>Try the demo</span><svg class="arrow" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></a>
+        <a class="btn btn-ghost" href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor" aria-hidden="true"><path d="M12 0.5C5.65 0.5 0.5 5.65 0.5 12a11.5 11.5 0 0 0 7.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.28-1.68-1.28-1.68-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.7 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.47.11-3.05 0 0 .97-.31 3.18 1.18A11 11 0 0 1 12 6.8a11 11 0 0 1 2.9.39c2.2-1.5 3.17-1.18 3.17-1.18.63 1.58.24 2.76.12 3.05.74.81 1.18 1.84 1.18 3.1 0 4.43-2.7 5.4-5.27 5.69.42.36.78 1.07.78 2.15v3.19c0 .31.21.67.8.56A11.5 11.5 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z"/></svg>
+          <span>View on GitHub</span>
+        </a>
+      </div>
+    </div>
+
+  </div>
+</article>
+
+<footer class="pagefoot">
+  <div class="wrap">
+    <div class="pagefoot-inner">
+      <div>&copy; 2026 Artem Boiko / DataDrivenConstruction &middot; Open source under AGPL-3.0.</div>
+      <div>
+        <a href="/">Home</a> &middot;
+        <a href="/partners.html">Partners</a> &middot;
+        <a href="/news.html">News</a> &middot;
+        <a href="https://github.com/datadrivenconstruction/OpenConstructionERP" target="_blank" rel="noopener">GitHub</a> &middot;
+        <a href="https://datadrivenconstruction.io" target="_blank" rel="noopener">DataDrivenConstruction.io</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<!-- ================================================================ -->
+<!-- COOKIE CONSENT BANNER                                             -->
+<!-- ================================================================ -->
+<div class="cookie-banner" id="cookie-banner" role="dialog" aria-label="Cookie preferences" aria-live="polite">
+  <div class="cookie-banner-inner">
+    <div class="cookie-banner-icon" aria-hidden="true">🍪</div>
+    <div class="cookie-banner-body">
+      <div class="cookie-banner-title" data-i18n="cookie.title">Cookies &amp; analytics</div>
+      <p class="cookie-banner-text" data-i18n-html="cookie.text">
+        We use essential cookies and anonymised analytics to improve the site. No third-party trackers, no ads. <a href="/privacy-policy.html">Learn more</a>.
+      </p>
+    </div>
+    <div class="cookie-banner-actions">
+      <button type="button" class="cookie-btn cookie-btn-reject" id="cookie-reject" data-i18n="cookie.reject">Reject non-essential</button>
+      <button type="button" class="cookie-btn cookie-btn-accept" id="cookie-accept" data-i18n="cookie.accept">Accept all</button>
+    </div>
+  </div>
+</div>
+
+<script>
+  (function () {
+    var btn = document.getElementById('theme-toggle'); if (!btn) return;
+    btn.addEventListener('click', function () {
+      var cur = document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
+      var next = cur === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { localStorage.setItem('oce-theme', next); } catch (e) {}
+    });
+  })();
+  (function () {
+    var btn = document.getElementById('copy-upgrade'); if (!btn) return;
+    var cmd = 'pip install --upgrade openconstructionerp';
+    btn.addEventListener('click', function () {
+      var done = function () { var prev = btn.textContent; btn.textContent = 'Copied'; btn.classList.add('is-copied'); setTimeout(function () { btn.textContent = prev; btn.classList.remove('is-copied'); }, 1600); };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(done).catch(function () { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); });
+      } else { var ta = document.createElement('textarea'); ta.value = cmd; document.body.appendChild(ta); ta.select(); try { document.execCommand('copy'); } catch (e) {} document.body.removeChild(ta); done(); }
+    });
+  })();
+  // Cookie consent banner - GDPR Consent Mode v2 integration
+  (function setupCookieBanner() {
+    const banner = document.getElementById('cookie-banner');
+    const accept = document.getElementById('cookie-accept');
+    const reject = document.getElementById('cookie-reject');
+    if (!banner) return;
+    let prior = null;
+    try { prior = localStorage.getItem('oce-cookie-consent'); } catch (e) {}
+    if (!prior) {
+      setTimeout(() => banner.classList.add('is-visible'), 800);
+    }
+    function apply(choice) {
+      try { localStorage.setItem('oce-cookie-consent', choice); } catch (e) {}
+      if (typeof gtag === 'function') {
+        gtag('consent', 'update', {
+          'analytics_storage': choice === 'granted' ? 'granted' : 'denied'
+        });
+      }
+      banner.classList.remove('is-visible');
+    }
+    accept?.addEventListener('click', () => apply('granted'));
+    reject?.addEventListener('click', () => apply('denied'));
+    // Allow re-opening via any element with data-open-cookies
+    document.querySelectorAll('[data-open-cookies]').forEach((el) => {
+      el.addEventListener('click', (e) => { e.preventDefault(); banner.classList.add('is-visible'); });
+    });
+  })();
+</script>
+
+<script src="/news/assets/related-articles.js" defer></script>
+
+</body>
+</html>


### PR DESCRIPTION
## v8.8.2 supporting changes (news + capture harness)

Post-release follow-up to the v8.8.2 app release (#255). Kept separate so it did not restart the release CI.

### Marketing news (8 pages)
The news section had lapsed after `v8-3-0.html`. Adds release pages for **v8.4.0 through v8.8.2**, authored from `CHANGELOG.md` and wired into `news.html` + `related-articles.js`. Per-page SEO + canonical URLs, no competitor names, no em-dashes.

### CI module-capture harness (workflow_dispatch)
A reproducible way to record per-module video/GIF clips of the running app. The app cannot run locally here (it needs Python 3.12) and the production host must not be driven by a recording browser, so capture runs in CI:
- `.github/workflows/module-captures.yml` boots the app exactly like `e2e-cross-os.yml` (py3.12 + embedded PostgreSQL + demo seed), records a short clip per flagship module, converts each to an optimized GIF with ffmpeg, and uploads `webm` + `gif` + `captures.json` as artifacts.
- `frontend/tests/e2e/capture-module-videos.spec.ts` + `frontend/playwright.captures.config.ts` drive it (12 flagship modules, resilient per-module try/catch, demo-login reused from the smoke spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
