### PR TITLE
ci: homepage-loops capture workflow + spec

### DIFF
--- a/.github/workflows/homepage-loops.yml
+++ b/.github/workflows/homepage-loops.yml
@@ -1,0 +1,163 @@
+name: Homepage loops (marketing showcase GIFs)
+
+# Re-records the named showcase loops used by marketing-site/index.html (the
+# demo slider + guided tour) against the running app and converts each to an
+# optimized GIF, so the marketing animations always show the shipping UI.
+#
+# The app cannot run on the maintainer's Windows box (it needs Python 3.12) and
+# the production server must never be driven by a recording browser, so the
+# capture runs here in CI where the app boots exactly the way it ships: the
+# backend on embedded PostgreSQL serving the freshly built SPA on :8000, seeded
+# with the demo workspace. The boot sequence mirrors e2e-cross-os.yml.
+#
+# Manual-only (workflow_dispatch). Artifacts (both .webm and .gif) are uploaded
+# as "homepage-loops"; nothing is committed. Output filenames match the existing
+# assets/loops/<name>.gif so they can be dropped into the site in place.
+
+on:
+  workflow_dispatch:
+    inputs:
+      fps:
+        description: "GIF frame rate"
+        default: "14"
+        required: false
+      width:
+        description: "GIF width in px (height auto, aspect preserved)"
+        default: "1280"
+        required: false
+
+concurrency:
+  group: homepage-loops-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  loops:
+    name: Capture homepage loops
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend deps
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend (single-server SPA)
+        working-directory: frontend
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+        run: npm run build
+
+      - name: Install backend (serves the built SPA + API on :8000)
+        working-directory: backend
+        run: pip install -e .
+
+      - name: Install Playwright chromium (with deps)
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Install ffmpeg
+        shell: bash
+        run: |
+          # ffmpeg is NOT reliably preinstalled on ubuntu-latest runners.
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          ffmpeg -version | head -1
+
+      - name: Start backend (embedded PostgreSQL + demo seed)
+        working-directory: backend
+        shell: bash
+        env:
+          OE_DATA_DIR: ${{ runner.temp }}/oe-loops-data
+          SEED_DEMO: "true"
+          APP_ENV: development
+        run: |
+          nohup python -m app.cli serve --port 8000 --data-dir "${{ runner.temp }}/oe-loops-data" \
+            > "${{ runner.temp }}/backend.log" 2>&1 &
+          echo $! > "${{ runner.temp }}/backend.pid"
+          echo "backend launched (pid $(cat "${{ runner.temp }}/backend.pid"))"
+
+      - name: Wait for backend health (seed can take a few minutes)
+        shell: bash
+        run: |
+          for i in $(seq 1 72); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8000/api/health || true)
+            if [ "$code" = "200" ]; then echo "backend healthy after $((i*5))s"; exit 0; fi
+            sleep 5
+          done
+          echo "::error::backend never became healthy"
+          tail -80 "${{ runner.temp }}/backend.log" || true
+          exit 1
+
+      - name: Record homepage loops (chromium)
+        working-directory: frontend
+        shell: bash
+        env:
+          OE_TEST_BASE_URL: http://127.0.0.1:8000
+          OE_TEST_API_URL: http://127.0.0.1:8000
+        run: npx playwright test --config=playwright.homepage-loops.config.ts --project=chromium
+
+      - name: Convert webm loops to optimized GIFs
+        working-directory: frontend
+        shell: bash
+        env:
+          FPS: ${{ github.event.inputs.fps || '14' }}
+          WIDTH: ${{ github.event.inputs.width || '1280' }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          clips=(qa-loops/*.webm)
+          if [ ${#clips[@]} -eq 0 ]; then
+            echo "::warning::no .webm loops were produced; nothing to convert"
+            exit 0
+          fi
+          # Two-pass for quality: palettegen builds an optimal per-clip palette,
+          # paletteuse applies it with Floyd-Steinberg dithering. fps + width
+          # downscale keep GIFs small.
+          for clip in "${clips[@]}"; do
+            base="$(basename "${clip%.webm}")"
+            gif="qa-loops/${base}.gif"
+            palette="$(mktemp --suffix=.png)"
+            vf="fps=${FPS},scale=${WIDTH}:-1:flags=lanczos"
+            echo "converting ${clip} -> ${gif}"
+            ffmpeg -nostdin -y -i "$clip" -vf "${vf},palettegen=stats_mode=diff" "$palette"
+            ffmpeg -nostdin -y -i "$clip" -i "$palette" \
+              -lavfi "${vf} [x]; [x][1:v] paletteuse=dither=floyd_steinberg:diff_mode=rectangle" \
+              "$gif"
+            rm -f "$palette"
+          done
+          echo "GIF sizes:"
+          ls -la qa-loops/*.gif || true
+
+      - name: Upload homepage loops (webm + gif)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: homepage-loops
+          path: |
+            frontend/qa-loops/**/*.webm
+            frontend/qa-loops/**/*.gif
+            frontend/qa-loops/loops.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Dump backend log on failure
+        if: failure()
+        shell: bash
+        run: tail -120 "${{ runner.temp }}/backend.log" || true

--- a/frontend/playwright.homepage-loops.config.ts
+++ b/frontend/playwright.homepage-loops.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * playwright.homepage-loops.config.ts - marketing homepage showcase loops.
+ *
+ * Re-records the named loops used by marketing-site/index.html (demo slider +
+ * guided tour) against the single-server build on :8000 (what actually ships).
+ * Chromium only, retina-crisp, single worker (videos must not interleave). The
+ * app must already be running; this config does NOT auto-start a webServer (CI
+ * boots the backend separately, exactly like e2e-cross-os.yml).
+ *
+ * 16:9 to match the homepage media boxes. Named .webm files land in
+ * frontend/qa-loops/<name>.webm (the spec manages its own recording contexts),
+ * so the project-level `video` option is left off here on purpose.
+ *
+ * Run (against an already-running app on :8000):
+ *   npx playwright test --config=playwright.homepage-loops.config.ts
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: ['capture-homepage-loops.spec.ts'],
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  timeout: 18 * 60_000,
+  reporter: [['list']],
+  outputDir: 'qa-loops/test-results',
+  use: {
+    baseURL: process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000',
+    screenshot: 'off',
+    video: 'off',
+    trace: 'off',
+    ignoreHTTPSErrors: true,
+    navigationTimeout: 30_000,
+    actionTimeout: 15_000,
+    viewport: { width: 1440, height: 810 },
+    deviceScaleFactor: 2,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 810 }, deviceScaleFactor: 2 },
+    },
+  ],
+});

--- a/frontend/tests/e2e/capture-homepage-loops.spec.ts
+++ b/frontend/tests/e2e/capture-homepage-loops.spec.ts
@@ -1,0 +1,374 @@
+/**
+ * capture-homepage-loops: record fresh versions of the marketing homepage
+ * showcase loops (the demo slider + guided tour on marketing-site/index.html).
+ *
+ * The homepage references a fixed set of named loops in assets/loops/. This
+ * spec re-records each one against the CURRENT app so the marketing animations
+ * always show the shipping UI. Output filenames match the existing loop names
+ * exactly (e.g. 06_Build_BOQ_Fast.webm) so the CI step can convert them to
+ * <name>.gif and drop them straight into the site in place.
+ *
+ * Same resilient approach as capture-module-videos.spec.ts: boot already
+ * logged-in as the demo user with a pinned project, navigate to the scenario's
+ * route, perform ONE deterministic interaction, then flush the video. A
+ * scenario that fails to load is logged and skipped, never failing the run.
+ *
+ * 16:9 framing to match the homepage <img> boxes (2000x1125 slider, 1280x720
+ * tour). Runs against the single-server build on :8000 (what actually ships).
+ * Config: playwright.homepage-loops.config.ts
+ */
+import { test, expect, chromium, type Browser, type BrowserContext, type Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const API = process.env.OE_TEST_API_URL ?? process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000';
+const BASE = process.env.OE_TEST_BASE_URL ?? 'http://127.0.0.1:8000';
+const DEMO_EMAIL = process.env.OE_TEST_DEMO_EMAIL ?? 'demo@openconstructionerp.com';
+
+// 16:9 to match the homepage media boxes. deviceScaleFactor 2 keeps it crisp;
+// the CI step downscales to a sensible GIF width.
+const VIEWPORT = { width: 1440, height: 810 };
+const CLIP_MS = 8000;
+
+type Gesture =
+  | 'default'
+  | 'search'
+  | 'bim'
+  | 'dwg'
+  | 'pdf'
+  | 'newproject'
+  | 'boqexport'
+  | 'onboarding';
+
+interface Scenario {
+  /** Output base name - must match the existing assets/loops/<name>.gif. */
+  file: string;
+  path: string;
+  gesture: Gesture;
+  /** Onboarding needs the first-run overlay, so it must not be suppressed. */
+  showOnboarding?: boolean;
+}
+
+// The 12 loops referenced by marketing-site/index.html (demo slider + tour).
+const SCENARIOS: Scenario[] = [
+  { file: '02_AI_Photo_to_Estimate', path: '/ai-estimator', gesture: 'default' },
+  { file: '04_PDF_Takeoff', path: '/takeoff', gesture: 'pdf' },
+  { file: '05_Instant_Search', path: '/costs', gesture: 'search' },
+  { file: '06_Build_BOQ_Fast', path: '/boq', gesture: 'default' },
+  { file: '07_Role_Based_Onboarding', path: '/', gesture: 'onboarding', showOnboarding: true },
+  { file: '08_New_Project_Global', path: '/projects', gesture: 'newproject' },
+  { file: '09_Bulk_Link_BIM_Group', path: '/bim', gesture: 'bim' },
+  { file: '10_DWG_Layers', path: '/dwg-takeoff', gesture: 'dwg' },
+  { file: '11_Complete_Estimate_6M', path: '/boq', gesture: 'boqexport' },
+  { file: '12_Tasks_Linked_To_BIM', path: '/tasks', gesture: 'default' },
+  { file: '13_Data_Explorer_Pivot', path: '/data-explorer', gesture: 'default' },
+  { file: '14_Projects_Dashboard', path: '/', gesture: 'default' },
+];
+
+interface Session {
+  token: string;
+  refresh: string;
+  project: { id: string; name: string } | null;
+}
+
+const OUT_DIR = path.join(process.cwd(), 'qa-loops');
+
+function ensureDir(p: string): void {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+/** Demo-login and pick the first project, mirroring capture-module-videos. */
+async function openSession(): Promise<Session> {
+  const res = await fetch(`${API}/api/v1/users/auth/demo-login/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: DEMO_EMAIL }),
+  });
+  if (!res.ok) throw new Error(`demo-login failed: ${res.status} ${await res.text()}`);
+  const j: Record<string, string> = await res.json();
+  const token = j.access_token || j.access || j.token || '';
+  const refresh = j.refresh_token || j.refresh || '';
+  if (!token) throw new Error(`demo-login returned no token: ${JSON.stringify(j).slice(0, 200)}`);
+
+  let project: { id: string; name: string } | null = null;
+  try {
+    const pr = await fetch(`${API}/api/v1/projects/`, { headers: { Authorization: `Bearer ${token}` } });
+    const pd = await pr.json();
+    const items: Array<{ id: string; name: string }> = Array.isArray(pd) ? pd : (pd.items ?? []);
+    if (items.length) project = { id: items[0].id, name: items[0].name };
+  } catch {
+    /* a missing project list is non-fatal */
+  }
+  return { token, refresh, project };
+}
+
+/** Inject a real demo session + pinned active project before app scripts run. */
+async function hydrate(context: BrowserContext, session: Session, suppressOnboarding: boolean): Promise<void> {
+  await context.addInitScript(
+    ({ token, refresh, proj, suppress }) => {
+      try {
+        localStorage.setItem('oe_access_token', token);
+        if (refresh) localStorage.setItem('oe_refresh_token', refresh);
+        localStorage.setItem('oe_remember', '1');
+        sessionStorage.setItem('oe_access_token', token);
+        if (refresh) sessionStorage.setItem('oe_refresh_token', refresh);
+        if (proj) {
+          localStorage.setItem('oe_active_project', JSON.stringify({ id: proj.id, name: proj.name, boqId: null }));
+        }
+        if (suppress) {
+          localStorage.setItem('oe_onboarding_completed', '1');
+          localStorage.setItem('oe_welcome_dismissed', '1');
+          localStorage.setItem('oe_tour_completed', '1');
+        }
+      } catch {
+        /* ignore */
+      }
+    },
+    { token: session.token, refresh: session.refresh, proj: session.project, suppress: suppressOnboarding },
+  );
+}
+
+async function settle(page: Page): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout: 8000 }).catch(() => {});
+  await page.waitForTimeout(1200);
+}
+
+async function hoverFirst(page: Page, selectors: string[]): Promise<void> {
+  for (const sel of selectors) {
+    const el = page.locator(sel).first();
+    if (await el.isVisible({ timeout: 500 }).catch(() => false)) {
+      await el.hover({ timeout: 1500 }).catch(() => {});
+      return;
+    }
+  }
+}
+
+async function gentleScroll(page: Page): Promise<void> {
+  await page.mouse.move(VIEWPORT.width / 2, VIEWPORT.height / 2);
+  await page.mouse.wheel(0, 600);
+  await page.waitForTimeout(900);
+  await page.mouse.wheel(0, -600);
+  await page.waitForTimeout(700);
+}
+
+/** Type a query into the first search-like input we can find. */
+async function gestureSearch(page: Page): Promise<void> {
+  const candidates = [
+    'input[type="search"]',
+    'input[placeholder*="Search" i]',
+    'input[placeholder*="search" i]',
+    '[role="searchbox"]',
+    'main input[type="text"]',
+  ];
+  for (const sel of candidates) {
+    const el = page.locator(sel).first();
+    if (await el.isVisible({ timeout: 700 }).catch(() => false)) {
+      await el.click({ timeout: 1500 }).catch(() => {});
+      await el.type('concrete', { delay: 90 }).catch(() => {});
+      await page.waitForTimeout(1600);
+      return;
+    }
+  }
+  await gentleScroll(page);
+}
+
+/** Orbit the BIM canvas a little so the 3D model reads as interactive. */
+async function gestureBim(page: Page): Promise<void> {
+  await page.waitForTimeout(2500); // let geometry load
+  const canvas = page.locator('canvas').first();
+  if (await canvas.isVisible({ timeout: 2000 }).catch(() => false)) {
+    const box = await canvas.boundingBox().catch(() => null);
+    if (box) {
+      const cx = box.x + box.width / 2;
+      const cy = box.y + box.height / 2;
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx + 140, cy + 40, { steps: 24 });
+      await page.mouse.move(cx + 60, cy - 60, { steps: 24 });
+      await page.mouse.up();
+      await page.waitForTimeout(800);
+      return;
+    }
+  }
+  await hoverFirst(page, ['[role="tree"] [role="treeitem"]', 'aside button', 'main button:visible']);
+}
+
+async function gestureDwg(page: Page): Promise<void> {
+  await page.waitForTimeout(1500);
+  await hoverFirst(page, [
+    'aside [role="row"]',
+    'aside li',
+    'aside button:visible',
+    '[role="toolbar"] button:visible',
+  ]);
+  await gentleScroll(page);
+}
+
+async function gesturePdf(page: Page): Promise<void> {
+  await page.waitForTimeout(1500);
+  await hoverFirst(page, ['[role="toolbar"] button:visible', 'main button:visible', 'canvas']);
+  await page.waitForTimeout(800);
+}
+
+/** Open the "New project" dialog to show the create flow. */
+async function gestureNewProject(page: Page): Promise<void> {
+  const triggers = [
+    'button:has-text("New project")',
+    'button:has-text("New Project")',
+    'a:has-text("New project")',
+    'button:has-text("New")',
+  ];
+  for (const sel of triggers) {
+    const el = page.locator(sel).first();
+    if (await el.isVisible({ timeout: 800 }).catch(() => false)) {
+      await el.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(1800);
+      return;
+    }
+  }
+  await gentleScroll(page);
+}
+
+/** Show the BOQ totals and open the export menu (GAEB / Excel / PDF / JSON). */
+async function gestureBoqExport(page: Page): Promise<void> {
+  await page.mouse.wheel(0, 1200);
+  await page.waitForTimeout(900);
+  const triggers = ['button:has-text("Export")', 'button:has-text("export")', '[aria-label*="export" i]'];
+  for (const sel of triggers) {
+    const el = page.locator(sel).first();
+    if (await el.isVisible({ timeout: 800 }).catch(() => false)) {
+      await el.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(1600);
+      return;
+    }
+  }
+  await page.mouse.wheel(0, -600);
+  await page.waitForTimeout(700);
+}
+
+/** First-run overlay: just let it render and step once if a Next button shows. */
+async function gestureOnboarding(page: Page): Promise<void> {
+  await page.waitForTimeout(1500);
+  const next = page.locator('button:has-text("Next"), button:has-text("Continue"), button:has-text("Get started")').first();
+  if (await next.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await next.click({ timeout: 1500 }).catch(() => {});
+    await page.waitForTimeout(1400);
+  } else {
+    await gentleScroll(page);
+  }
+}
+
+async function performGesture(page: Page, gesture: Gesture): Promise<void> {
+  await settle(page);
+  try {
+    switch (gesture) {
+      case 'search':
+        await gestureSearch(page);
+        break;
+      case 'bim':
+        await gestureBim(page);
+        break;
+      case 'dwg':
+        await gestureDwg(page);
+        break;
+      case 'pdf':
+        await gesturePdf(page);
+        break;
+      case 'newproject':
+        await gestureNewProject(page);
+        break;
+      case 'boqexport':
+        await gestureBoqExport(page);
+        break;
+      case 'onboarding':
+        await gestureOnboarding(page);
+        break;
+      default:
+        await hoverFirst(page, ['main button:visible', '.ag-row:visible', '[role="row"]:visible', 'main a:visible']);
+        await gentleScroll(page);
+    }
+  } catch {
+    /* a gesture failure must never lose the clip */
+  }
+}
+
+async function captureScenario(browser: Browser, session: Session, sc: Scenario): Promise<void> {
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    deviceScaleFactor: 2,
+    baseURL: BASE,
+    ignoreHTTPSErrors: true,
+    recordVideo: { dir: OUT_DIR, size: VIEWPORT },
+  });
+  await hydrate(context, session, !sc.showOnboarding);
+
+  const page = await context.newPage();
+  let video = page.video();
+  try {
+    await page.goto(sc.path, { waitUntil: 'domcontentloaded', timeout: 30000 });
+    const start = Date.now();
+    await performGesture(page, sc.gesture);
+    const remaining = CLIP_MS - (Date.now() - start);
+    if (remaining > 0) await page.waitForTimeout(remaining);
+    video = page.video();
+  } finally {
+    await context.close();
+  }
+
+  if (video) {
+    const raw = await video.path().catch(() => '');
+    if (raw && fs.existsSync(raw)) {
+      const dest = path.join(OUT_DIR, `${sc.file}.webm`);
+      try {
+        fs.rmSync(dest, { force: true });
+      } catch {
+        /* ignore */
+      }
+      fs.renameSync(raw, dest);
+      return;
+    }
+  }
+  throw new Error(`no video produced for ${sc.file}`);
+}
+
+test('capture homepage showcase loops', async () => {
+  test.setTimeout(16 * 60_000);
+  ensureDir(OUT_DIR);
+
+  const session = await openSession();
+  const browser = await chromium.launch();
+
+  const ok: string[] = [];
+  const failed: Array<{ file: string; error: string }> = [];
+  try {
+    for (const sc of SCENARIOS) {
+      try {
+        await captureScenario(browser, session, sc);
+        ok.push(sc.file);
+        // eslint-disable-next-line no-console
+        console.log(`captured ${sc.file} -> qa-loops/${sc.file}.webm`);
+      } catch (e) {
+        const error = String(e).slice(0, 300);
+        failed.push({ file: sc.file, error });
+        // eslint-disable-next-line no-console
+        console.warn(`skipped ${sc.file}: ${error}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    baseURL: BASE,
+    project: session.project?.name ?? null,
+    captured: ok,
+    failed,
+    scenarios: SCENARIOS.map((s) => ({ file: s.file, path: s.path, gesture: s.gesture })),
+  };
+  fs.writeFileSync(path.join(OUT_DIR, 'loops.json'), JSON.stringify(manifest, null, 2));
+  // eslint-disable-next-line no-console
+  console.log(`homepage loops done: ${ok.length} ok, ${failed.length} skipped`);
+
+  expect(ok.length, `no homepage loops were captured at all (base=${BASE})`).toBeGreaterThan(0);
+});


### PR DESCRIPTION
Adds a manual-dispatch workflow that re-records the 12 marketing showcase loops used by the homepage demo slider and guided tour (`02_AI_Photo_to_Estimate` … `14_Projects_Dashboard`) against the current shipping app, then converts each to an optimized GIF whose filename matches the existing `assets/loops/<name>.gif`, so the live site animations always reflect the current UI.

- `frontend/tests/e2e/capture-homepage-loops.spec.ts` - scenario capture spec (per-scenario route + deterministic interaction; resilient, one broken scenario never fails the run; 16:9 to match the homepage media boxes).
- `frontend/playwright.homepage-loops.config.ts` - chromium-only, single-worker config.
- `.github/workflows/homepage-loops.yml` - boots the app on embedded PostgreSQL + demo seed (mirrors e2e-cross-os), records, installs ffmpeg, two-pass palette webm->gif, uploads the `homepage-loops` artifact. Nothing committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)