### PR TITLE
fix: accept X-API-Key auth on inbound-capture webhook endpoints

### DIFF
--- a/backend/app/modules/inbound_capture/router.py
+++ b/backend/app/modules/inbound_capture/router.py
@@ -13,14 +13,26 @@ incoming ``oe_correspondence`` row, publish ``correspondence.created`` and are
 idempotent on the provider's external message id.
 
 Auth: these endpoints may be called by an external system rather than an
-interactive user, but they are still NOT anonymous. The caller must present a
-valid platform token whose role grants ``inbound.write`` (the
-``dependencies=[RequirePermission(...)]`` gate, copied from the cost-recovery
-router), and the target project must pass :func:`verify_project_access` - which
-404s on both "missing" and "denied" so it never leaks project existence. Webhook
-deliveries additionally carry a provider HMAC signature, verified by the seam
-below. The desired public path for these routes is ``/api/v1/inbound/...``; the
-loader derives the mount from the package directory, so today they land under
+interactive user, but they are still NOT anonymous. The caller must present
+``inbound.write`` via one of two credentials, checked by
+:func:`resolve_capture_caller`:
+
+* a JWT bearer token (interactive user or a caller that can refresh one), same
+  as the rest of the platform; or
+* an ``X-API-Key`` header (:func:`app.dependencies.get_user_from_api_key`) for
+  a headless system that cannot reasonably hold a short-lived JWT indefinitely
+  - this is the credential the module's own "external system" framing implies,
+  and the mechanism already existed in ``app.dependencies`` but was not wired
+  to any permission-gated route before this.
+
+Both paths enforce the identical ``inbound.write`` check (admin bypass, then
+role/permission lookup, with the same stale-JWT live-registry fallback
+``RequirePermission`` uses). The target project must additionally pass
+:func:`verify_project_access` - which 404s on both "missing" and "denied" so it
+never leaks project existence. Webhook deliveries additionally carry a
+provider HMAC signature, verified by the seam below. The desired public path
+for these routes is ``/api/v1/inbound/...``; the loader derives the mount from
+the package directory, so today they land under
 ``/api/v1/inbound-capture/...`` (see the module REPORT for the one-line tweak to
 move them to ``/inbound``).
 """
@@ -34,6 +46,7 @@ import logging
 import os
 import re
 import uuid
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
@@ -41,6 +54,8 @@ from app.dependencies import (
     CurrentUserId,
     RequirePermission,
     SessionDep,
+    get_optional_user_payload,
+    get_user_from_api_key,
     verify_project_access,
 )
 from app.modules.correspondence.models import Correspondence
@@ -144,6 +159,68 @@ def verify_provider_signature(provider: str, raw_body: bytes, headers: object) -
     return hmac.compare_digest(expected, sig.lower())
 
 
+# --- Auth seam: JWT (interactive) or API key (machine caller) ---------------
+
+
+def _check_inbound_write(role: str, permissions: list[str], user_id: str) -> None:
+    """Enforce ``inbound.write`` for a resolved role, whatever the credential.
+
+    Mirrors :class:`app.dependencies.RequirePermission` exactly (admin bypass,
+    then membership in ``permissions``, then a live-registry fallback for a
+    permissions list that predates a role change) so a caller sees identical
+    behaviour regardless of whether it authenticated via JWT or API key.
+    """
+    if role == "admin":
+        return
+    if "inbound.write" in permissions:
+        return
+    from app.core.permissions import permission_registry
+
+    if permission_registry.role_has_permission(role, "inbound.write"):
+        return
+    logger.debug(
+        "Inbound capture permission denied: permission=inbound.write user=%s role=%s",
+        user_id,
+        role,
+    )
+    raise HTTPException(status_code=403, detail="Missing permission: inbound.write")
+
+
+async def resolve_capture_caller(
+    request: Request,
+    payload: Any = Depends(get_optional_user_payload),
+) -> str:
+    """Authorize a capture-endpoint caller and return their user id.
+
+    Tries the platform JWT first (``payload`` is non-``None`` when a valid
+    bearer token was presented - re-hydrated from the DB the same way every
+    other authenticated route sees it). When no JWT was presented, falls back
+    to an ``X-API-Key`` header: the module's own docstring already documents
+    that these endpoints "may be called by an external system rather than an
+    interactive user", and a headless system cannot reasonably keep a
+    short-lived JWT refreshed indefinitely. Either path enforces the same
+    ``inbound.write`` permission before the caller's id is trusted.
+    """
+    if payload is not None:
+        _check_inbound_write(
+            payload.get("role", ""), payload.get("permissions", []), str(payload.get("sub", "unknown"))
+        )
+        return str(payload["sub"])
+
+    if not request.headers.get("x-api-key"):
+        raise HTTPException(
+            status_code=401,
+            detail="Not authenticated",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = await get_user_from_api_key(request)
+    from app.core.permissions import permission_registry
+
+    _check_inbound_write(user.role, permission_registry.get_role_permissions(user.role), str(user.id))
+    return str(user.id)
+
+
 # --- Serialization ----------------------------------------------------------
 
 
@@ -193,12 +270,11 @@ def _parse_project_id(value: str) -> uuid.UUID:
 @router.post(
     "/email",
     response_model=InboundMessageOut,
-    dependencies=[Depends(RequirePermission("inbound.write"))],
 )
 async def capture_inbound_email(
     payload: InboundEmailRequest,
     session: SessionDep,
-    user_id: CurrentUserId = None,  # type: ignore[assignment]
+    user_id: str = Depends(resolve_capture_caller),
 ) -> InboundMessageOut:
     """Capture an already-parsed inbound email as incoming correspondence.
 
@@ -218,13 +294,12 @@ async def capture_inbound_email(
 @router.post(
     "/{provider}/webhook",
     response_model=InboundMessageOut,
-    dependencies=[Depends(RequirePermission("inbound.write"))],
 )
 async def capture_inbound_webhook(
     provider: str,
     request: Request,
     session: SessionDep,
-    user_id: CurrentUserId = None,  # type: ignore[assignment]
+    user_id: str = Depends(resolve_capture_caller),
 ) -> InboundMessageOut:
     """Capture a provider chat / SMS webhook delivery as incoming correspondence.
 

--- a/backend/tests/modules/inbound_capture/test_inbound_capture_auth.py
+++ b/backend/tests/modules/inbound_capture/test_inbound_capture_auth.py
@@ -1,0 +1,133 @@
+# DDC-CWICR-OE: DataDrivenConstruction - OpenConstructionERP
+# Copyright (c) 2026 Artem Boiko / DataDrivenConstruction
+"""Unit tests for the inbound-capture JWT-or-API-key auth seam.
+
+Pure (no DB, no ASGI/TestClient): exercises :func:`resolve_capture_caller` and
+:func:`_check_inbound_write` directly with constructed payload / request
+stand-ins, the same style ``test_inbound_capture_signature.py`` uses for the
+signature seam. Proves: a JWT payload with the permission (or role=admin)
+resolves to its ``sub``; a JWT payload missing the permission is rejected even
+via the live-registry fallback for a role that genuinely lacks it; no
+JWT + no ``X-API-Key`` header is 401; and an ``X-API-Key`` header resolves
+through :func:`app.dependencies.get_user_from_api_key` (mocked here) with the
+identical permission gate applied to the resolved user's role.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.inbound_capture import router as inbound_router
+from app.modules.inbound_capture.permissions import register_inbound_capture_permissions
+from app.modules.inbound_capture.router import resolve_capture_caller
+
+# Registering is idempotent (a dict update keyed by permission string), so it
+# is safe to call unconditionally rather than depend on app startup order.
+register_inbound_capture_permissions()
+
+
+class _StubRequest:
+    """Minimal stand-in for starlette Request: only ``.headers`` is touched."""
+
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+
+
+@dataclass
+class _FakeUser:
+    id: uuid.UUID
+    role: str
+
+
+# --- JWT path -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_jwt_payload_with_permission_resolves_sub() -> None:
+    payload = {"sub": "user-1", "role": "editor", "permissions": ["inbound.write"]}
+    user_id = await resolve_capture_caller(_StubRequest(), payload)
+    assert user_id == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_jwt_admin_bypasses_permission_list() -> None:
+    payload = {"sub": "user-2", "role": "admin", "permissions": []}
+    user_id = await resolve_capture_caller(_StubRequest(), payload)
+    assert user_id == "user-2"
+
+
+@pytest.mark.asyncio
+async def test_jwt_falls_back_to_live_registry_for_stale_permissions_list() -> None:
+    # "editor" genuinely has inbound.write in the live registry even though
+    # this stale-looking payload's own permissions list doesn't carry it -
+    # mirrors RequirePermission's Issue #101 fallback for a JWT issued before
+    # a permission was added to the role.
+    payload = {"sub": "user-3", "role": "editor", "permissions": []}
+    user_id = await resolve_capture_caller(_StubRequest(), payload)
+    assert user_id == "user-3"
+
+
+@pytest.mark.asyncio
+async def test_jwt_without_permission_is_rejected() -> None:
+    payload = {"sub": "user-4", "role": "viewer", "permissions": []}
+    with pytest.raises(HTTPException) as exc:
+        await resolve_capture_caller(_StubRequest(), payload)
+    assert exc.value.status_code == 403
+
+
+# --- No credential --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_jwt_and_no_api_key_header_is_401() -> None:
+    with pytest.raises(HTTPException) as exc:
+        await resolve_capture_caller(_StubRequest(), None)
+    assert exc.value.status_code == 401
+
+
+# --- API-key path (machine caller) ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_api_key_header_resolves_user_with_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_user = _FakeUser(id=uuid.uuid4(), role="editor")
+
+    async def _fake_get_user_from_api_key(request: object) -> _FakeUser:
+        return fake_user
+
+    monkeypatch.setattr(inbound_router, "get_user_from_api_key", _fake_get_user_from_api_key)
+
+    user_id = await resolve_capture_caller(_StubRequest({"X-API-Key": "sk_live_whatever"}), None)
+    assert user_id == str(fake_user.id)
+
+
+@pytest.mark.asyncio
+async def test_api_key_header_rejects_user_without_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_user = _FakeUser(id=uuid.uuid4(), role="viewer")
+
+    async def _fake_get_user_from_api_key(request: object) -> _FakeUser:
+        return fake_user
+
+    monkeypatch.setattr(inbound_router, "get_user_from_api_key", _fake_get_user_from_api_key)
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_capture_caller(_StubRequest({"X-API-Key": "sk_live_whatever"}), None)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_api_key_lookup_failure_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An invalid/expired key must surface get_user_from_api_key's own 401, not be swallowed."""
+
+    async def _fake_get_user_from_api_key(request: object) -> None:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    monkeypatch.setattr(inbound_router, "get_user_from_api_key", _fake_get_user_from_api_key)
+
+    with pytest.raises(HTTPException) as exc:
+        await resolve_capture_caller(_StubRequest({"X-API-Key": "bad-key"}), None)
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary

- `inbound_capture`'s own module docstring says its two capture endpoints "may be called by an external system rather than an interactive user," but the `RequirePermission` gate only ever checks a JWT bearer payload — a headless caller had no way to hold a usable credential without implementing a login+refresh cycle just to POST a webhook delivery.
- `app/dependencies.py` already defines an `X-API-Key` mechanism (`get_user_from_api_key` / `ApiKeyUser`) for exactly this kind of caller, but grepping the codebase shows it wasn't wired into any permission-gated route anywhere.
- Adds `resolve_capture_caller()`: tries the JWT payload first (unchanged behavior for interactive callers — including the admin bypass and the stale-JWT live-registry fallback `RequirePermission` already has), and falls back to `X-API-Key` when no JWT is presented, applying the identical `inbound.write` permission check to the resolved user's role either way.
- `POST /email` and `POST /{provider}/webhook` now depend on `resolve_capture_caller` instead of `CurrentUserId` + `RequirePermission("inbound.write")`. The read endpoint (`GET /projects/{project_id}/captured`) is untouched.

Found this while wiring a third-party WhatsApp-parsing service to push captured messages into this module for a construction-site correspondence use case — it's a real machine caller with no interactive user, and a natural first applicant for the API-key mechanism the module's docstring already implied was supported.

## Test plan

- [x] `ruff format --check` / `ruff check` pass on both changed files
- [x] All 19 pre-existing tests in `backend/tests/modules/inbound_capture/` still pass unchanged (JWT flow, signature seam, IDOR guard)
- [x] Added `backend/tests/modules/inbound_capture/test_inbound_capture_auth.py` (8 new pure-unit tests, no DB): JWT-with-permission resolves, admin bypass, stale-JWT live-registry fallback, JWT-without-permission → 403, no-credential → 401, API-key-with-permission resolves, API-key-without-permission → 403, and a bad/expired API key's own 401 propagates unmodified
- [x] Full `backend/tests/modules/inbound_capture/` suite (27 tests) passes after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)