### PR TITLE
fix: pointcloud WebGL2 guard (Firefox/WebKit) + EAC KPI registration

### DIFF
--- a/backend/app/modules/bi_dashboards/kpis.py
+++ b/backend/app/modules/bi_dashboards/kpis.py
@@ -794,14 +794,11 @@ async def sv_kpi(
     )
 
 
-@register_kpi(
-    "eac",
-    name="Estimate at Completion",
-    unit="currency",
-    category="financial",
-    source_modules=["finance", "tasks", "projects"],
-    description=("AC + (BAC - EV) / (CPI * SPI) - assumes both perf indices persist (common in construction)."),
-)
+# Pure helper shared by the EAC / ETC / VAC KPI formulas below. NOT a
+# registered KPI itself - the ``@register_kpi("eac", ...)`` decorator lives on
+# ``eac_kpi``, which the registry invokes with ``(session, project_id=...,
+# allowed_project_ids=..., **)``. This helper takes only the four EVM
+# primitives, so it must stay undecorated.
 def _eac_from_primitives(bac: Decimal, pv: Decimal, ev: Decimal, ac: Decimal) -> Decimal:
     """EAC = AC + (BAC - EV) / (CPI * SPI). Falls back to BAC when a
     performance index is undefined (no actuals / no progress yet)."""
@@ -815,6 +812,14 @@ def _eac_from_primitives(bac: Decimal, pv: Decimal, ev: Decimal, ac: Decimal) ->
     return ac + _safe_div(bac - ev, denom)
 
 
+@register_kpi(
+    "eac",
+    name="Estimate at Completion",
+    unit="currency",
+    category="financial",
+    source_modules=["finance", "tasks", "projects"],
+    description=("AC + (BAC - EV) / (CPI * SPI) - assumes both perf indices persist (common in construction)."),
+)
 async def eac_kpi(
     session: AsyncSession,
     project_id: uuid.UUID | None = None,

--- a/frontend/src/features/pointcloud/PointCloudBackground.tsx
+++ b/frontend/src/features/pointcloud/PointCloudBackground.tsx
@@ -28,6 +28,26 @@ const POINT_COUNT = 2200;
 /** Half-extent of the cube the points are scattered through. */
 const SPREAD = 60;
 
+/**
+ * Feature-detect a usable WebGL2 context before we ever construct a
+ * THREE.WebGLRenderer. three.js (r163+) requires WebGL2 and THROWS
+ * synchronously when a context cannot be created - on headless Firefox /
+ * WebKit (no GPU, no software fallback) that throw escapes the effect and
+ * trips the page's React error boundary. Probing first lets this purely
+ * decorative layer no-op silently instead, so the page degrades gracefully
+ * while the chromium happy path is unchanged.
+ */
+function canUseWebGL2(): boolean {
+  if (typeof document === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2');
+    return gl != null;
+  } catch {
+    return false;
+  }
+}
+
 export function PointCloudBackground() {
   const containerRef = useRef<HTMLDivElement>(null);
   const resolvedTheme = useThemeStore((s) => s.resolved);
@@ -44,7 +64,18 @@ export function PointCloudBackground() {
     let width = container.clientWidth || 1;
     let height = container.clientHeight || 1;
 
-    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    // This is a decorative, aria-hidden layer. If WebGL2 is unavailable or the
+    // renderer fails to start (common on headless Firefox / WebKit), skip it
+    // silently - the page content still renders and never throws. The real
+    // viewer surfaces its own WebGL notice; the background just stays blank.
+    if (!canUseWebGL2()) return;
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    } catch {
+      return;
+    }
     renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
     renderer.setSize(width, height, false);
     renderer.setClearColor(0x000000, 0);

--- a/frontend/src/features/pointcloud/PointCloudViewer.tsx
+++ b/frontend/src/features/pointcloud/PointCloudViewer.tsx
@@ -154,8 +154,17 @@ export function PointCloudViewer({ scanId, scanLabel }: PointCloudViewerProps) {
     const container = containerRef.current;
     if (!container) return undefined;
 
+    // three.js (r163+) requires WebGL2 and throws when a context cannot be
+    // created (e.g. headless Firefox / WebKit). Feature-detect first, then
+    // guard the construction itself, so the page degrades to the notice below
+    // instead of letting the throw reach the React error boundary.
     let renderer: THREE.WebGLRenderer;
     try {
+      const probe = document.createElement('canvas').getContext('webgl2');
+      if (probe == null) {
+        setWebglFailed(true);
+        return undefined;
+      }
       renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
     } catch {
       setWebglFailed(true);
@@ -560,7 +569,7 @@ export function PointCloudViewer({ scanId, scanLabel }: PointCloudViewerProps) {
             </p>
             <p className="max-w-md text-xs text-content-tertiary">
               {t('pointcloud.viewer_webgl_desc', {
-                defaultValue: 'WebGL could not start in this browser. Update your browser or enable hardware acceleration.',
+                defaultValue: 'Point Cloud viewer requires a WebGL2-capable browser. Update your browser or enable hardware acceleration.',
               })}
             </p>
           </div>


### PR DESCRIPTION
Two pre-existing bugs surfaced by the first full cross-browser E2E matrix run (`e2e-cross-os.yml`, 93/94 modules green).

## 1. `/pointcloud` crashed on Firefox / WebKit
three.js (r163+) requires WebGL2 and throws synchronously when a context cannot be created. Headless Firefox/WebKit have no software fallback (chromium does), so the throw escaped a `useEffect` and tripped the React error boundary, white-screening the page.

- `PointCloudBackground.tsx`: added a `canUseWebGL2()` feature-detect plus `try/catch` around the renderer construction. This purely decorative `aria-hidden` layer now no-ops silently.
- `PointCloudViewer.tsx`: hardened the existing guard with a WebGL2 probe before construction and made the graceful notice name WebGL2 explicitly.

Chromium happy-path behavior is unchanged.

## 2. EAC KPI silently returned 0 everywhere
The `@register_kpi("eac", ...)` decorator was on the pure helper `_eac_from_primitives(bac, pv, ev, ac)` instead of the async `eac_kpi`. The KPI registry invokes formulas as `fn(session, project_id=..., ...)`, so the call raised `TypeError: _eac_from_primitives() got an unexpected keyword argument 'project_id'`, which `compute()` swallowed - making the Estimate at Completion KPI return `Decimal("0")` everywhere while the real `eac_kpi` was dead code.

- `kpis.py`: moved the decorator to `eac_kpi`, matching every sibling KPI (`spi`/`cpi`/`vac`/`tcpi`). The helper stays shared and undecorated.

## Verification
- `tsc -b`: clean (exit 0).
- Backend AST parse OK; `test_evm_kpis_registered_and_compute_safely["eac"]` now exercises the real `eac_kpi` instead of the swallowed error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)