### PR TITLE
fix(takeoff): render server measurements on document open

### DIFF
--- a/frontend/src/modules/pdf-takeoff/TakeoffViewerModule.tsx
+++ b/frontend/src/modules/pdf-takeoff/TakeoffViewerModule.tsx
@@ -665,11 +665,16 @@ export default function TakeoffViewerModule({
     // (issue #238); a null id (fresh local drop) keeps everything local.
     documentId,
     measurements,
-    setMeasurements: (ms) => setMeasurements(ms),
+    // Pass the stable useState setters directly. Inline wrappers here would be
+    // re-allocated every render, and `useMeasurementPersistence`'s server-load
+    // effect depends on these callbacks: changing identities tear the effect
+    // down mid-fetch (cancelled=true) and the re-run early-returns on the
+    // unchanged document identity, discarding the just-fetched measurements.
+    setMeasurements,
     // Per-page scale: the hook persists the whole page-scale model and
     // migrates a legacy single-scale document into the default on load.
     pageScales,
-    setPageScales: (ps) => setPageScales(ps),
+    setPageScales,
     // The current page's effective scale is still sent on each measurement
     // (scale_pixels_per_unit) so the server-side B8 recompute uses the same
     // ratio the row was drawn at.


### PR DESCRIPTION
## Summary

The PDF Takeoff viewer fetches a document's saved measurements when it opens (HTTP 200) but never displays them — the canvas is empty and the Measurements panel shows "(0)". The data is intact server-side; this is a client-side hydration bug.

## Root cause

`useMeasurementPersistence`'s server-load effect depends on the `setMeasurements` / `setPageScales` callbacks, but `TakeoffViewerModule` passed freshly-allocated inline wrappers on every render:

```tsx
setMeasurements: (ms) => setMeasurements(ms),
setPageScales: (ps) => setPageScales(ps),
```

Any re-render gives them new identities, so React tears the effect down mid-fetch (its cleanup sets `cancelled = true`). When the request resolves, the `!cancelled` guard is false and `setMeasurements` is never called; the replacement effect early-returns on the unchanged document identity, so nothing re-fetches. Net: 200 OK, data in hand, nothing rendered.

## Fix

Pass the stable `useState` setters directly, so the effect is torn down only on a genuine document change.

## Verification

Built the app via the Docker quickstart and confirmed saved measurements re-render after a page reload (the Measurements panel goes from "(0)" back to the saved measurements).
