### PR TITLE
feat(schedule-intelligence): Phase 0 governance + Phase 1 Readiness (Watch)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -82,6 +82,7 @@ from app.modules.rfq_bidding import models as _rfq_bidding  # noqa: F401, E402
 from app.modules.risk import models as _risk  # noqa: F401, E402
 from app.modules.safety import models as _safety  # noqa: F401, E402
 from app.modules.schedule import models as _sched  # noqa: F401, E402
+from app.modules.schedule_intelligence import models as _sched_intel  # noqa: F401, E402
 from app.modules.submittals import models as _submittals  # noqa: F401, E402
 from app.modules.takeoff import models as _takeoff  # noqa: F401, E402
 from app.modules.tasks import models as _tasks  # noqa: F401, E402

--- a/backend/app/modules/schedule_intelligence/README.md
+++ b/backend/app/modules/schedule_intelligence/README.md
@@ -22,16 +22,31 @@ before any apply flow:
 | **E5.2 locked-figure guard** | `locked_guard.py` — pure policy-as-code. Once a figure is locked, no flow may change it; byte-identical re-writes pass, mutations raise `LockedFigureViolation`. Backing store: `locked_figure` table. |
 | **E5.3 confidence framework** | `confidence.py` — one uniform `score / band / rationale` for every insight. Corroboration bonuses first, caps last (hard ceiling); a degraded feed's reduced confidence is always explained, never silent. Config-as-data: `confidence_config` table (versioned). |
 | **Data model** | `models.py` — `confidence_config`, `locked_figure`, plus the insight tables the later phases fill: `readiness_result` (E1), `risk_score` + `risk_factor` (E2), `decision` (E4). |
-| **RBAC** | `permissions.py` — `schedule_intelligence.{read,score,attribute,quantify,decide,apply,configure,lock}`, registered in `__init__.on_startup()`. Apply flows reuse the `app/core` approval gate + audit — no new gate. |
+| **RBAC** | `permissions.py` — `schedule_intelligence.{read,watch,score,attribute,quantify,decide,apply,configure,lock}`, registered in `__init__.on_startup()`. Apply flows reuse the `app/core` approval gate + audit — no new gate. |
 | **API** | `router.py` — governance surface: lock / list / unlock / dry-run-verify locked figures; get / versioned-upsert / preview confidence config. Mounted at `/api/v1/schedule-intelligence/`. |
 
 Every project-scoped endpoint is gated twice: `RequirePermission(...)` (RBAC)
 + `verify_project_access(...)` (404-on-deny IDOR defence).
 
+## Status — Phase 1 (E1 Readiness / "Watch") ✅
+
+Turns `schedule_advanced`'s binary ready/not-ready into a deterministic
+**Ready / At-risk / Blocked** classification per look-ahead activity, persisted
+as `readiness_result` snapshots.
+
+| Area | What's here |
+|---|---|
+| **Engine** | `readiness_engine.py` — a **pure** classifier (no I/O, no clock). `classify_activity` / `evaluate_look_ahead` apply a hardcoded truth table over raw constraints + optional CPM float; `run_digest` hashes the canonical inputs into the `evaluation_run_id` so a re-run is idempotent (E1.1-AC6). Each verdict carries a `binding_constraint_ref`, traceable `drivers[]` (P4), a `float_burn` delta vs the prior snapshot, and a uniform E5.3 confidence. |
+| **Correctness catch** | Consumes **raw** constraint rows: `cannot_clear → BLOCKED` is handled here, because `schedule_advanced.constraint_ready_state` treats `cannot_clear` as *not open* and would call a permanently-blocked activity "ready". Open-blocker subset is exactly `{open, in_progress, escalated}`. |
+| **Service** | `service.evaluate_readiness` derives the look-ahead's project (IDOR 404), pulls constraints via `schedule_advanced`, resolves best-effort CPM float (one swappable `_resolve_float` against `oe_schedule_activity`), runs the engine under the project's confidence policy, and snapshots one idempotent run. `list_readiness` returns the latest run. |
+| **API** | `POST …/projects/{id}/look-aheads/{la}/readiness/evaluate` (gated `.watch`) and `GET …/projects/{id}/readiness` (gated `.read`). |
+
+The `task_ref ↔ schedule-activity` float join is intentionally best-effort for
+the MVP: unresolved float degrades confidence (never silently), and `_resolve_float`
+is the single swap-point when a richer task↔activity mapping lands.
+
 ## What comes next
 
-- **Phase 1 — E1 Readiness (Watch):** `readiness_engine.py` classifies
-  look-ahead activities Ready / At-risk / Blocked, deterministically.
 - **Phase 2 — E2 Risk (Score):** `risk_scoring.py`, a weighted-factor forward
   score behind a pluggable `Scorer` interface (ML out of MVP).
 - **Phase 3–4 — E3/E4 (Attribute → Quantify → Decide):** attribution over the

--- a/backend/app/modules/schedule_intelligence/README.md
+++ b/backend/app/modules/schedule_intelligence/README.md
@@ -1,0 +1,62 @@
+# oe_schedule_intelligence
+
+A **thin orchestration + governance layer** over the existing
+`schedule_advanced` / `risk` / `variations` / `contracts` / `full_evm` modules.
+It flags delay risk early, attributes cause/responsibility, quantifies
+critical-path impact, and presents human-approved **claim-vs-accelerate**
+decisions — with commercially-sensitive figures locked and a uniform confidence
+framework gating every insight.
+
+It does **not** re-implement CPM, delay quantification, Monte-Carlo risk, rate
+tables, or the approval/audit machinery — those already exist and are reused.
+Rows that live elsewhere (a `delay_event`, a `constraint`, a look-ahead
+activity) are referenced by **string ref**, never copied: one source of truth.
+
+## Status — Phase 0 (governance foundation) ✅
+
+Phase 0 builds the trust guarantees the spec (`docs/business.md`) puts first,
+before any apply flow:
+
+| Area | What's here |
+|---|---|
+| **E5.2 locked-figure guard** | `locked_guard.py` — pure policy-as-code. Once a figure is locked, no flow may change it; byte-identical re-writes pass, mutations raise `LockedFigureViolation`. Backing store: `locked_figure` table. |
+| **E5.3 confidence framework** | `confidence.py` — one uniform `score / band / rationale` for every insight. Corroboration bonuses first, caps last (hard ceiling); a degraded feed's reduced confidence is always explained, never silent. Config-as-data: `confidence_config` table (versioned). |
+| **Data model** | `models.py` — `confidence_config`, `locked_figure`, plus the insight tables the later phases fill: `readiness_result` (E1), `risk_score` + `risk_factor` (E2), `decision` (E4). |
+| **RBAC** | `permissions.py` — `schedule_intelligence.{read,score,attribute,quantify,decide,apply,configure,lock}`, registered in `__init__.on_startup()`. Apply flows reuse the `app/core` approval gate + audit — no new gate. |
+| **API** | `router.py` — governance surface: lock / list / unlock / dry-run-verify locked figures; get / versioned-upsert / preview confidence config. Mounted at `/api/v1/schedule-intelligence/`. |
+
+Every project-scoped endpoint is gated twice: `RequirePermission(...)` (RBAC)
++ `verify_project_access(...)` (404-on-deny IDOR defence).
+
+## What comes next
+
+- **Phase 1 — E1 Readiness (Watch):** `readiness_engine.py` classifies
+  look-ahead activities Ready / At-risk / Blocked, deterministically.
+- **Phase 2 — E2 Risk (Score):** `risk_scoring.py`, a weighted-factor forward
+  score behind a pluggable `Scorer` interface (ML out of MVP).
+- **Phase 3–4 — E3/E4 (Attribute → Quantify → Decide):** attribution over the
+  existing `delay_event`, quantification via `delay_engine.impacted_as_planned`,
+  and the priced claim-vs-accelerate `decision_engine.py`.
+- **Phase 5 (post-MVP) — E5.5:** governed P6 write-back (read-only until then).
+
+## Migration note
+
+`migrations/v0001_initial.py` holds the full inspector-guarded DDL for all six
+tables but is **inert** — Alembic only runs `backend/alembic/versions/`. In dev
+the tables materialise via boot-time `metadata.create_all` (the models are
+imported in `backend/alembic/env.py`). To fold the migration into the live
+chain, either autogenerate (`make migrate-new MSG="schedule_intelligence
+initial"`, then delete the draft) or move it into `alembic/versions/` and set
+`down_revision` to the current head — after the repo's multi-head Alembic graph
+is consolidated.
+
+## Tests
+
+- `backend/tests/unit/test_oe_schedule_intelligence_*` — pure guard/confidence
+  units (incl. the E5.2 negative-injection suite) + manifest/schema/permission
+  checks.
+- `backend/tests/integration/test_oe_schedule_intelligence_*` — full governance
+  stack round-tripped on real PostgreSQL, plus an app-boot + endpoint-mount
+  check.
+
+Run just this module's suite: `make module-test NAME=oe_schedule_intelligence`.

--- a/backend/app/modules/schedule_intelligence/__init__.py
+++ b/backend/app/modules/schedule_intelligence/__init__.py
@@ -1,0 +1,27 @@
+"""Schedule Intelligence module.
+
+A thin orchestration + governance layer over ``schedule_advanced`` / ``risk`` /
+``variations`` / ``contracts`` / ``full_evm``: it flags delay risk early,
+attributes cause/responsibility, quantifies critical-path impact, and presents
+human-approved claim-vs-accelerate decisions — with commercially-sensitive
+figures locked (E5.2) and a uniform confidence framework (E5.3) gating every
+insight. Applies changes only through the existing ``app/core`` approval gate;
+it adds no gate of its own.
+
+The module loader discovers this package automatically when it lives under
+``backend/app/modules/schedule_intelligence/``.
+"""
+
+
+async def on_startup() -> None:
+    """Module startup hook — register permissions at app boot.
+
+    Kept fast and side-effect-light; the loader awaits each module's hook in
+    sequence. Governance (approval gate + audit) is reused from ``app/core`` —
+    nothing new is registered here beyond this module's permission set.
+    """
+    from app.modules.schedule_intelligence.permissions import (
+        register_schedule_intelligence_permissions,
+    )
+
+    register_schedule_intelligence_permissions()

--- a/backend/app/modules/schedule_intelligence/confidence.py
+++ b/backend/app/modules/schedule_intelligence/confidence.py
@@ -1,0 +1,236 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E5.3 — Confidence framework (uniform schema + config-as-data gating).
+
+Every insight this module emits — a readiness classification, a forward-risk
+score, a priced decision — carries the *same* confidence shape: a 0..1
+``score``, a ``band`` (high/medium/low), and a ``rationale`` that lists, in
+order, every adjustment that produced the score. There is one place that
+computes it (:func:`compute_confidence`) so the semantics can never drift
+between engines.
+
+The gating policy is **config-as-data**, not code: caps and bonuses live in a
+``confidence_config`` row (versioned + audit-logged, E2.1-AC7) and are loaded
+into a :class:`ConfidencePolicy`. This is what lets a degraded feed surface a
+*reduced, explained* confidence rather than a silently optimistic one
+(spec P5 — "degraded feeds show reduced confidence with stated reason, never
+silent"): a schedule-quality or feed-coverage tier imposes a hard ceiling the
+base score cannot exceed, and the reason is always recorded in the rationale.
+
+Ordering guarantee: corroboration **bonuses** are applied first, then **caps**
+last, so a cap is a true ceiling that corroboration can never lift past. The
+whole computation is pure and deterministic — identical inputs always yield an
+identical result (mirrors the determinism the classifier promises, E1.1-AC6).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.modules.schedule_intelligence.enums import ConfidenceBand
+
+# Deployment-wide fallback used when no ``confidence_config`` row exists yet.
+# Deliberately conservative: unknown-quality inputs are not assumed pristine.
+_DEFAULT_BAND_THRESHOLDS: dict[str, float] = {"high": 0.75, "medium": 0.5}
+_DEFAULT_SCHEDULE_QUALITY_CAPS: dict[str, float] = {
+    "poor": 0.4,
+    "fair": 0.7,
+    "good": 1.0,
+}
+_DEFAULT_FEED_COVERAGE_CAPS: dict[str, float] = {
+    "sparse": 0.5,
+    "partial": 0.8,
+    "full": 1.0,
+}
+_DEFAULT_CORROBORATION_BONUSES: dict[str, float] = {
+    "document_backed": 0.1,
+    "cross_feed_agreement": 0.1,
+    "human_confirmed": 0.15,
+}
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+@dataclass(frozen=True)
+class ConfidencePolicy:
+    """Immutable, resolved confidence gating policy (the data behind E5.3)."""
+
+    band_thresholds: Mapping[str, float]
+    schedule_quality_caps: Mapping[str, float]
+    feed_coverage_caps: Mapping[str, float]
+    corroboration_bonuses: Mapping[str, float]
+    version: int | None = None
+
+    @classmethod
+    def default(cls) -> ConfidencePolicy:
+        """The built-in fallback policy (no DB row required)."""
+        return cls(
+            band_thresholds=dict(_DEFAULT_BAND_THRESHOLDS),
+            schedule_quality_caps=dict(_DEFAULT_SCHEDULE_QUALITY_CAPS),
+            feed_coverage_caps=dict(_DEFAULT_FEED_COVERAGE_CAPS),
+            corroboration_bonuses=dict(_DEFAULT_CORROBORATION_BONUSES),
+            version=None,
+        )
+
+    @classmethod
+    def from_config(cls, row: Any) -> ConfidencePolicy:
+        """Build a policy from a ``ConfidenceConfig`` ORM row (duck-typed).
+
+        Missing / empty maps fall back to the corresponding default so a
+        partially-configured row still behaves sensibly (an operator can set
+        only the caps they care about). Keeps this module import-free of the
+        models layer.
+        """
+        default = cls.default()
+        return cls(
+            band_thresholds=dict(getattr(row, "band_thresholds", None) or default.band_thresholds),
+            schedule_quality_caps=dict(getattr(row, "schedule_quality_caps", None) or default.schedule_quality_caps),
+            feed_coverage_caps=dict(getattr(row, "feed_coverage_caps", None) or default.feed_coverage_caps),
+            corroboration_bonuses=dict(getattr(row, "corroboration_bonuses", None) or default.corroboration_bonuses),
+            version=getattr(row, "version", None),
+        )
+
+
+@dataclass(frozen=True)
+class ConfidenceResult:
+    """Uniform confidence attached to every insight.
+
+    ``rationale`` is an ordered list of ``{"step", "effect", "detail"}`` dicts —
+    the audit-and-UI record of *why* the score is what it is. It is never
+    empty: the base contribution is always the first entry.
+    """
+
+    score: float
+    band: ConfidenceBand
+    rationale: list[dict[str, Any]] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "band": self.band.value,
+            "rationale": self.rationale,
+        }
+
+
+def band_for(score: float, thresholds: Mapping[str, float]) -> ConfidenceBand:
+    """Map a 0..1 score to a band using the policy thresholds."""
+    high = float(thresholds.get("high", _DEFAULT_BAND_THRESHOLDS["high"]))
+    medium = float(thresholds.get("medium", _DEFAULT_BAND_THRESHOLDS["medium"]))
+    if score >= high:
+        return ConfidenceBand.HIGH
+    if score >= medium:
+        return ConfidenceBand.MEDIUM
+    return ConfidenceBand.LOW
+
+
+def compute_confidence(
+    base_score: float,
+    *,
+    schedule_quality: str | None = None,
+    feed_coverage: str | None = None,
+    corroboration: Iterable[str] = (),
+    policy: ConfidencePolicy | None = None,
+) -> ConfidenceResult:
+    """Compute a uniform :class:`ConfidenceResult` from a base score + signals.
+
+    Args:
+        base_score: The engine's raw 0..1 confidence before gating.
+        schedule_quality: Schedule-quality tier of the underlying data (keys of
+            ``policy.schedule_quality_caps``, e.g. ``"poor"``). Caps the score.
+        feed_coverage: Feed-coverage tier (keys of
+            ``policy.feed_coverage_caps``, e.g. ``"sparse"``). Caps the score.
+        corroboration: Corroboration signals present for this insight (keys of
+            ``policy.corroboration_bonuses``, e.g. ``"document_backed"``). Each
+            adds its bonus before caps apply.
+        policy: The gating policy; defaults to :meth:`ConfidencePolicy.default`.
+
+    Returns:
+        A deterministic result whose ``rationale`` records the base score, each
+        corroboration bonus applied, and each cap in effect (whether or not it
+        bound), so nothing about the number is silent.
+    """
+    policy = policy or ConfidencePolicy.default()
+    rationale: list[dict[str, Any]] = []
+
+    score = _clamp01(float(base_score))
+    rationale.append({"step": "base", "effect": round(score, 4), "detail": "engine base score"})
+
+    # 1) Corroboration bonuses (applied first, additive, clamped to 1.0).
+    for signal in corroboration:
+        bonus = policy.corroboration_bonuses.get(signal)
+        if not bonus:
+            continue
+        before = score
+        score = _clamp01(score + float(bonus))
+        rationale.append(
+            {
+                "step": f"corroboration:{signal}",
+                "effect": round(score - before, 4),
+                "detail": f"+{float(bonus):g} for {signal}",
+            }
+        )
+
+    # 2) Caps (applied last — a hard ceiling corroboration cannot lift past).
+    score = _apply_cap(
+        score,
+        tier=schedule_quality,
+        caps=policy.schedule_quality_caps,
+        kind="schedule_quality",
+        rationale=rationale,
+    )
+    score = _apply_cap(
+        score,
+        tier=feed_coverage,
+        caps=policy.feed_coverage_caps,
+        kind="feed_coverage",
+        rationale=rationale,
+    )
+
+    score = round(_clamp01(score), 4)
+    return ConfidenceResult(
+        score=score,
+        band=band_for(score, policy.band_thresholds),
+        rationale=rationale,
+    )
+
+
+def _apply_cap(
+    score: float,
+    *,
+    tier: str | None,
+    caps: Mapping[str, float],
+    kind: str,
+    rationale: list[dict[str, Any]],
+) -> float:
+    """Apply a tier cap, always recording it when the tier is known.
+
+    Recording the cap even when it does not bind is intentional (P5): the UI
+    can state "capped at 0.7 by fair schedule quality" so a degraded feed's
+    reduced ceiling is never invisible.
+    """
+    if tier is None:
+        return score
+    if tier not in caps:
+        # Unknown tier is itself a degraded-input signal — surface it.
+        rationale.append(
+            {
+                "step": f"cap:{kind}",
+                "effect": 0.0,
+                "detail": f"unknown {kind} tier {tier!r}; no cap applied",
+            }
+        )
+        return score
+    cap = float(caps[tier])
+    before = score
+    score = min(score, cap)
+    rationale.append(
+        {
+            "step": f"cap:{kind}",
+            "effect": round(score - before, 4),
+            "detail": f"{kind}={tier!r} caps confidence at {cap:g}",
+        }
+    )
+    return score

--- a/backend/app/modules/schedule_intelligence/enums.py
+++ b/backend/app/modules/schedule_intelligence/enums.py
@@ -1,0 +1,95 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Shared enumerations for the Schedule Intelligence module.
+
+These are ``StrEnum`` values used by the pure engines (readiness, risk
+scoring, decision, confidence, locked-figure guard) for type-safe code
+paths, and persisted as plain ``String`` columns to match the rest of the
+codebase (see ``modules/risk/models.py`` — enums are stored as strings,
+not DB-level ``ENUM`` types, so SQLite and PostgreSQL behave identically).
+
+Keep the string *values* stable: they are written to the DB and returned
+over the API. Renaming a member's value is a data migration.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ReadinessClass(StrEnum):
+    """E1 deterministic readiness classification of a look-ahead activity."""
+
+    READY = "ready"
+    AT_RISK = "at_risk"
+    BLOCKED = "blocked"
+
+
+class RiskBand(StrEnum):
+    """E2 forward-risk band derived from the composite score (0..1)."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class ConfidenceBand(StrEnum):
+    """E5.3 uniform confidence band attached to every insight."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class FactorSourceType(StrEnum):
+    """Origin feed of a single risk-score factor (E2 decomposition, P4 trace).
+
+    Every factor must trace back to a concrete source row so the UI can
+    reach it in ≤2 clicks. The ``*_ref`` string on the factor row holds the
+    id of the source entity in its owning module (never copied here).
+    """
+
+    FLOAT = "float"
+    CRITICALITY = "criticality"
+    CONSTRAINT = "constraint"
+    PROCUREMENT = "procurement"
+    APPROVAL = "approval"
+    RFI = "rfi"
+    SLIP_VELOCITY = "slip_velocity"
+    HISTORICAL = "historical"
+    SNAPSHOT = "snapshot"
+
+
+class DecisionOption(StrEnum):
+    """E4 claim-vs-accelerate options."""
+
+    CLAIM = "claim"
+    ACCELERATE = "accelerate"
+    MONITOR = "monitor"
+
+
+class DecisionStatus(StrEnum):
+    """Lifecycle of an E4 decision. Apply is always human-gated."""
+
+    DRAFT = "draft"
+    RECOMMENDED = "recommended"
+    APPROVED = "approved"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+
+
+class LockedFigureType(StrEnum):
+    """E5.2 categories of commercially-sensitive figures that get locked.
+
+    Once a figure of one of these types is confirmed by a human, the
+    locked-figure guard rejects any subsequent write that would change its
+    value from any flow (recompute, re-render, apply). See ``locked_guard``.
+    """
+
+    BASELINE_DATE = "baseline_date"
+    IMPACT_DAYS = "impact_days"
+    ENTITLEMENT_DAYS = "entitlement_days"
+    ENTITLEMENT_COST = "entitlement_cost"
+    LDS_AVOIDED = "lds_avoided"
+    PROLONGATION_COST = "prolongation_cost"
+    ACCELERATION_COST = "acceleration_cost"

--- a/backend/app/modules/schedule_intelligence/locked_guard.py
+++ b/backend/app/modules/schedule_intelligence/locked_guard.py
@@ -1,0 +1,222 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E5.2 — Locked-figure guard (policy-as-code).
+
+The commercial-trust heart of the module. Once a human confirms a
+commercially-sensitive figure (a baseline date, quantified impact days,
+entitlement, LDs-avoided, prolongation/acceleration cost), that figure is
+*locked*: no later flow — a recompute, a single-store re-render, an apply
+action — may silently change it. Every write path in the module funnels
+through :class:`LockedFigureGuard` before it persists a value the guard knows
+about, and rejects any change with a :class:`LockedFigureViolation`.
+
+Design tenets:
+    * **Pure & dependency-free.** The guard core takes an explicit set of
+      locked entries and knows nothing about SQLAlchemy, FastAPI, or the DB.
+      That is what makes the negative-injection suite exhaustive and fast —
+      no fixture, no session. :meth:`LockedFigureGuard.from_rows` adapts ORM
+      rows into it at the edge.
+    * **Byte-identical, not approximately-equal.** Comparison is on a
+      *canonical string* serialization (:func:`canonical_value`), so ``5``,
+      ``5.0`` and ``"5"`` compare equal but ``5`` and ``5.01`` do not. Values
+      are normalised the same way going in (at lock time) and coming back
+      (at write time), so the check is stable across float/Decimal/str inputs.
+    * **Idempotent re-writes pass.** Writing the *same* canonical value to a
+      locked path is allowed — single-store re-renders (spec E4.3) re-emit the
+      confirmed figure constantly and must not trip the guard. Only a *change*
+      is a violation.
+    * **Fail closed, explain loudly.** A violation names the path, the locked
+      value, and the rejected value so the audit trail and the UI can show
+      exactly what was blocked (spec P5 — never silent).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+def canonical_value(value: Any) -> str:
+    """Serialize ``value`` to the canonical string used for lock comparison.
+
+    The same function is applied at lock time and at every write, so two
+    inputs that represent the same figure produce the same string regardless
+    of their Python type:
+
+        canonical_value(5) == canonical_value(5.0) == canonical_value("5")
+        canonical_value(Decimal("12.50")) == canonical_value(12.5)
+
+    Numbers are normalised through :class:`~decimal.Decimal` and stripped of
+    trailing-zero noise; containers are JSON with sorted keys and tight
+    separators; ``None`` is the literal ``"null"``. Anything else falls back
+    to ``str()``.
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        # bool is an int subclass — handle before the numeric branch.
+        return "true" if value else "false"
+    if isinstance(value, (int, float, Decimal)):
+        return _canonical_number(value)
+    if isinstance(value, str):
+        # A numeric-looking string canonicalises as a number so "5" == 5;
+        # a non-numeric string is used verbatim.
+        stripped = value.strip()
+        try:
+            return _canonical_number(Decimal(stripped))
+        except (InvalidOperation, ValueError):
+            return value
+    if isinstance(value, (Mapping, list, tuple)):
+        return json.dumps(_jsonable(value), sort_keys=True, separators=(",", ":"), default=str)
+    return str(value)
+
+
+def _canonical_number(value: int | float | Decimal) -> str:
+    """Normalise a number to a stable decimal string (no trailing zeros)."""
+    dec = value if isinstance(value, Decimal) else Decimal(str(value))
+    # normalize() drops trailing zeros; the exponent guard turns e.g.
+    # Decimal("5E+1") back into "50" instead of scientific notation, and
+    # "0" stays "0" rather than "0E+…".
+    normalized = dec.normalize()
+    if normalized == 0:
+        return "0"
+    formatted = format(normalized, "f")
+    return formatted
+
+
+def _jsonable(value: Any) -> Any:
+    """Recursively coerce a container into JSON-serialisable primitives."""
+    if isinstance(value, Mapping):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, Decimal):
+        return _canonical_number(value)
+    return value
+
+
+def value_hash(canonical: str) -> str:
+    """SHA-256 of a canonical value — the tamper-detection / audit fingerprint."""
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class LockedEntry:
+    """One locked figure, addressed by its canonical ``path``.
+
+    ``value`` is stored already-canonicalised so comparison is a plain string
+    equality. Build entries via :meth:`for_value` (which canonicalises for you)
+    rather than the constructor when starting from a raw value.
+    """
+
+    path: str
+    value: str
+    figure_type: str | None = None
+
+    @classmethod
+    def for_value(cls, path: str, value: Any, *, figure_type: str | None = None) -> LockedEntry:
+        return cls(path=path, value=canonical_value(value), figure_type=figure_type)
+
+    @property
+    def value_hash(self) -> str:
+        return value_hash(self.value)
+
+
+class LockedFigureViolation(Exception):
+    """Raised when a write would change a locked figure.
+
+    Carries the structured fields the router maps to an HTTP 409 and the audit
+    log records verbatim, so a blocked write is always explainable.
+    """
+
+    def __init__(self, path: str, locked_value: str, attempted_value: str) -> None:
+        self.path = path
+        self.locked_value = locked_value
+        self.attempted_value = attempted_value
+        super().__init__(
+            f"Locked figure {path!r} may not change: locked={locked_value!r} attempted={attempted_value!r}"
+        )
+
+
+class LockedFigureGuard:
+    """Enforces that locked figures never change from any write flow.
+
+    Construct with the set of currently-locked entries (from the DB via
+    :meth:`from_rows`, or inline in tests), then gate every write through
+    :meth:`assert_writable` / :meth:`assert_batch_writable`. After an apply,
+    call :meth:`verify_unchanged` to prove the persisted figure still equals
+    its locked value byte-for-byte (spec E4.3-AC4).
+    """
+
+    def __init__(self, entries: Iterable[LockedEntry] = ()) -> None:
+        self._by_path: dict[str, LockedEntry] = {}
+        for entry in entries:
+            self._by_path[entry.path] = entry
+
+    @classmethod
+    def from_rows(cls, rows: Iterable[Any]) -> LockedFigureGuard:
+        """Build a guard from ``LockedFigure`` ORM rows (``active`` only).
+
+        Rows are duck-typed (``active``, ``path``, ``value``, ``figure_type``)
+        so this stays import-free of the models layer and trivially testable
+        with stubs.
+        """
+        entries = [
+            LockedEntry(
+                path=row.path,
+                value=row.value,
+                figure_type=getattr(row, "figure_type", None),
+            )
+            for row in rows
+            if getattr(row, "active", True)
+        ]
+        return cls(entries)
+
+    def is_locked(self, path: str) -> bool:
+        return path in self._by_path
+
+    def locked_value(self, path: str) -> str | None:
+        entry = self._by_path.get(path)
+        return entry.value if entry is not None else None
+
+    def assert_writable(self, path: str, proposed_value: Any) -> None:
+        """Reject a write to ``path`` that would change a locked figure.
+
+        No-op when ``path`` is not locked, or when ``proposed_value``
+        canonicalises to the locked value (idempotent re-write). Raises
+        :class:`LockedFigureViolation` otherwise.
+        """
+        entry = self._by_path.get(path)
+        if entry is None:
+            return  # path carries no lock — free to write
+        proposed = canonical_value(proposed_value)
+        if proposed != entry.value:
+            raise LockedFigureViolation(path, entry.value, proposed)
+
+    def assert_batch_writable(self, writes: Mapping[str, Any]) -> None:
+        """Assert every write in a batch is permitted.
+
+        Reports the *first* offending path (deterministic order) so the caller
+        gets a single, stable violation for an apply payload that touches many
+        fields.
+        """
+        for path in sorted(writes):
+            self.assert_writable(path, writes[path])
+
+    def verify_unchanged(self, path: str, current_value: Any) -> None:
+        """Post-apply proof that a locked figure survived a write unchanged.
+
+        Unlike :meth:`assert_writable`, an *unlocked* path here is itself an
+        error — you only verify things you locked. Raises
+        :class:`LockedFigureViolation` if the current value drifted, or
+        :class:`KeyError` if ``path`` was never locked.
+        """
+        entry = self._by_path.get(path)
+        if entry is None:
+            raise KeyError(f"No locked figure at path {path!r} to verify")
+        current = canonical_value(current_value)
+        if current != entry.value:
+            raise LockedFigureViolation(path, entry.value, current)

--- a/backend/app/modules/schedule_intelligence/manifest.py
+++ b/backend/app/modules/schedule_intelligence/manifest.py
@@ -1,0 +1,39 @@
+"""‌⁠‍Schedule Intelligence module manifest.
+
+Edit the placeholders below. The ``make module-new`` target drops
+this package into ``backend/app/modules/schedule_intelligence/`` (note:
+short name, no ``oe_`` prefix — matches the existing core modules).
+"""
+
+from app.core.module_loader import ModuleManifest
+
+manifest = ModuleManifest(
+    name="oe_schedule_intelligence",
+    version="0.1.0",
+    display_name="Schedule Intelligence",
+    description=(
+        "Watch → Score → Attribute → Quantify → Decide layer that flags delay "
+        "risk early, attributes cause/responsibility, quantifies critical-path "
+        "impact, and presents human-approved claim-vs-accelerate decisions. "
+        "Orchestrates schedule_advanced, risk, variations, contracts and evm "
+        "rather than duplicating them."
+    ),
+    author="Leaders International",
+    category="business",  # one of: core, integration, regional, community
+    depends=[
+        "oe_projects",
+        "oe_schedule",
+        "oe_schedule_advanced",
+        "oe_risk",
+        "oe_variations",
+        "oe_contracts",
+        "oe_full_evm",
+    ],
+    optional_depends=[
+        "oe_claims_evidence",
+        "oe_retrieval",
+        "oe_file_search",
+    ],
+    auto_install=False,  # set True to enable on first boot
+    enabled=True,
+)

--- a/backend/app/modules/schedule_intelligence/migrations/__init__.py
+++ b/backend/app/modules/schedule_intelligence/migrations/__init__.py
@@ -1,0 +1,6 @@
+"""‌⁠‍Schedule Intelligence alembic migrations.
+
+Rename / renumber these files to fit the global revision chain when
+the module is dropped into ``backend/alembic/versions/``. The numeric
+prefix only needs to be monotonic relative to ``down_revision``.
+"""

--- a/backend/app/modules/schedule_intelligence/migrations/v0001_initial.py
+++ b/backend/app/modules/schedule_intelligence/migrations/v0001_initial.py
@@ -1,0 +1,310 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Schedule Intelligence initial schema — governance + insight tables.
+
+Creates the six ``oe_schedule_intelligence_*`` tables:
+    confidence_config, locked_figure, readiness_result,
+    risk_score, risk_factor, decision.
+
+Idempotent and inspector-guarded so a re-run on a partially-migrated DB is
+safe. SQLite-friendly (``GUID()`` ⇒ ``VARCHAR(36)``).
+
+────────────────────────────────────────────────────────────────────────────
+⚠️  THIS FILE IS INERT UNTIL MOVED + CHAINED (deps-enabled env required)
+────────────────────────────────────────────────────────────────────────────
+Alembic only runs files under ``backend/alembic/versions/``; this copy under
+the module is a reviewable draft. The Alembic graph currently has many open
+heads, so ``down_revision`` MUST NOT be hand-picked blind. In a deps-enabled
+env (Docker/venv) do ONE of:
+
+  A) Autogenerate (preferred — models are the source of truth):
+       cd backend && make migrate-new MSG="schedule_intelligence initial"
+     then delete this draft file.
+
+  B) Adopt this hand-authored DDL:
+       cd backend && alembic heads        # pick the current head
+       mv app/modules/schedule_intelligence/migrations/v0001_initial.py \
+          alembic/versions/vNNNN_schedule_intelligence.py
+     then set ``down_revision`` below to that head and run ``make migrate``.
+
+Note: because these models are imported in ``alembic/env.py``, boot-time
+``metadata.create_all`` already materialises the tables in dev even before this
+migration is chained — so the app is loadable now; this migration is for
+production upgrade integrity.
+
+Revision ID: oe_schedule_intelligence_v0001_initial
+Revises: <FILL_IN_CURRENT_HEAD>
+Create Date: 2026-07-15
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "oe_schedule_intelligence_v0001_initial"
+down_revision: Union[str, Sequence[str], None] = None  # set to current head!
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_PREFIX = "oe_schedule_intelligence_"
+_CONFIDENCE_CONFIG = f"{_PREFIX}confidence_config"
+_LOCKED_FIGURE = f"{_PREFIX}locked_figure"
+_READINESS = f"{_PREFIX}readiness_result"
+_RISK_SCORE = f"{_PREFIX}risk_score"
+_RISK_FACTOR = f"{_PREFIX}risk_factor"
+_DECISION = f"{_PREFIX}decision"
+
+# Ordered for create (parents first) — locked_figure before decision (FK),
+# risk_score before risk_factor (FK). Reverse for drop.
+_ALL_TABLES = (
+    _CONFIDENCE_CONFIG,
+    _LOCKED_FIGURE,
+    _READINESS,
+    _RISK_SCORE,
+    _RISK_FACTOR,
+    _DECISION,
+)
+
+
+def _has_table(inspector: sa.engine.reflection.Inspector, name: str) -> bool:
+    return name in inspector.get_table_names()
+
+
+def _guid(is_sqlite: bool) -> Any:
+    return sa.String(36) if is_sqlite else sa.dialects.postgresql.UUID(as_uuid=True)
+
+
+def _timestamps() -> list[sa.Column[Any]]:
+    return [
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    ]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    is_sqlite = bind.dialect.name == "sqlite"
+    guid = _guid(is_sqlite)
+
+    # ── confidence_config (E5.3) ─────────────────────────────────────────
+    if not _has_table(inspector, _CONFIDENCE_CONFIG):
+        op.create_table(
+            _CONFIDENCE_CONFIG,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "project_id",
+                guid,
+                sa.ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+                nullable=True,
+            ),
+            sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column("description", sa.Text(), nullable=False, server_default=""),
+            sa.Column("band_thresholds", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column("schedule_quality_caps", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column("feed_coverage_caps", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column("corroboration_bonuses", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column(
+                "created_by",
+                guid,
+                sa.ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            *_timestamps(),
+            sa.UniqueConstraint(
+                "project_id",
+                "version",
+                name="uq_sched_intel_confidence_config_project_version",
+            ),
+        )
+        op.create_index(f"ix_{_CONFIDENCE_CONFIG}_project_id", _CONFIDENCE_CONFIG, ["project_id"])
+        op.create_index(f"ix_{_CONFIDENCE_CONFIG}_active", _CONFIDENCE_CONFIG, ["active"])
+
+    # ── locked_figure (E5.2) ─────────────────────────────────────────────
+    if not _has_table(inspector, _LOCKED_FIGURE):
+        op.create_table(
+            _LOCKED_FIGURE,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "project_id",
+                guid,
+                sa.ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("path", sa.String(255), nullable=False),
+            sa.Column("figure_type", sa.String(50), nullable=False),
+            sa.Column("value", sa.String(255), nullable=False),
+            sa.Column("value_hash", sa.String(64), nullable=False),
+            sa.Column("source_ref", sa.String(64), nullable=True),
+            sa.Column("reason", sa.Text(), nullable=False, server_default=""),
+            sa.Column("active", sa.Boolean(), nullable=False, server_default=sa.true()),
+            sa.Column(
+                "locked_by",
+                guid,
+                sa.ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("locked_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "unlocked_by",
+                guid,
+                sa.ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("unlocked_at", sa.DateTime(timezone=True), nullable=True),
+            *_timestamps(),
+            sa.UniqueConstraint(
+                "project_id",
+                "path",
+                name="uq_sched_intel_locked_figure_project_path",
+            ),
+        )
+        op.create_index(f"ix_{_LOCKED_FIGURE}_project_id", _LOCKED_FIGURE, ["project_id"])
+        op.create_index(f"ix_{_LOCKED_FIGURE}_path", _LOCKED_FIGURE, ["path"])
+        op.create_index(f"ix_{_LOCKED_FIGURE}_figure_type", _LOCKED_FIGURE, ["figure_type"])
+        op.create_index(f"ix_{_LOCKED_FIGURE}_active", _LOCKED_FIGURE, ["active"])
+
+    # ── readiness_result (E1) ────────────────────────────────────────────
+    if not _has_table(inspector, _READINESS):
+        op.create_table(
+            _READINESS,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "project_id",
+                guid,
+                sa.ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("activity_ref", sa.String(64), nullable=False),
+            sa.Column("look_ahead_ref", sa.String(64), nullable=True),
+            sa.Column("classification", sa.String(20), nullable=False),
+            sa.Column("binding_constraint_ref", sa.String(64), nullable=True),
+            sa.Column("need_by_date", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("planned_start_date", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("total_float_days", sa.Integer(), nullable=True),
+            sa.Column("float_burn_days", sa.Integer(), nullable=True),
+            sa.Column("drivers", sa.JSON(), nullable=False, server_default="[]"),
+            sa.Column("confidence_score", sa.Numeric(6, 4), nullable=True),
+            sa.Column("confidence_band", sa.String(20), nullable=True),
+            sa.Column("confidence_rationale", sa.JSON(), nullable=False, server_default="[]"),
+            sa.Column("evaluation_run_id", sa.String(64), nullable=True),
+            *_timestamps(),
+        )
+        op.create_index(f"ix_{_READINESS}_project_id", _READINESS, ["project_id"])
+        op.create_index(f"ix_{_READINESS}_activity_ref", _READINESS, ["activity_ref"])
+        op.create_index(f"ix_{_READINESS}_classification", _READINESS, ["classification"])
+
+    # ── risk_score (E2) ──────────────────────────────────────────────────
+    if not _has_table(inspector, _RISK_SCORE):
+        op.create_table(
+            _RISK_SCORE,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "project_id",
+                guid,
+                sa.ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("activity_ref", sa.String(64), nullable=False),
+            sa.Column("score", sa.Numeric(6, 4), nullable=False),
+            sa.Column("band", sa.String(20), nullable=False),
+            sa.Column("scorer_version", sa.String(32), nullable=False, server_default="v0"),
+            sa.Column("first_flagged_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("config_version", sa.Integer(), nullable=True),
+            sa.Column("confidence_score", sa.Numeric(6, 4), nullable=True),
+            sa.Column("confidence_band", sa.String(20), nullable=True),
+            sa.Column("confidence_rationale", sa.JSON(), nullable=False, server_default="[]"),
+            *_timestamps(),
+        )
+        op.create_index(f"ix_{_RISK_SCORE}_project_id", _RISK_SCORE, ["project_id"])
+        op.create_index(f"ix_{_RISK_SCORE}_activity_ref", _RISK_SCORE, ["activity_ref"])
+        op.create_index(f"ix_{_RISK_SCORE}_band", _RISK_SCORE, ["band"])
+
+    # ── risk_factor (E2 decomposition) ───────────────────────────────────
+    if not _has_table(inspector, _RISK_FACTOR):
+        op.create_table(
+            _RISK_FACTOR,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "risk_score_id",
+                guid,
+                sa.ForeignKey(f"{_RISK_SCORE}.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("factor_key", sa.String(50), nullable=False),
+            sa.Column("weight", sa.Numeric(6, 4), nullable=False),
+            sa.Column("raw_value", sa.Numeric(12, 4), nullable=False),
+            sa.Column("contribution", sa.Numeric(6, 4), nullable=False),
+            sa.Column("source_type", sa.String(30), nullable=True),
+            sa.Column("source_ref", sa.String(64), nullable=True),
+            sa.Column("detail", sa.Text(), nullable=False, server_default=""),
+            *_timestamps(),
+        )
+        op.create_index(f"ix_{_RISK_FACTOR}_risk_score_id", _RISK_FACTOR, ["risk_score_id"])
+
+    # ── decision (E4) ────────────────────────────────────────────────────
+    if not _has_table(inspector, _DECISION):
+        op.create_table(
+            _DECISION,
+            sa.Column("id", guid, primary_key=True),
+            sa.Column(
+                "project_id",
+                guid,
+                sa.ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("title", sa.String(255), nullable=False, server_default=""),
+            sa.Column("delay_event_ref", sa.String(64), nullable=True),
+            sa.Column(
+                "impact_locked_figure_id",
+                guid,
+                sa.ForeignKey(f"{_LOCKED_FIGURE}.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("option_claim", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column("option_accelerate", sa.JSON(), nullable=False, server_default="{}"),
+            sa.Column("recommendation", sa.String(20), nullable=True),
+            sa.Column(
+                "recommendation_rationale",
+                sa.JSON(),
+                nullable=False,
+                server_default="[]",
+            ),
+            sa.Column("status", sa.String(20), nullable=False, server_default="draft"),
+            sa.Column("confidence_score", sa.Numeric(6, 4), nullable=True),
+            sa.Column("confidence_band", sa.String(20), nullable=True),
+            sa.Column("confidence_rationale", sa.JSON(), nullable=False, server_default="[]"),
+            sa.Column("applied_option", sa.String(20), nullable=True),
+            sa.Column(
+                "applied_by",
+                guid,
+                sa.ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("applied_at", sa.DateTime(timezone=True), nullable=True),
+            *_timestamps(),
+        )
+        op.create_index(f"ix_{_DECISION}_project_id", _DECISION, ["project_id"])
+        op.create_index(f"ix_{_DECISION}_status", _DECISION, ["status"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    for table in reversed(_ALL_TABLES):
+        if _has_table(inspector, table):
+            op.drop_table(table)

--- a/backend/app/modules/schedule_intelligence/models.py
+++ b/backend/app/modules/schedule_intelligence/models.py
@@ -1,0 +1,349 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Schedule Intelligence ORM models.
+
+This module is a **thin orchestration + governance layer** over the existing
+``schedule_advanced`` / ``risk`` / ``variations`` / ``contracts`` / ``full_evm``
+modules. It therefore owns very little state of its own: its tables hold the
+*derived* insights (readiness, forward risk, priced decisions) and the
+*governance* records (locked figures, confidence configuration) that no other
+module produces.
+
+Reuse boundary (see plan Key risks):
+    Rows that already live elsewhere — a ``schedule_advanced`` ``delay_event``,
+    a ``constraint``, a ``look_ahead`` activity — are referenced by their **id
+    as a string ref**, never copied. There is exactly one source of truth per
+    fact; these tables link to it. Refs are stored as ``String`` (not FK)
+    because the target lives in a sibling module that this one must not
+    hard-couple to at the DB level.
+
+Tables (all prefixed ``oe_schedule_intelligence_``):
+    confidence_config  — E5.3 config-as-data gating (caps / bonuses / bands)
+    locked_figure      — E5.2 commercially-locked figures (policy-as-code guard)
+    readiness_result   — E1 Ready/At-risk/Blocked per look-ahead activity
+    risk_score         — E2 forward-risk composite (0..1) + band
+    risk_factor        — E2 per-factor decomposition rows (P4 traceability)
+    decision           — E4 claim-vs-accelerate priced options
+
+``Base`` already provides ``id`` (UUID PK), ``created_at`` and ``updated_at`` —
+do NOT redeclare them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.database import GUID, Base
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.3 — Confidence configuration (config-as-data gating)
+# ─────────────────────────────────────────────────────────────────────────────
+class ConfidenceConfig(Base):
+    """Versioned, per-deployment confidence gating policy.
+
+    The confidence framework (``confidence.py``) reads the active row and
+    applies its caps/bonuses to every insight so that degraded feeds surface a
+    reduced, *explained* confidence instead of a silent one (spec P5). A row
+    with ``project_id IS NULL`` is the deployment-wide default; a project row
+    overrides it. Thresholds are config-as-data (E2.1-AC7): versioned and
+    audit-logged, never hard-coded in an engine.
+    """
+
+    __tablename__ = "oe_schedule_intelligence_confidence_config"
+    __table_args__ = (
+        UniqueConstraint(
+            "project_id",
+            "version",
+            name="uq_sched_intel_confidence_config_project_version",
+        ),
+    )
+
+    # NULL project_id = deployment-wide default policy.
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true", index=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # Band cutoffs on the final 0..1 confidence score, e.g.
+    #   {"high": 0.75, "medium": 0.5}  (>= high → HIGH, >= medium → MEDIUM, else LOW)
+    band_thresholds: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict, server_default="{}")
+    # Caps keyed by schedule-quality tier, e.g. {"poor": 0.4, "fair": 0.7}.
+    # A capped score can never exceed the cap for the insight's quality tier.
+    schedule_quality_caps: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, server_default="{}"
+    )
+    # Caps keyed by feed-coverage tier, e.g. {"sparse": 0.5, "partial": 0.8}.
+    feed_coverage_caps: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict, server_default="{}")
+    # Additive bonuses keyed by corroboration signal, e.g.
+    #   {"document_backed": 0.1, "cross_feed_agreement": 0.1}
+    corroboration_bonuses: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, server_default="{}"
+    )
+
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        scope = "global" if self.project_id is None else f"project={self.project_id}"
+        return f"<ConfidenceConfig {scope} v{self.version} active={self.active}>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.2 — Locked figures (policy-as-code guard backing store)
+# ─────────────────────────────────────────────────────────────────────────────
+class LockedFigure(Base):
+    """A commercially-sensitive figure that has been locked by a human.
+
+    This is the persistent backing store for the locked-figure guard
+    (``locked_guard.py``). Once a figure is locked, the guard rejects any write
+    that would change ``value`` — from a recompute, a re-render, or an apply —
+    unless the incoming value is byte-identical (idempotent re-writes are
+    allowed so single-store re-renders keep working, spec E4.3).
+
+    ``path`` is the canonical, guard-addressable identity of the figure (e.g.
+    ``decision.<decision_id>.impact_days``). ``value`` is the canonical string
+    serialization used for byte-identical comparison; ``value_hash`` is its
+    SHA-256 for cheap tamper detection and audit. ``source_ref`` records the
+    owning row (a decision id, a delay_event id) so the lock is traceable.
+    """
+
+    __tablename__ = "oe_schedule_intelligence_locked_figure"
+    __table_args__ = (UniqueConstraint("project_id", "path", name="uq_sched_intel_locked_figure_project_path"),)
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Guard-addressable canonical path, unique per project.
+    path: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    figure_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    # Canonical string serialization — the byte-identical comparison target.
+    value: Mapped[str] = mapped_column(String(255), nullable=False)
+    # SHA-256 of ``value`` for tamper detection / audit trail.
+    value_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Ref to the owning row in this or a sibling module (e.g. a decision id).
+    source_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    reason: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # A lock can be released (unlocked) by an authorised actor; we keep the
+    # row for audit rather than deleting it. Only ``active`` locks are enforced.
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true", index=True)
+    locked_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    locked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    unlocked_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    unlocked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<LockedFigure {self.path}={self.value!r} active={self.active}>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E1 — Readiness result (Watch)
+# ─────────────────────────────────────────────────────────────────────────────
+class ReadinessResult(Base):
+    """Deterministic Ready/At-risk/Blocked classification of one activity.
+
+    Produced by ``readiness_engine.py`` (Phase 1) from a ``schedule_advanced``
+    look-ahead activity + its constraints + CPM float. The activity and its
+    binding constraint are referenced by id (``activity_ref`` /
+    ``binding_constraint_ref``), never copied.
+    """
+
+    __tablename__ = "oe_schedule_intelligence_readiness_result"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Ref to the schedule_advanced look-ahead activity / schedule task.
+    activity_ref: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    look_ahead_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    classification: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    binding_constraint_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    need_by_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    planned_start_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    total_float_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    float_burn_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Drivers behind the classification, each linked to a source row (P4):
+    #   [{"type": "constraint", "ref": "...", "detail": "..."}, ...]
+    drivers: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
+
+    # E5.3 confidence attached uniformly.
+    confidence_score: Mapped[Decimal | None] = mapped_column(Numeric(6, 4), nullable=True)
+    confidence_band: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    confidence_rationale: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
+
+    # Stamp of the evaluation run that produced this row (determinism check,
+    # E1.1-AC6: two runs over identical inputs produce identical classification).
+    evaluation_run_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<ReadinessResult activity={self.activity_ref} {self.classification}>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E2 — Forward risk score (Score) + factor decomposition
+# ─────────────────────────────────────────────────────────────────────────────
+class RiskScore(Base):
+    """Deterministic weighted-factor forward-risk composite for one activity.
+
+    Distinct from ``schedule_advanced``'s Monte-Carlo schedule-risk engine:
+    this is a forward-looking, decomposable early-warning score (0..1) with a
+    band and a first-flagged timestamp. Computed by ``risk_scoring.py`` behind
+    a pluggable ``Scorer`` interface (Phase 2). ML is out of MVP (spec §2.3).
+    """
+
+    __tablename__ = "oe_schedule_intelligence_risk_score"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    activity_ref: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # Composite score normalised to 0..1.
+    score: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
+    band: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    scorer_version: Mapped[str] = mapped_column(String(32), nullable=False, default="v0")
+    # First time this activity crossed the flag threshold (weeks-early signal).
+    first_flagged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Which confidence_config version priced this score (audit).
+    config_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    confidence_score: Mapped[Decimal | None] = mapped_column(Numeric(6, 4), nullable=True)
+    confidence_band: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    confidence_rationale: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
+
+    factors: Mapped[list[RiskFactor]] = relationship(
+        back_populates="risk_score",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<RiskScore activity={self.activity_ref} score={self.score} band={self.band}>"
+
+
+class RiskFactor(Base):
+    """One decomposed contributor to a :class:`RiskScore` (P4 traceability).
+
+    Every factor links to the concrete source row it was derived from
+    (``source_type`` + ``source_ref``) so the UI can reach it in ≤2 clicks.
+    """
+
+    __tablename__ = "oe_schedule_intelligence_risk_factor"
+
+    risk_score_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("oe_schedule_intelligence_risk_score.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    factor_key: Mapped[str] = mapped_column(String(50), nullable=False)
+    weight: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
+    raw_value: Mapped[Decimal] = mapped_column(Numeric(12, 4), nullable=False)
+    # weight * normalised(raw_value) — the factor's share of the composite.
+    contribution: Mapped[Decimal] = mapped_column(Numeric(6, 4), nullable=False)
+    source_type: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    # Ref to the source row in its owning module (constraint / PO / RFI / snapshot).
+    source_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    detail: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    risk_score: Mapped[RiskScore] = relationship(back_populates="factors")
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<RiskFactor {self.factor_key} contrib={self.contribution}>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E4 — Claim-vs-accelerate decision (Quantify → Decide)
+# ─────────────────────────────────────────────────────────────────────────────
+class Decision(Base):
+    """A priced claim-vs-accelerate decision assembled from existing pieces.
+
+    Option A (claim) and Option B (accelerate) are stored as itemised JSON
+    (line items each traceable to a source: contract LD/fee, resource rates,
+    EAC delta) rather than exploded columns, so the decision surface can render
+    both side-by-side without a schema change per new line-item kind. The
+    delay event and quantified impact are referenced, not copied. Applying a
+    decision is always human-gated through the existing ``app/core`` approval
+    gate — this module adds no new gate.
+    """
+
+    __tablename__ = "oe_schedule_intelligence_decision"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        GUID(),
+        ForeignKey("oe_projects_project.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Ref to the schedule_advanced delay_event this decision responds to.
+    delay_event_ref: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    # Ref to the locked_figure holding the confirmed critical-path impact days.
+    impact_locked_figure_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_schedule_intelligence_locked_figure.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    # Itemised, traceable option payloads (see class docstring).
+    option_claim: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict, server_default="{}")
+    option_accelerate: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict, server_default="{}")
+    recommendation: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    recommendation_rationale: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="draft", index=True)
+
+    confidence_score: Mapped[Decimal | None] = mapped_column(Numeric(6, 4), nullable=True)
+    confidence_band: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    confidence_rationale: Mapped[list[Any]] = mapped_column(JSON, nullable=False, default=list, server_default="[]")
+
+    applied_option: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    applied_by: Mapped[uuid.UUID | None] = mapped_column(
+        GUID(),
+        ForeignKey("oe_users_user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    applied_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return f"<Decision {self.title[:30]!r} status={self.status}>"

--- a/backend/app/modules/schedule_intelligence/permissions.py
+++ b/backend/app/modules/schedule_intelligence/permissions.py
@@ -1,0 +1,41 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Schedule Intelligence module permission definitions.
+
+Maps each verb in the Watch → Score → Attribute → Quantify → Decide pipeline
+(plus the two governance verbs, ``configure`` and ``lock``) to a minimum role
+on the shared ``admin > manager > editor > viewer`` ladder. Registered at boot
+from ``__init__.on_startup``.
+
+Rationale for the role floors:
+    * ``read`` — VIEWER: anyone on the project may see insights.
+    * ``score`` / ``attribute`` / ``quantify`` — EDITOR: running the engines
+      and staging analysis is normal project work.
+    * ``decide`` — MANAGER: choosing a claim-vs-accelerate recommendation is a
+      commercial judgement.
+    * ``apply`` — MANAGER: applying a decision changes committed state; it also
+      still passes through the existing ``app/core`` approval gate + audit (this
+      module adds NO new gate — see plan Phase 0 step 4).
+    * ``configure`` — MANAGER: editing confidence thresholds is a policy change
+      (versioned + audit-logged, E2.1-AC7).
+    * ``lock`` — MANAGER: locking/unlocking a commercial figure is the
+      trust-critical E5.2 action.
+"""
+
+from app.core.permissions import Role, permission_registry
+
+
+def register_schedule_intelligence_permissions() -> None:
+    """Register permissions for the schedule_intelligence module."""
+    permission_registry.register_module_permissions(
+        "schedule_intelligence",
+        {
+            "schedule_intelligence.read": Role.VIEWER,
+            "schedule_intelligence.score": Role.EDITOR,
+            "schedule_intelligence.attribute": Role.EDITOR,
+            "schedule_intelligence.quantify": Role.EDITOR,
+            "schedule_intelligence.decide": Role.MANAGER,
+            "schedule_intelligence.apply": Role.MANAGER,
+            "schedule_intelligence.configure": Role.MANAGER,
+            "schedule_intelligence.lock": Role.MANAGER,
+        },
+    )

--- a/backend/app/modules/schedule_intelligence/permissions.py
+++ b/backend/app/modules/schedule_intelligence/permissions.py
@@ -8,8 +8,8 @@ from ``__init__.on_startup``.
 
 Rationale for the role floors:
     * ``read`` — VIEWER: anyone on the project may see insights.
-    * ``score`` / ``attribute`` / ``quantify`` — EDITOR: running the engines
-      and staging analysis is normal project work.
+    * ``watch`` / ``score`` / ``attribute`` / ``quantify`` — EDITOR: running the
+      engines and staging analysis is normal project work.
     * ``decide`` — MANAGER: choosing a claim-vs-accelerate recommendation is a
       commercial judgement.
     * ``apply`` — MANAGER: applying a decision changes committed state; it also
@@ -30,6 +30,7 @@ def register_schedule_intelligence_permissions() -> None:
         "schedule_intelligence",
         {
             "schedule_intelligence.read": Role.VIEWER,
+            "schedule_intelligence.watch": Role.EDITOR,
             "schedule_intelligence.score": Role.EDITOR,
             "schedule_intelligence.attribute": Role.EDITOR,
             "schedule_intelligence.quantify": Role.EDITOR,

--- a/backend/app/modules/schedule_intelligence/readiness_engine.py
+++ b/backend/app/modules/schedule_intelligence/readiness_engine.py
@@ -1,0 +1,304 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E1 "Watch" — the Readiness Engine (Phase 1).
+
+Turns ``schedule_advanced``'s binary *ready / not-ready* into a deterministic
+**Ready / At-risk / Blocked** classification per look-ahead activity, with a
+traceable ``binding_constraint`` + ``drivers[]`` (each linked to its source row,
+spec P4) and a uniform E5.3 confidence.
+
+This is a **pure** engine: no I/O, no session, no clock. Its inputs are plain
+dataclasses the service layer fills from the existing feeds — raw
+``schedule_advanced`` constraint rows, an optional CPM float from
+``oe_schedule_activity``, and the prior snapshot's float. That keeps the
+classification testable as a truth table and makes the run **idempotent**:
+:func:`run_digest` hashes the canonical inputs so re-evaluating identical inputs
+yields the same ``evaluation_run_id`` (E1.1-AC6).
+
+Correctness catch (see plan): ``schedule_advanced.constraint_ready_state`` treats
+``cannot_clear`` as *not open* and skips it — which would call a permanently
+blocked activity "ready". This engine consumes **raw** constraint rows and maps
+``cannot_clear → BLOCKED`` itself; the open-blocker subset is exactly
+``{open, in_progress, escalated}``.
+
+Classification constants are hardcoded here (a locked design decision); only the
+*confidence* gating stays config-as-data (E5.3), resolved from a policy row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import Any
+
+from app.modules.schedule_intelligence.confidence import (
+    ConfidencePolicy,
+    ConfidenceResult,
+    compute_confidence,
+)
+from app.modules.schedule_intelligence.enums import ReadinessClass
+
+# ── Classification constants (hardcoded design decision) ─────────────────────
+# A constraint is an *open blocker* while its status is one of these; the
+# schedule_advanced state machine also emits ``cleared`` (resolved) and
+# ``cannot_clear`` (permanently blocked), both handled explicitly below.
+OPEN_STATUSES: frozenset[str] = frozenset({"open", "in_progress", "escalated"})
+CLEARED_STATUS = "cleared"
+CANNOT_CLEAR_STATUS = "cannot_clear"
+
+# Need-by within this many days is the "near horizon": an *undated* open
+# make-ready constraint against a near-horizon activity is treated as unable to
+# clear in time (→ BLOCKED); a near-horizon need-by with thin cover is At-risk.
+NEAR_HORIZON_DAYS = 14
+# Total float at or below this (in days) is "thin" → At-risk; ``≤ 0`` with an
+# open blocker is Blocked.
+AT_RISK_FLOAT_DAYS = 2
+
+# Base confidence the classifier emits before E5.3 gating. Deliberately not 1.0:
+# even a clean classification is a model of reality, not reality.
+_BASE_CONFIDENCE = 0.9
+
+
+def _driver(driver_type: str, ref: Any, detail: str) -> dict[str, str]:
+    """One traceable driver row: ``{type, ref, detail}`` (ref stringified, P4)."""
+    return {"type": driver_type, "ref": str(ref) if ref is not None else "", "detail": detail}
+
+
+@dataclass(frozen=True)
+class ConstraintInput:
+    """A raw ``schedule_advanced`` constraint, as the engine sees it.
+
+    ``status`` is the raw string from the row (``open`` / ``in_progress`` /
+    ``escalated`` / ``cleared`` / ``cannot_clear``); the engine — not the caller
+    — decides what each status means for readiness.
+    """
+
+    ref: Any
+    status: str
+    target_clear_date: date | None = None
+    constraint_type: str | None = None
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class ActivityInput:
+    """One look-ahead activity plus everything needed to classify it.
+
+    ``need_by_date`` is when the activity must be able to start (its planned
+    start); constraints must clear before it. ``total_float`` / ``is_critical``
+    are best-effort CPM enrichment (``None`` when the float join is unresolved —
+    confidence degrades, never silently). ``prior_float`` is the same activity's
+    float in the previous snapshot, used only to detect float *burn*; it is
+    deliberately excluded from :func:`run_digest` so a re-run stays idempotent.
+    """
+
+    task_ref: Any
+    constraints: Sequence[ConstraintInput] = field(default_factory=tuple)
+    need_by_date: date | None = None
+    planned_start_date: date | None = None
+    total_float: int | None = None
+    is_critical: bool = False
+    prior_float: int | None = None
+
+
+@dataclass(frozen=True)
+class ActivityReadiness:
+    """The engine's verdict for one activity — everything the service persists."""
+
+    task_ref: str
+    classification: ReadinessClass
+    binding_constraint_ref: str | None
+    drivers: list[dict[str, str]]
+    need_by_date: date | None
+    planned_start_date: date | None
+    total_float_days: int | None
+    float_burn_days: int | None
+    confidence: ConfidenceResult
+
+
+def _feed_coverage(activity: ActivityInput) -> str:
+    """Feed-coverage tier for E5.3 gating — degrades when float is unresolved.
+
+    ``full`` when CPM float is present; ``partial`` when it is missing but there
+    are constraints to reason over; ``sparse`` when neither is available (the
+    classification then rests almost entirely on absence-of-signal).
+    """
+    if activity.total_float is not None:
+        return "full"
+    if activity.constraints:
+        return "partial"
+    return "sparse"
+
+
+def classify_activity(
+    activity: ActivityInput,
+    today: date,
+    *,
+    policy: ConfidencePolicy | None = None,
+) -> ActivityReadiness:
+    """Classify a single activity as Ready / At-risk / Blocked.
+
+    Pure and deterministic: constraints are considered in a stable
+    ref-sorted order, and the first BLOCKED/AT_RISK rule that fires wins, so the
+    same inputs always yield the same verdict, binding constraint and driver
+    order (E1.1-AC6).
+    """
+    policy = policy or ConfidencePolicy.default()
+    constraints = sorted(activity.constraints, key=lambda c: str(c.ref))
+    open_cs = [c for c in constraints if c.status in OPEN_STATUSES]
+    dead_cs = [c for c in constraints if c.status == CANNOT_CLEAR_STATUS]
+
+    float_days = activity.total_float
+    float_burn: int | None = None
+    if activity.prior_float is not None and float_days is not None:
+        # Positive = float lost since the prior run (burning down toward zero).
+        float_burn = activity.prior_float - float_days
+
+    near_horizon = activity.need_by_date is not None and activity.need_by_date <= today + timedelta(
+        days=NEAR_HORIZON_DAYS
+    )
+
+    drivers: list[dict[str, str]] = []
+    binding: str | None = None
+    classification: ReadinessClass | None = None
+
+    # ── BLOCKED ───────────────────────────────────────────────────────────
+    # 1) A constraint the field has declared permanently un-clearable.
+    if dead_cs:
+        classification = ReadinessClass.BLOCKED
+        binding = str(dead_cs[0].ref)
+        for c in dead_cs:
+            drivers.append(_driver("constraint", c.ref, f"{c.constraint_type or 'constraint'} marked cannot-clear"))
+
+    # 2) An open constraint that cannot clear before the activity must start.
+    if classification is None and activity.need_by_date is not None:
+        offenders: list[tuple[ConstraintInput, str]] = []
+        for c in open_cs:
+            if c.target_clear_date is not None and c.target_clear_date >= activity.need_by_date:
+                offenders.append(
+                    (
+                        c,
+                        f"targets {c.target_clear_date.isoformat()}, not before "
+                        f"need-by {activity.need_by_date.isoformat()}",
+                    )
+                )
+            elif c.target_clear_date is None and near_horizon:
+                offenders.append(
+                    (
+                        c,
+                        f"undated make-ready with need-by {activity.need_by_date.isoformat()} "
+                        f"within {NEAR_HORIZON_DAYS}d",
+                    )
+                )
+        if offenders:
+            classification = ReadinessClass.BLOCKED
+            binding = str(offenders[0][0].ref)
+            for c, detail in offenders:
+                drivers.append(_driver("constraint", c.ref, detail))
+
+    # 3) No critical-path slack left while an open blocker still stands.
+    if classification is None and float_days is not None and float_days <= 0 and open_cs:
+        classification = ReadinessClass.BLOCKED
+        binding = str(open_cs[0].ref)
+        drivers.append(_driver("float", activity.task_ref, f"total float {float_days}d ≤ 0 with an open blocker"))
+        drivers.append(_driver("constraint", open_cs[0].ref, "open blocker on a zero-float activity"))
+
+    # ── AT_RISK / READY ───────────────────────────────────────────────────
+    if classification is None:
+        at_risk = False
+        if open_cs:
+            at_risk = True
+            binding = str(open_cs[0].ref)
+            for c in open_cs:
+                tgt = c.target_clear_date.isoformat() if c.target_clear_date else "undated"
+                drivers.append(_driver("constraint", c.ref, f"open {c.constraint_type or 'constraint'} (target {tgt})"))
+        if float_days is not None and float_days <= AT_RISK_FLOAT_DAYS:
+            at_risk = True
+            drivers.append(
+                _driver("float", activity.task_ref, f"thin total float {float_days}d ≤ {AT_RISK_FLOAT_DAYS}d")
+            )
+            if activity.is_critical:
+                drivers.append(_driver("criticality", activity.task_ref, "activity is on the critical path"))
+        if float_burn is not None and float_burn > 0:
+            at_risk = True
+            drivers.append(_driver("float_burn", activity.task_ref, f"burned {float_burn}d of float since prior run"))
+        if at_risk and near_horizon and activity.need_by_date is not None:
+            drivers.append(
+                _driver(
+                    "need_by",
+                    activity.task_ref,
+                    f"need-by {activity.need_by_date.isoformat()} within {NEAR_HORIZON_DAYS}d",
+                )
+            )
+        classification = ReadinessClass.AT_RISK if at_risk else ReadinessClass.READY
+
+    if classification == ReadinessClass.READY and not drivers:
+        drivers.append(_driver("clear", activity.task_ref, "no open constraints; float healthy"))
+
+    confidence = compute_confidence(
+        _BASE_CONFIDENCE,
+        feed_coverage=_feed_coverage(activity),
+        policy=policy,
+    )
+
+    return ActivityReadiness(
+        task_ref=str(activity.task_ref),
+        classification=classification,
+        binding_constraint_ref=binding,
+        drivers=drivers,
+        need_by_date=activity.need_by_date,
+        planned_start_date=activity.planned_start_date,
+        total_float_days=float_days,
+        float_burn_days=float_burn,
+        confidence=confidence,
+    )
+
+
+def evaluate_look_ahead(
+    activities: Sequence[ActivityInput],
+    today: date,
+    *,
+    policy: ConfidencePolicy | None = None,
+) -> list[ActivityReadiness]:
+    """Classify every activity, returned in a stable ref-sorted order."""
+    policy = policy or ConfidencePolicy.default()
+    ordered = sorted(activities, key=lambda a: str(a.task_ref))
+    return [classify_activity(a, today, policy=policy) for a in ordered]
+
+
+def run_digest(activities: Sequence[ActivityInput], today: date) -> str:
+    """Deterministic SHA-256 of the canonical inputs → the ``evaluation_run_id``.
+
+    Two evaluations over identical inputs (same ``today``, same constraints,
+    same float) produce the same digest, so a re-run is idempotent (E1.1-AC6).
+    ``prior_float`` is intentionally excluded — it is a derived output of earlier
+    runs, and including it would make a run's id depend on whether a snapshot
+    already exists, defeating idempotency.
+    """
+    payload = {
+        "today": today.isoformat(),
+        "activities": [
+            {
+                "task_ref": str(a.task_ref),
+                "need_by": a.need_by_date.isoformat() if a.need_by_date else None,
+                "total_float": a.total_float,
+                "is_critical": bool(a.is_critical),
+                "constraints": sorted(
+                    (
+                        {
+                            "ref": str(c.ref),
+                            "status": c.status,
+                            "target": c.target_clear_date.isoformat() if c.target_clear_date else None,
+                        }
+                        for c in a.constraints
+                    ),
+                    key=lambda d: d["ref"],
+                ),
+            }
+            for a in sorted(activities, key=lambda a: str(a.task_ref))
+        ],
+    }
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/backend/app/modules/schedule_intelligence/repository.py
+++ b/backend/app/modules/schedule_intelligence/repository.py
@@ -1,0 +1,104 @@
+"""Schedule Intelligence data access layer.
+
+Pure queries — no HTTP, no business logic. Each method takes an
+``AsyncSession`` and returns model instances or primitives. The ``service``
+layer composes these into the governance workflows (lock / unlock / verify /
+configure). Phase 0 covers only the two governance tables; insight
+repositories (readiness, risk, decision) arrive with their engines.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.schedule_intelligence.models import ConfidenceConfig, LockedFigure
+
+
+class LockedFigureRepository:
+    """Access to :class:`LockedFigure` rows (E5.2 backing store)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_by_id(self, figure_id: uuid.UUID) -> LockedFigure | None:
+        return await self.session.get(LockedFigure, figure_id)
+
+    async def get_active_by_path(self, project_id: uuid.UUID, path: str) -> LockedFigure | None:
+        stmt = select(LockedFigure).where(
+            LockedFigure.project_id == project_id,
+            LockedFigure.path == path,
+            LockedFigure.active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def list_active_for_project(self, project_id: uuid.UUID) -> list[LockedFigure]:
+        stmt = select(LockedFigure).where(
+            LockedFigure.project_id == project_id,
+            LockedFigure.active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_for_project(self, project_id: uuid.UUID, *, include_inactive: bool = False) -> list[LockedFigure]:
+        stmt = select(LockedFigure).where(LockedFigure.project_id == project_id)
+        if not include_inactive:
+            stmt = stmt.where(LockedFigure.active.is_(True))
+        stmt = stmt.order_by(LockedFigure.locked_at.desc())
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def add(self, row: LockedFigure) -> LockedFigure:
+        self.session.add(row)
+        await self.session.flush()
+        return row
+
+
+class ConfidenceConfigRepository:
+    """Access to :class:`ConfidenceConfig` rows (E5.3 config-as-data)."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_active_for_project(self, project_id: uuid.UUID) -> ConfidenceConfig | None:
+        stmt = select(ConfidenceConfig).where(
+            ConfidenceConfig.project_id == project_id,
+            ConfidenceConfig.active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def get_active_global(self) -> ConfidenceConfig | None:
+        stmt = select(ConfidenceConfig).where(
+            ConfidenceConfig.project_id.is_(None),
+            ConfidenceConfig.active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def max_version_for_project(self, project_id: uuid.UUID) -> int:
+        stmt = select(ConfidenceConfig.version).where(ConfidenceConfig.project_id == project_id)
+        result = await self.session.execute(stmt)
+        versions = [v for v in result.scalars().all() if v is not None]
+        return max(versions, default=0)
+
+    async def list_active_for_project(self, project_id: uuid.UUID) -> list[ConfidenceConfig]:
+        """All currently-active rows for a project (should be at most one).
+
+        Returned so the service can deactivate any stragglers before creating
+        a new version.
+        """
+        stmt = select(ConfidenceConfig).where(
+            ConfidenceConfig.project_id == project_id,
+            ConfidenceConfig.active.is_(True),
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def add(self, row: ConfidenceConfig) -> ConfidenceConfig:
+        self.session.add(row)
+        await self.session.flush()
+        return row

--- a/backend/app/modules/schedule_intelligence/repository.py
+++ b/backend/app/modules/schedule_intelligence/repository.py
@@ -11,10 +11,14 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.modules.schedule_intelligence.models import ConfidenceConfig, LockedFigure
+from app.modules.schedule_intelligence.models import (
+    ConfidenceConfig,
+    LockedFigure,
+    ReadinessResult,
+)
 
 
 class LockedFigureRepository:
@@ -102,3 +106,82 @@ class ConfidenceConfigRepository:
         self.session.add(row)
         await self.session.flush()
         return row
+
+
+class ReadinessResultRepository:
+    """Access to :class:`ReadinessResult` snapshots (E1 Watch backing store).
+
+    A single ``evaluate`` produces one *run* — a batch of rows sharing one
+    deterministic ``evaluation_run_id``. Reads return the latest run; writes are
+    idempotent per run id (the service short-circuits when a run already exists).
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def bulk_add(self, rows: list[ReadinessResult]) -> list[ReadinessResult]:
+        for row in rows:
+            self.session.add(row)
+        await self.session.flush()
+        return rows
+
+    async def list_by_run(self, project_id: uuid.UUID, evaluation_run_id: str) -> list[ReadinessResult]:
+        """All rows of one specific run, oldest-first (stable insert order)."""
+        stmt = (
+            select(ReadinessResult)
+            .where(
+                ReadinessResult.project_id == project_id,
+                ReadinessResult.evaluation_run_id == evaluation_run_id,
+            )
+            .order_by(ReadinessResult.created_at.asc(), ReadinessResult.activity_ref.asc())
+        )
+        result = await self.session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def latest_run_id(
+        self,
+        project_id: uuid.UUID,
+        *,
+        look_ahead_ref: str | None = None,
+    ) -> str | None:
+        """The ``evaluation_run_id`` of the most recently created snapshot."""
+        stmt = select(ReadinessResult.evaluation_run_id).where(ReadinessResult.project_id == project_id)
+        if look_ahead_ref is not None:
+            stmt = stmt.where(ReadinessResult.look_ahead_ref == look_ahead_ref)
+        stmt = stmt.order_by(desc(ReadinessResult.created_at)).limit(1)
+        result = await self.session.execute(stmt)
+        return result.scalars().first()
+
+    async def list_latest_run(
+        self,
+        project_id: uuid.UUID,
+        *,
+        look_ahead_ref: str | None = None,
+    ) -> list[ReadinessResult]:
+        """Every row of the latest run (optionally scoped to one look-ahead)."""
+        run_id = await self.latest_run_id(project_id, look_ahead_ref=look_ahead_ref)
+        if run_id is None:
+            return []
+        return await self.list_by_run(project_id, run_id)
+
+    async def get_prior_by_activity(
+        self,
+        project_id: uuid.UUID,
+        activity_ref: str,
+        *,
+        exclude_run_id: str | None = None,
+    ) -> ReadinessResult | None:
+        """The most recent prior snapshot for one activity (for float-burn).
+
+        ``exclude_run_id`` skips the run currently being written so a fresh row
+        never compares against itself.
+        """
+        stmt = select(ReadinessResult).where(
+            ReadinessResult.project_id == project_id,
+            ReadinessResult.activity_ref == activity_ref,
+        )
+        if exclude_run_id is not None:
+            stmt = stmt.where(ReadinessResult.evaluation_run_id != exclude_run_id)
+        stmt = stmt.order_by(desc(ReadinessResult.created_at)).limit(1)
+        result = await self.session.execute(stmt)
+        return result.scalars().first()

--- a/backend/app/modules/schedule_intelligence/router.py
+++ b/backend/app/modules/schedule_intelligence/router.py
@@ -1,0 +1,199 @@
+"""Schedule Intelligence API routes.
+
+Mounted automatically by the module loader at
+``/api/v1/schedule-intelligence/``. Phase 0 exposes the governance surface
+only — locked figures (E5.2) and confidence configuration/preview (E5.3).
+Insight endpoints (readiness, risk, decision) land with their engines.
+
+Every project-scoped endpoint is gated twice: ``RequirePermission`` checks the
+RBAC verb, and ``verify_project_access`` checks the caller may touch *this*
+project (404-on-deny IDOR defence). Applying a locked-figure change is refused
+by the guard with a 409 that names exactly what was blocked.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, status
+
+from app.dependencies import (
+    CurrentUserId,
+    RequirePermission,
+    SessionDep,
+    verify_project_access,
+)
+from app.modules.schedule_intelligence import service
+from app.modules.schedule_intelligence.confidence import ConfidencePolicy
+from app.modules.schedule_intelligence.schemas import (
+    ConfidenceConfigRead,
+    ConfidenceConfigUpsert,
+    ConfidencePreviewRequest,
+    ConfidencePreviewResponse,
+    LockedFigureRead,
+    LockFigureRequest,
+    VerifyWritesRequest,
+    VerifyWritesResponse,
+    WriteViolation,
+)
+
+router = APIRouter(tags=["schedule_intelligence"])
+
+
+def _as_uuid(user_id: str) -> uuid.UUID | None:
+    """Best-effort parse of the JWT subject into a UUID for audit columns."""
+    try:
+        return uuid.UUID(str(user_id))
+    except (ValueError, TypeError):
+        return None
+
+
+def _config_read(source: str, policy: ConfidencePolicy) -> ConfidenceConfigRead:
+    return ConfidenceConfigRead(
+        source=source,
+        version=policy.version,
+        band_thresholds=dict(policy.band_thresholds),
+        schedule_quality_caps=dict(policy.schedule_quality_caps),
+        feed_coverage_caps=dict(policy.feed_coverage_caps),
+        corroboration_bonuses=dict(policy.corroboration_bonuses),
+    )
+
+
+@router.get("/")
+async def module_info() -> dict[str, str]:
+    """Health-style ping so operators can confirm the module mounted."""
+    return {"module": "oe_schedule_intelligence", "status": "active"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.2 — Locked figures
+# ─────────────────────────────────────────────────────────────────────────────
+@router.post(
+    "/projects/{project_id}/locked-figures",
+    response_model=LockedFigureRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def lock_figure(
+    project_id: uuid.UUID,
+    payload: LockFigureRequest,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.lock")),
+) -> LockedFigureRead:
+    await verify_project_access(project_id, user_id, session)
+    row = await service.lock_figure(session, project_id, payload, _as_uuid(user_id))
+    await session.commit()
+    return LockedFigureRead.model_validate(row)
+
+
+@router.get(
+    "/projects/{project_id}/locked-figures",
+    response_model=list[LockedFigureRead],
+)
+async def list_locked_figures(
+    project_id: uuid.UUID,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    include_inactive: bool = Query(False),
+    _: None = Depends(RequirePermission("schedule_intelligence.read")),
+) -> list[LockedFigureRead]:
+    await verify_project_access(project_id, user_id, session)
+    rows = await service.list_locked_figures(session, project_id, include_inactive=include_inactive)
+    return [LockedFigureRead.model_validate(r) for r in rows]
+
+
+@router.post(
+    "/projects/{project_id}/locked-figures/{figure_id}/unlock",
+    response_model=LockedFigureRead,
+)
+async def unlock_figure(
+    project_id: uuid.UUID,
+    figure_id: uuid.UUID,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.lock")),
+) -> LockedFigureRead:
+    await verify_project_access(project_id, user_id, session)
+    row = await service.unlock_figure(session, project_id, figure_id, _as_uuid(user_id))
+    await session.commit()
+    return LockedFigureRead.model_validate(row)
+
+
+@router.post(
+    "/projects/{project_id}/locked-figures/verify",
+    response_model=VerifyWritesResponse,
+)
+async def verify_writes(
+    project_id: uuid.UUID,
+    payload: VerifyWritesRequest,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.read")),
+) -> VerifyWritesResponse:
+    """Dry-run proposed writes against active locks (read-only preview)."""
+    await verify_project_access(project_id, user_id, session)
+    violations = await service.verify_writes(session, project_id, payload)
+    return VerifyWritesResponse(
+        ok=not violations,
+        violations=[
+            WriteViolation(
+                path=v.path,
+                locked_value=v.locked_value,
+                attempted_value=v.attempted_value,
+            )
+            for v in violations
+        ],
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.3 — Confidence configuration + preview
+# ─────────────────────────────────────────────────────────────────────────────
+@router.get(
+    "/projects/{project_id}/confidence-config",
+    response_model=ConfidenceConfigRead,
+)
+async def get_confidence_config(
+    project_id: uuid.UUID,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.read")),
+) -> ConfidenceConfigRead:
+    await verify_project_access(project_id, user_id, session)
+    policy, source = await service.resolve_policy(session, project_id)
+    return _config_read(source, policy)
+
+
+@router.put(
+    "/projects/{project_id}/confidence-config",
+    response_model=ConfidenceConfigRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upsert_confidence_config(
+    project_id: uuid.UUID,
+    payload: ConfidenceConfigUpsert,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.configure")),
+) -> ConfidenceConfigRead:
+    await verify_project_access(project_id, user_id, session)
+    await service.upsert_confidence_config(session, project_id, payload, _as_uuid(user_id))
+    await session.commit()
+    policy, source = await service.resolve_policy(session, project_id)
+    return _config_read(source, policy)
+
+
+@router.post(
+    "/projects/{project_id}/confidence/preview",
+    response_model=ConfidencePreviewResponse,
+)
+async def preview_confidence(
+    project_id: uuid.UUID,
+    payload: ConfidencePreviewRequest,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.read")),
+) -> ConfidencePreviewResponse:
+    await verify_project_access(project_id, user_id, session)
+    result = await service.preview_confidence(session, project_id, payload)
+    return ConfidencePreviewResponse(score=result.score, band=result.band, rationale=result.rationale)

--- a/backend/app/modules/schedule_intelligence/router.py
+++ b/backend/app/modules/schedule_intelligence/router.py
@@ -25,6 +25,7 @@ from app.dependencies import (
 )
 from app.modules.schedule_intelligence import service
 from app.modules.schedule_intelligence.confidence import ConfidencePolicy
+from app.modules.schedule_intelligence.models import ReadinessResult
 from app.modules.schedule_intelligence.schemas import (
     ConfidenceConfigRead,
     ConfidenceConfigUpsert,
@@ -32,6 +33,9 @@ from app.modules.schedule_intelligence.schemas import (
     ConfidencePreviewResponse,
     LockedFigureRead,
     LockFigureRequest,
+    ReadinessEvaluateRequest,
+    ReadinessResultRead,
+    ReadinessRunResponse,
     VerifyWritesRequest,
     VerifyWritesResponse,
     WriteViolation,
@@ -46,6 +50,22 @@ def _as_uuid(user_id: str) -> uuid.UUID | None:
         return uuid.UUID(str(user_id))
     except (ValueError, TypeError):
         return None
+
+
+def _readiness_run_response(
+    run_id: str | None,
+    rows: list[ReadinessResult],
+) -> ReadinessRunResponse:
+    counts: dict[str, int] = {"ready": 0, "at_risk": 0, "blocked": 0}
+    for r in rows:
+        counts[r.classification] = counts.get(r.classification, 0) + 1
+    look_ahead_ref = rows[0].look_ahead_ref if rows else None
+    return ReadinessRunResponse(
+        evaluation_run_id=run_id,
+        look_ahead_ref=look_ahead_ref,
+        counts=counts,
+        results=[ReadinessResultRead.model_validate(r) for r in rows],
+    )
 
 
 def _config_read(source: str, policy: ConfidencePolicy) -> ConfidenceConfigRead:
@@ -197,3 +217,46 @@ async def preview_confidence(
     await verify_project_access(project_id, user_id, session)
     result = await service.preview_confidence(session, project_id, payload)
     return ConfidencePreviewResponse(score=result.score, band=result.band, rationale=result.rationale)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E1 — Readiness (Watch)
+# ─────────────────────────────────────────────────────────────────────────────
+@router.post(
+    "/projects/{project_id}/look-aheads/{look_ahead_id}/readiness/evaluate",
+    response_model=ReadinessRunResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def evaluate_readiness(
+    project_id: uuid.UUID,
+    look_ahead_id: uuid.UUID,
+    payload: ReadinessEvaluateRequest,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    _: None = Depends(RequirePermission("schedule_intelligence.watch")),
+) -> ReadinessRunResponse:
+    """Evaluate & snapshot Ready/At-risk/Blocked for a look-ahead's activities.
+
+    Idempotent: re-running over identical inputs returns the existing run.
+    """
+    await verify_project_access(project_id, user_id, session)
+    run_id, rows = await service.evaluate_readiness(session, project_id, look_ahead_id, today=payload.today)
+    await session.commit()
+    return _readiness_run_response(run_id, rows)
+
+
+@router.get(
+    "/projects/{project_id}/readiness",
+    response_model=ReadinessRunResponse,
+)
+async def list_readiness(
+    project_id: uuid.UUID,
+    session: SessionDep,
+    user_id: CurrentUserId,
+    look_ahead_id: uuid.UUID | None = Query(None),
+    _: None = Depends(RequirePermission("schedule_intelligence.read")),
+) -> ReadinessRunResponse:
+    """Return the latest readiness run (optionally scoped to one look-ahead)."""
+    await verify_project_access(project_id, user_id, session)
+    run_id, rows = await service.list_readiness(session, project_id, look_ahead_id=look_ahead_id)
+    return _readiness_run_response(run_id, rows)

--- a/backend/app/modules/schedule_intelligence/schemas.py
+++ b/backend/app/modules/schedule_intelligence/schemas.py
@@ -1,19 +1,25 @@
 """Schedule Intelligence Pydantic schemas — request / response shapes.
 
-Phase 0 exposes only the **governance surface** (locked figures + confidence
-config + a confidence preview). The per-insight schemas (readiness, risk,
-decision) arrive with their engines in Phases 1–4.
+Phase 0 exposes the **governance surface** (locked figures + confidence config +
+a confidence preview); Phase 1 adds the **readiness (Watch)** surface. The
+remaining per-insight schemas (risk, decision) arrive with their engines in
+Phases 2–4.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from decimal import Decimal
 from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.modules.schedule_intelligence.enums import ConfidenceBand, LockedFigureType
+from app.modules.schedule_intelligence.enums import (
+    ConfidenceBand,
+    LockedFigureType,
+    ReadinessClass,
+)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -123,3 +129,58 @@ class ConfidencePreviewResponse(BaseModel):
     score: float
     band: ConfidenceBand
     rationale: list[dict[str, Any]] = Field(default_factory=list)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E1 — Readiness (Watch)
+# ─────────────────────────────────────────────────────────────────────────────
+class ReadinessEvaluateRequest(BaseModel):
+    """Trigger a readiness evaluation for a look-ahead.
+
+    ``today`` overrides the evaluation date (defaults to the server's UTC date);
+    supplying it makes the deterministic ``evaluation_run_id`` reproducible in
+    tests and back-dated re-runs.
+    """
+
+    today: date | None = None
+
+
+class ReadinessDriver(BaseModel):
+    """One traceable reason behind a classification (P4): links to a source row."""
+
+    type: str
+    ref: str
+    detail: str
+
+
+class ReadinessResultRead(BaseModel):
+    """A persisted readiness snapshot row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    activity_ref: str
+    look_ahead_ref: str | None
+    classification: ReadinessClass
+    binding_constraint_ref: str | None
+    need_by_date: datetime | None
+    planned_start_date: datetime | None
+    total_float_days: int | None
+    float_burn_days: int | None
+    drivers: list[ReadinessDriver] = Field(default_factory=list)
+    confidence_score: Decimal | None
+    confidence_band: str | None
+    confidence_rationale: list[dict[str, Any]] = Field(default_factory=list)
+    evaluation_run_id: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ReadinessRunResponse(BaseModel):
+    """A whole readiness run: its id, per-class counts, and the rows."""
+
+    evaluation_run_id: str | None
+    look_ahead_ref: str | None = None
+    counts: dict[str, int] = Field(default_factory=dict)
+    results: list[ReadinessResultRead] = Field(default_factory=list)

--- a/backend/app/modules/schedule_intelligence/schemas.py
+++ b/backend/app/modules/schedule_intelligence/schemas.py
@@ -1,0 +1,125 @@
+"""Schedule Intelligence Pydantic schemas — request / response shapes.
+
+Phase 0 exposes only the **governance surface** (locked figures + confidence
+config + a confidence preview). The per-insight schemas (readiness, risk,
+decision) arrive with their engines in Phases 1–4.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.modules.schedule_intelligence.enums import ConfidenceBand, LockedFigureType
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.2 — Locked figures
+# ─────────────────────────────────────────────────────────────────────────────
+class LockFigureRequest(BaseModel):
+    """Request to lock a commercially-sensitive figure.
+
+    ``value`` accepts any JSON scalar/container; the service canonicalises it
+    (see ``locked_guard.canonical_value``) before comparison and storage, so
+    ``5``, ``5.0`` and ``"5"`` are equivalent.
+    """
+
+    path: str = Field(min_length=1, max_length=255)
+    figure_type: LockedFigureType
+    value: Any
+    source_ref: str | None = Field(default=None, max_length=64)
+    reason: str = Field(default="", max_length=5000)
+
+
+class LockedFigureRead(BaseModel):
+    """A stored locked figure."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    project_id: UUID
+    path: str
+    figure_type: str
+    value: str
+    value_hash: str
+    source_ref: str | None
+    reason: str
+    active: bool
+    locked_by: UUID | None
+    locked_at: datetime
+    unlocked_by: UUID | None
+    unlocked_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class VerifyWritesRequest(BaseModel):
+    """Dry-run a batch of proposed writes against the project's locked figures.
+
+    Maps ``path -> proposed value``; the response reports which writes a real
+    apply would reject. Read-only — persists nothing.
+    """
+
+    writes: dict[str, Any] = Field(default_factory=dict)
+
+
+class WriteViolation(BaseModel):
+    path: str
+    locked_value: str
+    attempted_value: str
+
+
+class VerifyWritesResponse(BaseModel):
+    ok: bool
+    violations: list[WriteViolation] = Field(default_factory=list)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.3 — Confidence configuration + preview
+# ─────────────────────────────────────────────────────────────────────────────
+class ConfidenceConfigUpsert(BaseModel):
+    """Create a new active version of a project's confidence gating policy.
+
+    Any omitted map keeps the built-in default for that facet. Upsert always
+    creates a new version and deactivates the prior one (versioned + audited).
+    """
+
+    description: str = Field(default="", max_length=5000)
+    band_thresholds: dict[str, float] | None = None
+    schedule_quality_caps: dict[str, float] | None = None
+    feed_coverage_caps: dict[str, float] | None = None
+    corroboration_bonuses: dict[str, float] | None = None
+
+
+class ConfidenceConfigRead(BaseModel):
+    """The resolved, active confidence policy for a project.
+
+    ``source`` states where it came from: ``"project"`` (a project override),
+    ``"global"`` (the deployment default row) or ``"default"`` (built-in
+    fallback, no row yet) — never silent about which policy is in force.
+    """
+
+    source: str
+    version: int | None
+    band_thresholds: dict[str, float]
+    schedule_quality_caps: dict[str, float]
+    feed_coverage_caps: dict[str, float]
+    corroboration_bonuses: dict[str, float]
+
+
+class ConfidencePreviewRequest(BaseModel):
+    """Inputs to compute a uniform confidence result under the active policy."""
+
+    base_score: float = Field(ge=0.0, le=1.0)
+    schedule_quality: str | None = None
+    feed_coverage: str | None = None
+    corroboration: list[str] = Field(default_factory=list)
+
+
+class ConfidencePreviewResponse(BaseModel):
+    score: float
+    band: ConfidenceBand
+    rationale: list[dict[str, Any]] = Field(default_factory=list)

--- a/backend/app/modules/schedule_intelligence/service.py
+++ b/backend/app/modules/schedule_intelligence/service.py
@@ -1,0 +1,272 @@
+"""Schedule Intelligence service — governance business logic (Phase 0).
+
+Stateless functions that accept an ``AsyncSession`` plus domain primitives,
+orchestrate repository calls, and raise :class:`fastapi.HTTPException` for
+caller-visible failures. Two governance workflows live here:
+
+    * **Locked figures (E5.2)** — lock / unlock / list, and a dry-run verify of
+      a batch of proposed writes against the active locks. Locking is
+      idempotent (re-locking the identical value is a no-op) and monotonic (you
+      cannot re-lock a path to a *different* value without unlocking first).
+    * **Confidence config (E5.3)** — resolve the active policy for a project
+      (project row → global row → built-in default, never silent about which)
+      and upsert a new versioned policy.
+
+Apply/decision flows (Phases 2–4) will reuse the existing ``app/core`` approval
+gate + audit; this module adds no gate of its own.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.events import event_bus
+from app.modules.schedule_intelligence.confidence import (
+    ConfidencePolicy,
+    ConfidenceResult,
+    compute_confidence,
+)
+from app.modules.schedule_intelligence.locked_guard import (
+    LockedFigureGuard,
+    LockedFigureViolation,
+    canonical_value,
+    value_hash,
+)
+from app.modules.schedule_intelligence.models import ConfidenceConfig, LockedFigure
+from app.modules.schedule_intelligence.repository import (
+    ConfidenceConfigRepository,
+    LockedFigureRepository,
+)
+from app.modules.schedule_intelligence.schemas import (
+    ConfidenceConfigUpsert,
+    ConfidencePreviewRequest,
+    LockFigureRequest,
+    VerifyWritesRequest,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.2 — Locked figures
+# ─────────────────────────────────────────────────────────────────────────────
+async def lock_figure(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    payload: LockFigureRequest,
+    user_id: uuid.UUID | None,
+) -> LockedFigure:
+    """Lock a commercial figure at ``payload.path``.
+
+    Idempotent: re-locking the identical canonical value returns the existing
+    lock. Monotonic: attempting to lock a path that already holds a *different*
+    active value is a conflict (409) — the figure must be explicitly unlocked
+    first, so a lock can never be silently overwritten.
+    """
+    canonical = canonical_value(payload.value)
+    repo = LockedFigureRepository(session)
+
+    existing = await repo.get_active_by_path(project_id, payload.path)
+    if existing is not None:
+        if existing.value == canonical:
+            return existing  # idempotent re-lock of the same value
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(f"Path {payload.path!r} is already locked to a different value; unlock it before re-locking."),
+        )
+
+    row = LockedFigure(
+        project_id=project_id,
+        path=payload.path,
+        figure_type=payload.figure_type.value,
+        value=canonical,
+        value_hash=value_hash(canonical),
+        source_ref=payload.source_ref,
+        reason=payload.reason,
+        active=True,
+        locked_by=user_id,
+        locked_at=_utcnow(),
+    )
+    row = await repo.add(row)
+    _publish(
+        "schedule_intelligence.figure.locked",
+        {
+            "id": str(row.id),
+            "project_id": str(project_id),
+            "path": row.path,
+            "figure_type": row.figure_type,
+        },
+    )
+    return row
+
+
+async def unlock_figure(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    figure_id: uuid.UUID,
+    user_id: uuid.UUID | None,
+) -> LockedFigure:
+    """Release an active lock (kept as an inactive row for audit)."""
+    repo = LockedFigureRepository(session)
+    row = await repo.get_by_id(figure_id)
+    # 404 (not 403) when the row belongs to another project — same IDOR policy
+    # as verify_project_access: never confirm the existence of a foreign id.
+    if row is None or row.project_id != project_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Locked figure not found")
+    if not row.active:
+        raise HTTPException(status.HTTP_409_CONFLICT, "Figure is already unlocked")
+
+    row.active = False
+    row.unlocked_by = user_id
+    row.unlocked_at = _utcnow()
+    await session.flush()
+    _publish(
+        "schedule_intelligence.figure.unlocked",
+        {"id": str(row.id), "project_id": str(project_id), "path": row.path},
+    )
+    return row
+
+
+async def list_locked_figures(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    *,
+    include_inactive: bool = False,
+) -> list[LockedFigure]:
+    repo = LockedFigureRepository(session)
+    return await repo.list_for_project(project_id, include_inactive=include_inactive)
+
+
+async def build_guard(session: AsyncSession, project_id: uuid.UUID) -> LockedFigureGuard:
+    """Load the project's active locks into a :class:`LockedFigureGuard`.
+
+    Every write flow in later phases builds a guard from here and gates its
+    payload through it before persisting.
+    """
+    repo = LockedFigureRepository(session)
+    rows = await repo.list_active_for_project(project_id)
+    return LockedFigureGuard.from_rows(rows)
+
+
+async def verify_writes(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    payload: VerifyWritesRequest,
+) -> list[LockedFigureViolation]:
+    """Dry-run proposed writes against active locks; return any violations.
+
+    Read-only. Persists nothing — this is the preview an apply screen calls
+    before committing, so the user sees exactly what would be blocked.
+    """
+    guard = await build_guard(session, project_id)
+    violations: list[LockedFigureViolation] = []
+    for path in sorted(payload.writes):
+        try:
+            guard.assert_writable(path, payload.writes[path])
+        except LockedFigureViolation as exc:
+            violations.append(exc)
+    return violations
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.3 — Confidence configuration + preview
+# ─────────────────────────────────────────────────────────────────────────────
+async def resolve_policy(session: AsyncSession, project_id: uuid.UUID) -> tuple[ConfidencePolicy, str]:
+    """Resolve the active confidence policy and its source.
+
+    Precedence: project override → deployment-wide default row → built-in
+    fallback. Returns ``(policy, source)`` where ``source`` is one of
+    ``"project" | "global" | "default"`` so callers never have to guess which
+    policy priced an insight.
+    """
+    repo = ConfidenceConfigRepository(session)
+
+    project_row = await repo.get_active_for_project(project_id)
+    if project_row is not None:
+        return ConfidencePolicy.from_config(project_row), "project"
+
+    global_row = await repo.get_active_global()
+    if global_row is not None:
+        return ConfidencePolicy.from_config(global_row), "global"
+
+    return ConfidencePolicy.default(), "default"
+
+
+async def upsert_confidence_config(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    payload: ConfidenceConfigUpsert,
+    user_id: uuid.UUID | None,
+) -> ConfidenceConfig:
+    """Create a new active confidence-config version for a project.
+
+    Deactivates any currently-active project rows and inserts a fresh version
+    (``max(version)+1``). Omitted maps inherit the built-in default facet, so a
+    partial config is still valid.
+    """
+    repo = ConfidenceConfigRepository(session)
+    default = ConfidencePolicy.default()
+
+    for stale in await repo.list_active_for_project(project_id):
+        stale.active = False
+
+    next_version = await repo.max_version_for_project(project_id) + 1
+    row = ConfidenceConfig(
+        project_id=project_id,
+        version=next_version,
+        active=True,
+        description=payload.description,
+        band_thresholds=payload.band_thresholds
+        if payload.band_thresholds is not None
+        else dict(default.band_thresholds),
+        schedule_quality_caps=payload.schedule_quality_caps
+        if payload.schedule_quality_caps is not None
+        else dict(default.schedule_quality_caps),
+        feed_coverage_caps=payload.feed_coverage_caps
+        if payload.feed_coverage_caps is not None
+        else dict(default.feed_coverage_caps),
+        corroboration_bonuses=payload.corroboration_bonuses
+        if payload.corroboration_bonuses is not None
+        else dict(default.corroboration_bonuses),
+        created_by=user_id,
+    )
+    row = await repo.add(row)
+    _publish(
+        "schedule_intelligence.confidence_config.updated",
+        {
+            "id": str(row.id),
+            "project_id": str(project_id),
+            "version": next_version,
+        },
+    )
+    return row
+
+
+async def preview_confidence(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    payload: ConfidencePreviewRequest,
+) -> ConfidenceResult:
+    """Compute a uniform confidence result under the project's active policy."""
+    policy, _source = await resolve_policy(session, project_id)
+    return compute_confidence(
+        payload.base_score,
+        schedule_quality=payload.schedule_quality,
+        feed_coverage=payload.feed_coverage,
+        corroboration=payload.corroboration,
+        policy=policy,
+    )
+
+
+def _publish(topic: str, data: dict[str, str | int]) -> None:
+    """Best-effort event publish — a bus hiccup must not fail the request."""
+    try:
+        event_bus.publish_detached(topic, data, source_module="oe_schedule_intelligence")
+    except Exception:  # noqa: BLE001 — event bus is best-effort
+        pass

--- a/backend/app/modules/schedule_intelligence/service.py
+++ b/backend/app/modules/schedule_intelligence/service.py
@@ -19,12 +19,17 @@ gate + audit; this module adds no gate of its own.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 
 from fastapi import HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.events import event_bus
+from app.modules.schedule.models import Activity
+from app.modules.schedule_advanced.models import Constraint, LookAheadPlan, MasterSchedule
+from app.modules.schedule_advanced.repository import ConstraintRepository
 from app.modules.schedule_intelligence.confidence import (
     ConfidencePolicy,
     ConfidenceResult,
@@ -36,10 +41,21 @@ from app.modules.schedule_intelligence.locked_guard import (
     canonical_value,
     value_hash,
 )
-from app.modules.schedule_intelligence.models import ConfidenceConfig, LockedFigure
+from app.modules.schedule_intelligence.models import (
+    ConfidenceConfig,
+    LockedFigure,
+    ReadinessResult,
+)
+from app.modules.schedule_intelligence.readiness_engine import (
+    ActivityInput,
+    ConstraintInput,
+    evaluate_look_ahead,
+    run_digest,
+)
 from app.modules.schedule_intelligence.repository import (
     ConfidenceConfigRepository,
     LockedFigureRepository,
+    ReadinessResultRepository,
 )
 from app.modules.schedule_intelligence.schemas import (
     ConfidenceConfigUpsert,
@@ -262,6 +278,197 @@ async def preview_confidence(
         corroboration=payload.corroboration,
         policy=policy,
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E1 — Readiness (Watch)
+# ─────────────────────────────────────────────────────────────────────────────
+def _parse_iso_date(value: str | None) -> date | None:
+    """Best-effort parse of an ISO date/datetime string's date part."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except ValueError:
+        return None
+
+
+async def _project_id_for_look_ahead(session: AsyncSession, look_ahead_id: uuid.UUID) -> uuid.UUID | None:
+    """Resolve the owning project of a look-ahead via its master schedule.
+
+    Returns ``None`` when the look-ahead does not exist. Used for the IDOR
+    check: the caller's ``project_id`` must match this, else the look-ahead is
+    treated as not found (never confirm a foreign id's existence).
+    """
+    stmt = (
+        select(MasterSchedule.project_id)
+        .join(LookAheadPlan, LookAheadPlan.master_schedule_id == MasterSchedule.id)
+        .where(LookAheadPlan.id == look_ahead_id)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+async def _resolve_float(session: AsyncSession, task_ref: uuid.UUID) -> tuple[int | None, bool, date | None]:
+    """Best-effort CPM enrichment for a constraint's ``task_ref``.
+
+    Returns ``(total_float, is_critical, need_by_date)``. The ``task_ref ↔
+    schedule-activity`` join is intentionally best-effort for the MVP: we look
+    the activity up by id (some deployments carry the schedule-activity id as the
+    task ref). When unresolved, float is ``None`` and confidence degrades — never
+    silently assumed pristine (spec P5). This is the single swap-point when a
+    richer task↔activity mapping lands.
+    """
+    activity = await session.get(Activity, task_ref)
+    if activity is None:
+        return None, False, None
+    return activity.total_float, bool(activity.is_critical), _parse_iso_date(activity.start_date)
+
+
+async def _build_activity_inputs(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    constraints: list[Constraint],
+    readiness_repo: ReadinessResultRepository,
+) -> list[ActivityInput]:
+    """Group raw constraints by ``task_ref`` and enrich each activity.
+
+    One :class:`ActivityInput` per distinct task, carrying its raw constraints,
+    best-effort CPM float/need-by, and the prior snapshot's float (for burn).
+    """
+    by_task: dict[str, list[Constraint]] = {}
+    for c in constraints:
+        by_task.setdefault(str(c.task_ref), []).append(c)
+
+    inputs: list[ActivityInput] = []
+    for task_key, task_constraints in by_task.items():
+        task_ref = task_constraints[0].task_ref
+        total_float, is_critical, need_by = await _resolve_float(session, task_ref)
+        prior = await readiness_repo.get_prior_by_activity(project_id, task_key)
+        inputs.append(
+            ActivityInput(
+                task_ref=task_key,
+                constraints=tuple(
+                    ConstraintInput(
+                        ref=c.id,
+                        status=c.status,
+                        target_clear_date=c.target_clear_date,
+                        constraint_type=c.constraint_type,
+                        description=c.description,
+                    )
+                    for c in task_constraints
+                ),
+                need_by_date=need_by,
+                planned_start_date=need_by,
+                total_float=total_float,
+                is_critical=is_critical,
+                prior_float=prior.total_float_days if prior is not None else None,
+            )
+        )
+    return inputs
+
+
+async def evaluate_readiness(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    look_ahead_id: uuid.UUID,
+    *,
+    today: date | None = None,
+) -> tuple[str, list[ReadinessResult]]:
+    """Evaluate & snapshot readiness for every activity in a look-ahead.
+
+    Derives the look-ahead's project for the IDOR check (a look-ahead in another
+    project is a 404). Pulls raw constraints from ``schedule_advanced``, resolves
+    best-effort CPM float, runs the pure engine under the project's confidence
+    policy, and persists one snapshot *run* stamped with a deterministic
+    ``evaluation_run_id``. Re-running identical inputs is idempotent: the
+    existing run is returned unchanged (E1.1-AC6).
+
+    Returns ``(evaluation_run_id, rows)``.
+    """
+    owning_project = await _project_id_for_look_ahead(session, look_ahead_id)
+    if owning_project is None or owning_project != project_id:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Look-ahead not found")
+
+    today = today or _utcnow().date()
+    constraint_repo = ConstraintRepository(session)
+    readiness_repo = ReadinessResultRepository(session)
+
+    constraints = await constraint_repo.list_for_look_ahead(look_ahead_id)
+    activities = await _build_activity_inputs(session, project_id, constraints, readiness_repo)
+
+    run_id = run_digest(activities, today)
+
+    # Idempotent re-run: an identical-input run already persisted → return it.
+    existing = await readiness_repo.list_by_run(project_id, run_id)
+    if existing:
+        return run_id, existing
+
+    policy, _source = await resolve_policy(session, project_id)
+    verdicts = evaluate_look_ahead(activities, today, policy=policy)
+
+    look_ahead_ref = str(look_ahead_id)
+    rows = [
+        ReadinessResult(
+            project_id=project_id,
+            activity_ref=v.task_ref,
+            look_ahead_ref=look_ahead_ref,
+            classification=v.classification.value,
+            binding_constraint_ref=v.binding_constraint_ref,
+            need_by_date=_as_utc_datetime(v.need_by_date),
+            planned_start_date=_as_utc_datetime(v.planned_start_date),
+            total_float_days=v.total_float_days,
+            float_burn_days=v.float_burn_days,
+            drivers=v.drivers,
+            confidence_score=Decimal(str(v.confidence.score)),
+            confidence_band=v.confidence.band.value,
+            confidence_rationale=v.confidence.rationale,
+            evaluation_run_id=run_id,
+        )
+        for v in verdicts
+    ]
+    rows = await readiness_repo.bulk_add(rows)
+
+    counts = {"ready": 0, "at_risk": 0, "blocked": 0}
+    for v in verdicts:
+        counts[v.classification.value] = counts.get(v.classification.value, 0) + 1
+    _publish(
+        "schedule_intelligence.readiness.evaluated",
+        {
+            "project_id": str(project_id),
+            "look_ahead_id": look_ahead_ref,
+            "evaluation_run_id": run_id,
+            "activity_count": len(rows),
+        },
+    )
+    return run_id, rows
+
+
+async def list_readiness(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    *,
+    look_ahead_id: uuid.UUID | None = None,
+) -> tuple[str | None, list[ReadinessResult]]:
+    """Return the latest readiness run for a project (optionally one look-ahead).
+
+    Returns ``(evaluation_run_id, rows)`` — ``(None, [])`` when nothing has been
+    evaluated yet.
+    """
+    repo = ReadinessResultRepository(session)
+    look_ahead_ref = str(look_ahead_id) if look_ahead_id is not None else None
+    run_id = await repo.latest_run_id(project_id, look_ahead_ref=look_ahead_ref)
+    if run_id is None:
+        return None, []
+    rows = await repo.list_by_run(project_id, run_id)
+    return run_id, rows
+
+
+def _as_utc_datetime(value: date | None) -> datetime | None:
+    """Store a plain date as a midnight-UTC datetime (the column is tz-aware)."""
+    if value is None:
+        return None
+    return datetime(value.year, value.month, value.day, tzinfo=UTC)
 
 
 def _publish(topic: str, data: dict[str, str | int]) -> None:

--- a/backend/app/modules/schedule_intelligence/tests/__init__.py
+++ b/backend/app/modules/schedule_intelligence/tests/__init__.py
@@ -1,0 +1,1 @@
+"""‌⁠‍Schedule Intelligence test package."""

--- a/backend/app/modules/schedule_intelligence/tests/test_schedule_intelligence.py
+++ b/backend/app/modules/schedule_intelligence/tests/test_schedule_intelligence.py
@@ -1,0 +1,23 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Placeholder — the real Schedule Intelligence tests moved to backend/tests/.
+
+The substantive suites live under ``backend/tests/unit/`` so the repo's test
+runner (``make test-backend`` / ``make module-test NAME=oe_schedule_intelligence``,
+which runs ``pytest tests/``) collects them:
+
+    * test_oe_schedule_intelligence_locked_guard.py  — E5.2 negative-injection
+    * test_oe_schedule_intelligence_confidence.py    — E5.3 confidence gating
+    * test_oe_schedule_intelligence_manifest.py       — manifest + schemas + perms
+
+This module-local file is retained only so the package's ``tests/`` dir is not
+empty; it intentionally contains no ``Item``-era assertions.
+"""
+
+from __future__ import annotations
+
+
+def test_module_imports_cleanly() -> None:
+    """The package and its manifest import without side effects."""
+    from app.modules.schedule_intelligence import manifest as manifest_mod
+
+    assert manifest_mod.manifest.name == "oe_schedule_intelligence"

--- a/backend/tests/integration/test_oe_schedule_intelligence_boot.py
+++ b/backend/tests/integration/test_oe_schedule_intelligence_boot.py
@@ -1,0 +1,59 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Boot-level checks for the Schedule Intelligence module.
+
+Proves the module is wired into the assembled app: the loader mounts its router
+at ``/api/v1/schedule-intelligence`` and ``on_startup`` registers its permission
+set. Uses the same ``create_app`` + lifespan harness as the other integration
+suites so the whole startup path (module discovery, permission registration,
+schema bring-up) actually runs.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+
+
+@pytest_asyncio.fixture(scope="module")
+async def client() -> AsyncClient:
+    app = create_app()
+
+    @asynccontextmanager
+    async def lifespan_ctx():
+        async with app.router.lifespan_context(app):
+            yield
+
+    async with lifespan_ctx():
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+
+async def test_module_health_endpoint_is_mounted(client: AsyncClient) -> None:
+    """The loader mounts the router at the kebab-cased module path."""
+    resp = await client.get("/api/v1/schedule-intelligence/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"module": "oe_schedule_intelligence", "status": "active"}
+
+
+async def test_permissions_registered_at_startup() -> None:
+    """on_startup registered the full verb set on the shared registry."""
+    from app.core.permissions import Role, permission_registry
+
+    all_perms = permission_registry.list_all()
+    assert all_perms.get("schedule_intelligence.read") == Role.VIEWER.value
+    assert all_perms.get("schedule_intelligence.lock") == Role.MANAGER.value
+    assert all_perms.get("schedule_intelligence.apply") == Role.MANAGER.value
+
+
+async def test_locked_figure_endpoint_requires_auth(client: AsyncClient) -> None:
+    """A project-scoped governance endpoint is gated (401 without a token)."""
+    resp = await client.get(
+        "/api/v1/schedule-intelligence/projects/00000000-0000-0000-0000-000000000000/locked-figures"
+    )
+    assert resp.status_code == 401

--- a/backend/tests/integration/test_oe_schedule_intelligence_governance_db.py
+++ b/backend/tests/integration/test_oe_schedule_intelligence_governance_db.py
@@ -1,0 +1,233 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""DB-backed integration tests for the Schedule Intelligence governance stack.
+
+Exercises the E5.2 locked-figure and E5.3 confidence workflows end-to-end
+against a real PostgreSQL database (the session template carries every module's
+schema), driving them through the *service* layer so the ORM models,
+repositories, guard, and confidence engine are all proven to integrate — not
+just the pure units.
+
+FK triggers are disabled for the session (``disable_fks=True``) so we can lock
+figures against a synthetic ``project_id`` without standing up the full
+projects/users graph; the governance logic under test never depends on those
+rows existing.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Import the module's models so its tables are registered in Base.metadata.
+import app.modules.schedule_intelligence.models  # noqa: F401
+from app.modules.schedule_intelligence import service
+from app.modules.schedule_intelligence.enums import ConfidenceBand, LockedFigureType
+from app.modules.schedule_intelligence.schemas import (
+    ConfidenceConfigUpsert,
+    ConfidencePreviewRequest,
+    LockFigureRequest,
+    VerifyWritesRequest,
+)
+from tests._pg import transactional_session
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    """Isolated PostgreSQL session, FK triggers off, rolled back on teardown."""
+    async with transactional_session(disable_fks=True) as sess:
+        yield sess
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.2 — locked figures through the real DB + service + guard
+# ─────────────────────────────────────────────────────────────────────────────
+async def test_lock_figure_persists_canonical_value_and_hash(
+    session: AsyncSession,
+) -> None:
+    project_id = uuid.uuid4()
+    row = await service.lock_figure(
+        session,
+        project_id,
+        LockFigureRequest(
+            path="decision.1.impact_days",
+            figure_type=LockedFigureType.IMPACT_DAYS,
+            value=42,
+            reason="director confirmed",
+        ),
+        uuid.uuid4(),
+    )
+    assert row.value == "42"  # canonicalised
+    assert row.value_hash and len(row.value_hash) == 64  # sha256 hex
+    assert row.active is True
+    assert row.figure_type == LockedFigureType.IMPACT_DAYS.value
+
+
+async def test_relock_same_value_is_idempotent(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    req = LockFigureRequest(path="p.impact_days", figure_type=LockedFigureType.IMPACT_DAYS, value=42)
+    first = await service.lock_figure(session, project_id, req, None)
+    # Numeric-equivalent value → same canonical form → same row, no conflict.
+    again = await service.lock_figure(
+        session,
+        project_id,
+        LockFigureRequest(path="p.impact_days", figure_type=LockedFigureType.IMPACT_DAYS, value=42.0),
+        None,
+    )
+    assert first.id == again.id
+
+
+async def test_relock_different_value_conflicts(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    await service.lock_figure(
+        session,
+        project_id,
+        LockFigureRequest(path="p.impact_days", figure_type=LockedFigureType.IMPACT_DAYS, value=42),
+        None,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await service.lock_figure(
+            session,
+            project_id,
+            LockFigureRequest(
+                path="p.impact_days",
+                figure_type=LockedFigureType.IMPACT_DAYS,
+                value=43,
+            ),
+            None,
+        )
+    assert exc.value.status_code == 409
+
+
+async def test_verify_writes_flags_mutation_but_allows_identical(
+    session: AsyncSession,
+) -> None:
+    project_id = uuid.uuid4()
+    await service.lock_figure(
+        session,
+        project_id,
+        LockFigureRequest(
+            path="decision.7.entitlement_days",
+            figure_type=LockedFigureType.ENTITLEMENT_DAYS,
+            value=15,
+        ),
+        None,
+    )
+
+    # A mutating write is reported as a violation.
+    bad = await service.verify_writes(
+        session,
+        project_id,
+        VerifyWritesRequest(writes={"decision.7.entitlement_days": 20}),
+    )
+    assert len(bad) == 1
+    assert bad[0].path == "decision.7.entitlement_days"
+    assert bad[0].locked_value == "15"
+    assert bad[0].attempted_value == "20"
+
+    # An identical (numeric-equivalent) write is allowed.
+    ok = await service.verify_writes(
+        session,
+        project_id,
+        VerifyWritesRequest(writes={"decision.7.entitlement_days": 15.0}),
+    )
+    assert ok == []
+
+
+async def test_unlock_releases_the_guard(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    row = await service.lock_figure(
+        session,
+        project_id,
+        LockFigureRequest(
+            path="p.lds_avoided",
+            figure_type=LockedFigureType.LDS_AVOIDED,
+            value="90000.00",
+        ),
+        None,
+    )
+    # Locked → mutation blocked.
+    assert await service.verify_writes(session, project_id, VerifyWritesRequest(writes={"p.lds_avoided": "0"}))
+
+    unlocked = await service.unlock_figure(session, project_id, row.id, None)
+    assert unlocked.active is False
+    assert unlocked.unlocked_at is not None
+
+    # Released → the path is writable again (no violation).
+    assert await service.verify_writes(session, project_id, VerifyWritesRequest(writes={"p.lds_avoided": "0"})) == []
+
+
+async def test_unlock_foreign_project_is_404(session: AsyncSession) -> None:
+    row = await service.lock_figure(
+        session,
+        uuid.uuid4(),
+        LockFigureRequest(path="p.impact_days", figure_type=LockedFigureType.IMPACT_DAYS, value=1),
+        None,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await service.unlock_figure(session, uuid.uuid4(), row.id, None)
+    assert exc.value.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E5.3 — confidence config through the real DB
+# ─────────────────────────────────────────────────────────────────────────────
+async def test_confidence_policy_resolves_default_then_project(
+    session: AsyncSession,
+) -> None:
+    project_id = uuid.uuid4()
+
+    # No row yet → built-in default policy.
+    policy, source = await service.resolve_policy(session, project_id)
+    assert source == "default"
+    assert policy.version is None
+
+    # Upsert a project override → resolves to it, versioned.
+    await service.upsert_confidence_config(
+        session,
+        project_id,
+        ConfidenceConfigUpsert(
+            description="tighter caps for pilot",
+            schedule_quality_caps={"poor": 0.2, "fair": 0.6, "good": 1.0},
+        ),
+        None,
+    )
+    policy, source = await service.resolve_policy(session, project_id)
+    assert source == "project"
+    assert policy.version == 1
+    assert policy.schedule_quality_caps["poor"] == 0.2
+
+
+async def test_confidence_upsert_bumps_version_and_deactivates_prior(
+    session: AsyncSession,
+) -> None:
+    project_id = uuid.uuid4()
+    await service.upsert_confidence_config(session, project_id, ConfidenceConfigUpsert(description="v1"), None)
+    await service.upsert_confidence_config(session, project_id, ConfidenceConfigUpsert(description="v2"), None)
+    policy, source = await service.resolve_policy(session, project_id)
+    assert source == "project"
+    assert policy.version == 2  # exactly one active row, the newest version
+
+
+async def test_confidence_preview_applies_project_caps(
+    session: AsyncSession,
+) -> None:
+    project_id = uuid.uuid4()
+    await service.upsert_confidence_config(
+        session,
+        project_id,
+        ConfidenceConfigUpsert(schedule_quality_caps={"poor": 0.2}),
+        None,
+    )
+    result = await service.preview_confidence(
+        session,
+        project_id,
+        ConfidencePreviewRequest(base_score=0.95, schedule_quality="poor"),
+    )
+    assert result.score == 0.2  # capped by the project's poor-quality ceiling
+    assert result.band == ConfidenceBand.LOW
+    # The cap is recorded, never silent.
+    assert any(r["step"] == "cap:schedule_quality" for r in result.rationale)

--- a/backend/tests/integration/test_oe_schedule_intelligence_readiness_db.py
+++ b/backend/tests/integration/test_oe_schedule_intelligence_readiness_db.py
@@ -1,0 +1,202 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""DB-backed integration tests for the E1 Readiness (Watch) workflow.
+
+Drives ``service.evaluate_readiness`` / ``list_readiness`` end-to-end against a
+real PostgreSQL database (the session template carries every module's schema),
+so the readiness engine, its repository, the ``schedule_advanced`` constraint
+feed, and the best-effort CPM-float join are all proven to integrate.
+
+FK triggers are disabled (``disable_fks=True``) so we can stand up a minimal
+``master_schedule → look_ahead → constraint`` chain (plus an optional
+``schedule_activity`` for the float path) against synthetic project ids without
+the full projects/users graph.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Import models so their tables are registered in Base.metadata.
+import app.modules.schedule_intelligence.models  # noqa: F401
+from app.modules.schedule.models import Activity, Schedule
+from app.modules.schedule_advanced.models import Constraint, LookAheadPlan, MasterSchedule
+from app.modules.schedule_intelligence import service
+from app.modules.schedule_intelligence.enums import ReadinessClass
+from tests._pg import transactional_session
+
+TODAY = date(2026, 7, 15)
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    async with transactional_session(disable_fks=True) as sess:
+        yield sess
+
+
+async def _make_look_ahead(session: AsyncSession, project_id: uuid.UUID) -> LookAheadPlan:
+    """Create a master schedule + look-ahead owned by ``project_id``."""
+    master = MasterSchedule(project_id=project_id, name="Master")
+    session.add(master)
+    await session.flush()
+    la = LookAheadPlan(
+        master_schedule_id=master.id,
+        period_start=date(2026, 7, 13),
+        period_end=date(2026, 8, 24),
+    )
+    session.add(la)
+    await session.flush()
+    return la
+
+
+async def _add_constraint(
+    session: AsyncSession,
+    la_id: uuid.UUID,
+    task_ref: uuid.UUID,
+    status: str,
+    *,
+    ctype: str = "material",
+    target: date | None = None,
+) -> Constraint:
+    c = Constraint(
+        look_ahead_id=la_id,
+        task_ref=task_ref,
+        constraint_type=ctype,
+        status=status,
+        target_clear_date=target,
+    )
+    session.add(c)
+    await session.flush()
+    return c
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Persist + classify through the real DB
+# ─────────────────────────────────────────────────────────────────────────────
+async def test_evaluate_persists_snapshot_and_classifies(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    la = await _make_look_ahead(session, project_id)
+
+    ready_task = uuid.uuid4()
+    blocked_task = uuid.uuid4()
+    await _add_constraint(session, la.id, ready_task, "cleared")
+    await _add_constraint(session, la.id, blocked_task, "cannot_clear", ctype="permit")
+
+    run_id, rows = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+
+    assert run_id and len(run_id) == 64
+    by_ref = {r.activity_ref: r for r in rows}
+    assert by_ref[str(ready_task)].classification == ReadinessClass.READY.value
+    assert by_ref[str(blocked_task)].classification == ReadinessClass.BLOCKED.value
+    # Snapshot carries the run stamp + a confidence band, uniformly.
+    assert all(r.evaluation_run_id == run_id for r in rows)
+    assert all(r.confidence_band for r in rows)
+    # The blocked row names its binding constraint (P4).
+    assert by_ref[str(blocked_task)].binding_constraint_ref is not None
+
+
+async def test_get_latest_run_returns_snapshot(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    la = await _make_look_ahead(session, project_id)
+    await _add_constraint(session, la.id, uuid.uuid4(), "open")
+
+    run_id, _ = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+    latest_id, latest_rows = await service.list_readiness(session, project_id, look_ahead_id=la.id)
+
+    assert latest_id == run_id
+    assert len(latest_rows) == 1
+    assert latest_rows[0].classification == ReadinessClass.AT_RISK.value
+
+
+async def test_reevaluate_identical_inputs_is_idempotent(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    la = await _make_look_ahead(session, project_id)
+    await _add_constraint(session, la.id, uuid.uuid4(), "open")
+
+    run1, rows1 = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+    run2, rows2 = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+
+    # Same digest, same rows — no duplicate snapshot written.
+    assert run1 == run2
+    assert {r.id for r in rows1} == {r.id for r in rows2}
+
+
+async def test_changed_inputs_produce_a_new_run(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    la = await _make_look_ahead(session, project_id)
+    task = uuid.uuid4()
+    c = await _add_constraint(session, la.id, task, "open")
+
+    run1, _ = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+
+    # Escalate the constraint → different canonical inputs → new run.
+    c.status = "cannot_clear"
+    await session.flush()
+    run2, rows2 = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+
+    assert run1 != run2
+    latest_id, latest_rows = await service.list_readiness(session, project_id, look_ahead_id=la.id)
+    assert latest_id == run2
+    assert latest_rows[0].classification == ReadinessClass.BLOCKED.value
+
+
+async def test_foreign_look_ahead_is_404(session: AsyncSession) -> None:
+    owner = uuid.uuid4()
+    other = uuid.uuid4()
+    la = await _make_look_ahead(session, owner)
+    await _add_constraint(session, la.id, uuid.uuid4(), "open")
+
+    with pytest.raises(HTTPException) as exc:
+        await service.evaluate_readiness(session, other, la.id, today=TODAY)
+    assert exc.value.status_code == 404
+
+
+async def test_missing_look_ahead_is_404(session: AsyncSession) -> None:
+    with pytest.raises(HTTPException) as exc:
+        await service.evaluate_readiness(session, uuid.uuid4(), uuid.uuid4(), today=TODAY)
+    assert exc.value.status_code == 404
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Best-effort CPM float join + float-burn across runs
+# ─────────────────────────────────────────────────────────────────────────────
+async def test_float_join_enriches_and_burn_detected_across_runs(session: AsyncSession) -> None:
+    project_id = uuid.uuid4()
+    la = await _make_look_ahead(session, project_id)
+
+    # The constraint's task_ref doubles as a schedule-activity id (the MVP's
+    # best-effort join point). First run: float 10, clean → READY.
+    task = uuid.uuid4()
+    sched = Schedule(project_id=project_id, name="S")
+    session.add(sched)
+    await session.flush()
+    act = Activity(
+        id=task,
+        schedule_id=sched.id,
+        name="Pour slab",
+        start_date="2026-08-01",
+        end_date="2026-08-05",
+        total_float=10,
+        is_critical=False,
+    )
+    session.add(act)
+    await session.flush()
+    await _add_constraint(session, la.id, task, "cleared")
+
+    _run1, rows1 = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+    assert rows1[0].total_float_days == 10
+    assert rows1[0].classification == ReadinessClass.READY.value
+    assert rows1[0].float_burn_days is None  # first snapshot, no prior
+
+    # Float burns down to 1 → thin float, and a burn of 9 vs the prior run.
+    act.total_float = 1
+    await session.flush()
+    _run2, rows2 = await service.evaluate_readiness(session, project_id, la.id, today=TODAY)
+    assert rows2[0].total_float_days == 1
+    assert rows2[0].float_burn_days == 9
+    assert rows2[0].classification == ReadinessClass.AT_RISK.value

--- a/backend/tests/unit/test_oe_schedule_intelligence_confidence.py
+++ b/backend/tests/unit/test_oe_schedule_intelligence_confidence.py
@@ -1,0 +1,118 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E5.3 confidence framework — uniform schema, config-as-data gating.
+
+Pure unit tests for ``confidence.compute_confidence``. Focus areas:
+    * caps are a true ceiling (degraded feed / poor schedule → reduced score),
+    * the reduction is never silent — the rationale states it (spec P5),
+    * corroboration bonuses apply before caps and cannot exceed them,
+    * the computation is deterministic (identical inputs → identical output).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.schedule_intelligence.confidence import (
+    ConfidencePolicy,
+    compute_confidence,
+)
+from app.modules.schedule_intelligence.enums import ConfidenceBand
+
+
+def test_clean_high_base_is_high_band() -> None:
+    result = compute_confidence(0.9)
+    assert result.score == 0.9
+    assert result.band == ConfidenceBand.HIGH
+    # rationale is never empty; the base is always first.
+    assert result.rationale[0]["step"] == "base"
+
+
+def test_poor_schedule_quality_caps_confidence() -> None:
+    result = compute_confidence(0.9, schedule_quality="poor")
+    assert result.score == 0.4  # default poor cap
+    assert result.band == ConfidenceBand.LOW
+    cap_steps = [r for r in result.rationale if r["step"] == "cap:schedule_quality"]
+    assert cap_steps and cap_steps[0]["effect"] < 0  # reduction recorded, not silent
+
+
+def test_sparse_feed_coverage_caps_confidence() -> None:
+    result = compute_confidence(0.95, feed_coverage="sparse")
+    assert result.score == 0.5  # default sparse cap
+    assert result.band == ConfidenceBand.MEDIUM
+    assert any(r["step"] == "cap:feed_coverage" for r in result.rationale)
+
+
+def test_corroboration_bonuses_are_additive_and_recorded() -> None:
+    result = compute_confidence(0.3, corroboration=["document_backed", "human_confirmed"])
+    # 0.3 + 0.10 + 0.15 = 0.55
+    assert result.score == 0.55
+    assert result.band == ConfidenceBand.MEDIUM
+    bonus_steps = [r for r in result.rationale if r["step"].startswith("corroboration:")]
+    assert len(bonus_steps) == 2
+
+
+def test_cap_beats_corroboration_bonus() -> None:
+    """A cap is a hard ceiling — corroboration cannot lift the score past it."""
+    result = compute_confidence(0.6, schedule_quality="poor", corroboration=["human_confirmed"])
+    assert result.score == 0.4  # bonus pushed to 0.75, then poor cap clamps to 0.4
+    assert result.band == ConfidenceBand.LOW
+
+
+def test_unknown_tier_is_surfaced_not_silently_ignored() -> None:
+    result = compute_confidence(0.8, schedule_quality="does-not-exist")
+    assert result.score == 0.8  # no cap applied
+    notes = [r for r in result.rationale if r["step"] == "cap:schedule_quality" and "unknown" in r["detail"]]
+    assert notes  # the unknown tier is recorded
+
+
+def test_base_score_is_clamped_to_unit_interval() -> None:
+    assert compute_confidence(1.5).score == 1.0
+    assert compute_confidence(-0.2).score == 0.0
+
+
+def test_computation_is_deterministic() -> None:
+    kwargs = dict(
+        schedule_quality="fair",
+        feed_coverage="partial",
+        corroboration=["document_backed"],
+    )
+    a = compute_confidence(0.7, **kwargs)
+    b = compute_confidence(0.7, **kwargs)
+    assert a.as_dict() == b.as_dict()
+
+
+class _ConfigRow:
+    """Duck-typed stand-in for a ConfidenceConfig ORM row."""
+
+    def __init__(self, **kwargs) -> None:
+        self.band_thresholds = kwargs.get("band_thresholds")
+        self.schedule_quality_caps = kwargs.get("schedule_quality_caps")
+        self.feed_coverage_caps = kwargs.get("feed_coverage_caps")
+        self.corroboration_bonuses = kwargs.get("corroboration_bonuses")
+        self.version = kwargs.get("version", 3)
+
+
+def test_from_config_falls_back_for_missing_facets() -> None:
+    # Only override the schedule-quality caps; everything else defaults.
+    policy = ConfidencePolicy.from_config(_ConfigRow(schedule_quality_caps={"poor": 0.2}))
+    assert policy.version == 3
+    assert policy.schedule_quality_caps["poor"] == 0.2
+    # Falls back to built-in defaults for the untouched facets.
+    assert policy.band_thresholds == ConfidencePolicy.default().band_thresholds
+    assert policy.corroboration_bonuses == ConfidencePolicy.default().corroboration_bonuses
+
+    result = compute_confidence(0.9, schedule_quality="poor", policy=policy)
+    assert result.score == 0.2  # the overridden cap is honoured
+
+
+@pytest.mark.parametrize(
+    "score,expected",
+    [
+        (0.75, ConfidenceBand.HIGH),
+        (0.74, ConfidenceBand.MEDIUM),
+        (0.5, ConfidenceBand.MEDIUM),
+        (0.49, ConfidenceBand.LOW),
+    ],
+)
+def test_band_thresholds_at_boundaries(score: float, expected: ConfidenceBand) -> None:
+    assert compute_confidence(score).band == expected

--- a/backend/tests/unit/test_oe_schedule_intelligence_locked_guard.py
+++ b/backend/tests/unit/test_oe_schedule_intelligence_locked_guard.py
@@ -1,0 +1,172 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E5.2 locked-figure guard — negative-injection suite.
+
+The commercial-trust heart of ``oe_schedule_intelligence``: prove that once a
+figure is locked, no write can change it, from any flow. These are pure unit
+tests — no DB, no session — because the guard core is deliberately
+dependency-free (``LockedFigureGuard`` takes explicit entries). That is what
+lets this suite be exhaustive and fast.
+
+Covers spec ACs: E5.2-AC2 (every apply flow rejects locked-path writes) and
+E4.3-AC4 (post-apply verification that locked figures are byte-identical).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.modules.schedule_intelligence.enums import LockedFigureType
+from app.modules.schedule_intelligence.locked_guard import (
+    LockedEntry,
+    LockedFigureGuard,
+    LockedFigureViolation,
+    canonical_value,
+    value_hash,
+)
+
+
+# ── canonicalisation: type-agnostic, byte-identical comparison ───────────────
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        (5, 5.0),
+        (5, "5"),
+        (Decimal("12.50"), 12.5),
+        (Decimal("12.50"), "12.5"),
+        (1000, "1000"),
+        (0, 0.0),
+    ],
+)
+def test_canonical_value_treats_equal_numbers_as_equal(a, b) -> None:
+    assert canonical_value(a) == canonical_value(b)
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        (5, 5.01),
+        (12.5, 12.51),
+        ("42 days", "43 days"),
+        (True, 1),  # bool is not the integer 1 here — distinct canonical forms
+    ],
+)
+def test_canonical_value_distinguishes_different_values(a, b) -> None:
+    assert canonical_value(a) != canonical_value(b)
+
+
+def test_canonical_value_is_order_independent_for_dicts() -> None:
+    assert canonical_value({"a": 1, "b": 2}) == canonical_value({"b": 2, "a": 1})
+
+
+def test_value_hash_matches_canonical() -> None:
+    assert value_hash(canonical_value(5)) == value_hash("5")
+
+
+# ── the core guard behaviours ────────────────────────────────────────────────
+def test_unlocked_path_is_freely_writable() -> None:
+    guard = LockedFigureGuard([LockedEntry.for_value("a.b", 10)])
+    guard.assert_writable("some.other.path", 999)  # no lock → no raise
+
+
+def test_idempotent_rewrite_of_same_value_is_allowed() -> None:
+    """Single-store re-renders re-emit the confirmed figure — must not trip."""
+    guard = LockedFigureGuard([LockedEntry.for_value("decision.1.impact_days", 42)])
+    guard.assert_writable("decision.1.impact_days", 42)
+    guard.assert_writable("decision.1.impact_days", 42.0)  # numeric-equivalent
+    guard.assert_writable("decision.1.impact_days", "42")
+
+
+def test_mutating_a_locked_figure_is_rejected() -> None:
+    guard = LockedFigureGuard([LockedEntry.for_value("decision.1.impact_days", 42)])
+    with pytest.raises(LockedFigureViolation) as exc:
+        guard.assert_writable("decision.1.impact_days", 43)
+    assert exc.value.path == "decision.1.impact_days"
+    assert exc.value.locked_value == "42"
+    assert exc.value.attempted_value == "43"
+
+
+def test_negative_injection_across_every_locked_figure_type() -> None:
+    """Lock one figure of each type, then inject a mutated write → all rejected.
+
+    This is the E5.2-AC2 guarantee in one sweep: no figure category has a hole.
+    """
+    baseline = {
+        LockedFigureType.BASELINE_DATE: ("baseline.date", "2026-01-01", "2026-02-01"),
+        LockedFigureType.IMPACT_DAYS: ("impact.days", 42, 30),
+        LockedFigureType.ENTITLEMENT_DAYS: ("eot.days", 15, 20),
+        LockedFigureType.ENTITLEMENT_COST: ("eot.cost", "125000.00", "150000.00"),
+        LockedFigureType.LDS_AVOIDED: ("lds.avoided", "90000.00", "0.00"),
+        LockedFigureType.PROLONGATION_COST: ("prolong.cost", "60000.00", "61000.00"),
+        LockedFigureType.ACCELERATION_COST: ("accel.cost", "80000.00", "40000.00"),
+    }
+    entries = [
+        LockedEntry.for_value(path, locked, figure_type=ftype.value)
+        for ftype, (path, locked, _mutated) in baseline.items()
+    ]
+    guard = LockedFigureGuard(entries)
+
+    for ftype, (path, locked, mutated) in baseline.items():
+        # identical re-write allowed
+        guard.assert_writable(path, locked)
+        # any change rejected
+        with pytest.raises(LockedFigureViolation):
+            guard.assert_writable(path, mutated)
+
+
+def test_batch_write_rejects_when_any_path_violates() -> None:
+    guard = LockedFigureGuard(
+        [
+            LockedEntry.for_value("a.impact_days", 42),
+            LockedEntry.for_value("b.eot_days", 15),
+        ]
+    )
+    # A payload that leaves both locked figures untouched passes.
+    guard.assert_batch_writable({"a.impact_days": 42, "b.eot_days": 15, "c.free": 999})
+    # A payload that mutates one locked figure is rejected.
+    with pytest.raises(LockedFigureViolation):
+        guard.assert_batch_writable({"a.impact_days": 42, "b.eot_days": 99})
+
+
+# ── post-apply verification (E4.3-AC4) ───────────────────────────────────────
+def test_verify_unchanged_passes_when_identical() -> None:
+    guard = LockedFigureGuard([LockedEntry.for_value("decision.1.impact_days", 42)])
+    guard.verify_unchanged("decision.1.impact_days", 42)
+
+
+def test_verify_unchanged_raises_on_drift() -> None:
+    guard = LockedFigureGuard([LockedEntry.for_value("decision.1.impact_days", 42)])
+    with pytest.raises(LockedFigureViolation):
+        guard.verify_unchanged("decision.1.impact_days", 41)
+
+
+def test_verify_unchanged_on_unlocked_path_is_an_error() -> None:
+    """You only verify what you locked; an unknown path is a programming error."""
+    guard = LockedFigureGuard([])
+    with pytest.raises(KeyError):
+        guard.verify_unchanged("never.locked", 1)
+
+
+# ── from_rows adapter: only active locks are enforced ────────────────────────
+class _Row:
+    def __init__(self, path: str, value: str, active: bool, figure_type: str) -> None:
+        self.path = path
+        self.value = value
+        self.active = active
+        self.figure_type = figure_type
+
+
+def test_from_rows_ignores_inactive_locks() -> None:
+    guard = LockedFigureGuard.from_rows(
+        [
+            _Row("active.path", "42", active=True, figure_type="impact_days"),
+            _Row("released.path", "10", active=False, figure_type="impact_days"),
+        ]
+    )
+    assert guard.is_locked("active.path")
+    assert not guard.is_locked("released.path")
+    # An unlocked (released) path is writable again.
+    guard.assert_writable("released.path", 999)
+    with pytest.raises(LockedFigureViolation):
+        guard.assert_writable("active.path", 999)

--- a/backend/tests/unit/test_oe_schedule_intelligence_manifest.py
+++ b/backend/tests/unit/test_oe_schedule_intelligence_manifest.py
@@ -1,0 +1,81 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""Schedule Intelligence manifest + governance-schema sanity checks."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+
+def test_manifest_is_well_formed() -> None:
+    from app.modules.schedule_intelligence import manifest as manifest_mod
+
+    m = manifest_mod.manifest
+    assert m.name == "oe_schedule_intelligence"
+    assert m.version
+    assert m.display_name
+    assert m.category == "business"
+    # Thin orchestration layer — must depend on the modules it composes.
+    assert "oe_schedule_advanced" in m.depends
+
+
+def test_permission_set_covers_the_pipeline() -> None:
+    """The registered verbs cover Watch→Score→Attribute→Quantify→Decide + governance."""
+    from app.core.permissions import permission_registry
+    from app.modules.schedule_intelligence.permissions import (
+        register_schedule_intelligence_permissions,
+    )
+
+    register_schedule_intelligence_permissions()
+    expected = {
+        "schedule_intelligence.read",
+        "schedule_intelligence.score",
+        "schedule_intelligence.attribute",
+        "schedule_intelligence.quantify",
+        "schedule_intelligence.decide",
+        "schedule_intelligence.apply",
+        "schedule_intelligence.configure",
+        "schedule_intelligence.lock",
+    }
+    registered = set(permission_registry.list_all().keys())
+    assert expected <= registered
+
+
+def test_lock_request_requires_path_and_type() -> None:
+    from app.modules.schedule_intelligence.schemas import LockFigureRequest
+
+    with pytest.raises(ValidationError):
+        LockFigureRequest(value=42)  # type: ignore[call-arg]
+
+
+def test_lock_request_accepts_valid_payload() -> None:
+    from app.modules.schedule_intelligence.enums import LockedFigureType
+    from app.modules.schedule_intelligence.schemas import LockFigureRequest
+
+    req = LockFigureRequest(
+        path="decision.1.impact_days",
+        figure_type=LockedFigureType.IMPACT_DAYS,
+        value=42,
+    )
+    assert req.figure_type == LockedFigureType.IMPACT_DAYS
+
+
+def test_confidence_preview_bounds_base_score() -> None:
+    from app.modules.schedule_intelligence.schemas import ConfidencePreviewRequest
+
+    ConfidencePreviewRequest(base_score=0.5)  # ok
+    with pytest.raises(ValidationError):
+        ConfidencePreviewRequest(base_score=1.5)
+    with pytest.raises(ValidationError):
+        ConfidencePreviewRequest(base_score=-0.1)
+
+
+def test_confidence_config_upsert_project_id_not_required() -> None:
+    from app.modules.schedule_intelligence.schemas import ConfidenceConfigUpsert
+
+    cfg = ConfidenceConfigUpsert(schedule_quality_caps={"poor": 0.3})
+    assert cfg.band_thresholds is None  # omitted facets stay unset → engine default
+    assert cfg.schedule_quality_caps == {"poor": 0.3}
+    _ = uuid4  # keep import parity with sibling tests

--- a/backend/tests/unit/test_oe_schedule_intelligence_readiness_engine.py
+++ b/backend/tests/unit/test_oe_schedule_intelligence_readiness_engine.py
@@ -1,0 +1,243 @@
+# DDC-CWICR-OE: DataDrivenConstruction · OpenConstructionERP
+"""E1 Readiness Engine — pure classification truth table + determinism.
+
+Unit tests for ``readiness_engine`` with no DB and no clock. Focus areas:
+    * the Ready / At-risk / Blocked truth table (every rule that fires),
+    * the correctness catch: raw ``cannot_clear`` rows classify as BLOCKED
+      (``schedule_advanced.constraint_ready_state`` would skip them),
+    * binding-constraint selection and P4 driver traceability,
+    * float-burn detection vs a prior snapshot,
+    * uniform E5.3 confidence + its degradation when CPM float is unresolved,
+    * determinism: identical inputs → identical verdict and ``run_digest``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from app.modules.schedule_intelligence.enums import ConfidenceBand, ReadinessClass
+from app.modules.schedule_intelligence.readiness_engine import (
+    AT_RISK_FLOAT_DAYS,
+    NEAR_HORIZON_DAYS,
+    ActivityInput,
+    ConstraintInput,
+    classify_activity,
+    evaluate_look_ahead,
+    run_digest,
+)
+
+TODAY = date(2026, 7, 15)
+
+
+def _c(ref: str, status: str, target: date | None = None, ctype: str = "material") -> ConstraintInput:
+    return ConstraintInput(ref=ref, status=status, target_clear_date=target, constraint_type=ctype)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# READY
+# ─────────────────────────────────────────────────────────────────────────────
+def test_no_constraints_healthy_float_is_ready() -> None:
+    v = classify_activity(ActivityInput(task_ref="t", constraints=(), total_float=10), TODAY)
+    assert v.classification is ReadinessClass.READY
+    assert v.binding_constraint_ref is None
+    assert v.drivers  # never empty — a "clear" driver is emitted
+
+
+def test_cleared_constraints_do_not_block() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(_c("c1", "cleared"), _c("c2", "cleared")), total_float=5),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.READY
+
+
+def test_unknown_float_but_no_constraints_is_ready() -> None:
+    v = classify_activity(ActivityInput(task_ref="t", constraints=()), TODAY)
+    assert v.classification is ReadinessClass.READY
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BLOCKED
+# ─────────────────────────────────────────────────────────────────────────────
+def test_cannot_clear_is_blocked_not_ready() -> None:
+    """The correctness catch: a raw ``cannot_clear`` row must block."""
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(_c("c1", "cannot_clear", ctype="permit"),), total_float=99),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.BLOCKED
+    assert v.binding_constraint_ref == "c1"
+    assert any(d["type"] == "constraint" and d["ref"] == "c1" for d in v.drivers)
+
+
+def test_open_constraint_targeting_after_need_by_is_blocked() -> None:
+    need_by = TODAY + timedelta(days=10)
+    late = need_by + timedelta(days=3)
+    v = classify_activity(
+        ActivityInput(
+            task_ref="t",
+            constraints=(_c("c1", "open", target=late),),
+            need_by_date=need_by,
+            total_float=20,
+        ),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.BLOCKED
+    assert v.binding_constraint_ref == "c1"
+
+
+def test_undated_open_constraint_near_horizon_is_blocked() -> None:
+    need_by = TODAY + timedelta(days=NEAR_HORIZON_DAYS - 1)
+    v = classify_activity(
+        ActivityInput(
+            task_ref="t",
+            constraints=(_c("c1", "open", target=None),),
+            need_by_date=need_by,
+            total_float=20,
+        ),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.BLOCKED
+
+
+def test_zero_float_with_open_blocker_is_blocked() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(_c("c1", "open"),), total_float=0),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.BLOCKED
+    assert any(d["type"] == "float" for d in v.drivers)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AT_RISK
+# ─────────────────────────────────────────────────────────────────────────────
+def test_open_constraint_clearing_in_time_is_at_risk() -> None:
+    need_by = TODAY + timedelta(days=30)
+    early = TODAY + timedelta(days=5)
+    v = classify_activity(
+        ActivityInput(
+            task_ref="t",
+            constraints=(_c("c1", "open", target=early),),
+            need_by_date=need_by,
+            total_float=20,
+        ),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.AT_RISK
+    assert v.binding_constraint_ref == "c1"
+
+
+def test_thin_float_alone_is_at_risk() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(), total_float=AT_RISK_FLOAT_DAYS),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.AT_RISK
+    assert any(d["type"] == "float" for d in v.drivers)
+
+
+def test_float_burn_vs_prior_snapshot_is_at_risk() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(), total_float=8, prior_float=12),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.AT_RISK
+    assert v.float_burn_days == 4  # lost 4 days of float since prior run
+    assert any(d["type"] == "float_burn" for d in v.drivers)
+
+
+def test_no_burn_when_float_grows_or_no_prior() -> None:
+    grew = classify_activity(ActivityInput(task_ref="t", constraints=(), total_float=15, prior_float=12), TODAY)
+    assert grew.classification is ReadinessClass.READY
+    assert grew.float_burn_days == -3  # gained float
+    first = classify_activity(ActivityInput(task_ref="t", constraints=(), total_float=15), TODAY)
+    assert first.float_burn_days is None
+
+
+def test_critical_activity_adds_criticality_driver() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(), total_float=1, is_critical=True),
+        TODAY,
+    )
+    assert v.classification is ReadinessClass.AT_RISK
+    assert any(d["type"] == "criticality" for d in v.drivers)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Binding selection & drivers (P4)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_binding_is_deterministic_by_ref_order() -> None:
+    v = classify_activity(
+        ActivityInput(
+            task_ref="t",
+            constraints=(_c("c9", "open"), _c("c2", "open"), _c("c5", "open")),
+        ),
+        TODAY,
+    )
+    # ref-sorted → the lowest ref binds, stably.
+    assert v.binding_constraint_ref == "c2"
+
+
+def test_every_driver_links_a_source_ref() -> None:
+    v = classify_activity(
+        ActivityInput(task_ref="t", constraints=(_c("c1", "open"),), total_float=1),
+        TODAY,
+    )
+    assert v.drivers
+    for d in v.drivers:
+        assert set(d) == {"type", "ref", "detail"}
+        assert d["ref"]  # non-empty
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Confidence (E5.3, uniform + degradation)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_confidence_is_high_with_resolved_float() -> None:
+    v = classify_activity(ActivityInput(task_ref="t", constraints=(), total_float=10), TODAY)
+    assert v.confidence.band is ConfidenceBand.HIGH
+    assert v.confidence.score == 0.9
+
+
+def test_confidence_degrades_when_float_unresolved() -> None:
+    resolved = classify_activity(ActivityInput(task_ref="t", constraints=(_c("c1", "open"),), total_float=10), TODAY)
+    unresolved = classify_activity(ActivityInput(task_ref="t", constraints=(_c("c1", "open"),)), TODAY)
+    assert unresolved.confidence.score < resolved.confidence.score
+    # The reduction is stated, never silent (P5).
+    assert any(r["step"] == "cap:feed_coverage" for r in unresolved.confidence.rationale)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Determinism (E1.1-AC6)
+# ─────────────────────────────────────────────────────────────────────────────
+def test_run_digest_is_order_independent_and_stable() -> None:
+    a = ActivityInput(task_ref="a", constraints=(_c("c1", "open", target=TODAY),), total_float=3)
+    b = ActivityInput(task_ref="b", constraints=(), total_float=10)
+    d1 = run_digest([a, b], TODAY)
+    d2 = run_digest([b, a], TODAY)
+    assert d1 == d2 and len(d1) == 64
+
+
+def test_run_digest_excludes_prior_float() -> None:
+    """Idempotency: a prior snapshot must not change the run id."""
+    base = ActivityInput(task_ref="a", constraints=(), total_float=5)
+    with_prior = ActivityInput(task_ref="a", constraints=(), total_float=5, prior_float=99)
+    assert run_digest([base], TODAY) == run_digest([with_prior], TODAY)
+
+
+def test_run_digest_changes_with_inputs() -> None:
+    a = ActivityInput(task_ref="a", constraints=(_c("c1", "open"),), total_float=5)
+    b = ActivityInput(task_ref="a", constraints=(_c("c1", "cannot_clear"),), total_float=5)
+    assert run_digest([a], TODAY) != run_digest([b], TODAY)
+
+
+def test_evaluate_look_ahead_is_sorted_and_deterministic() -> None:
+    acts = [
+        ActivityInput(task_ref="z", constraints=()),
+        ActivityInput(task_ref="a", constraints=(_c("c1", "cannot_clear"),)),
+        ActivityInput(task_ref="m", constraints=(_c("c2", "open"),)),
+    ]
+    r1 = evaluate_look_ahead(acts, TODAY)
+    r2 = evaluate_look_ahead(list(reversed(acts)), TODAY)
+    assert [r.task_ref for r in r1] == ["a", "m", "z"]
+    assert [r.classification for r in r1] == [r.classification for r in r2]


### PR DESCRIPTION
## Schedule Intelligence — Phase 0 (governance) + Phase 1 (E1 Readiness / "Watch")

This branch brings the new `oe_schedule_intelligence` module up through **Phase 1**. Phase 0 is included here because it is not yet on `main` and Phase 1 builds directly on it.

### Phase 0 — governance foundation (commits `ed3a5b33b`, `ec5ede138`)
- **E5.2 locked-figure guard** (`locked_guard.py`) — policy-as-code; once a figure is locked, no flow may change it (byte-identical re-writes pass).
- **E5.3 confidence framework** (`confidence.py`) — one uniform `score / band / rationale` for every insight; caps are a hard ceiling and always explained (never silent). Config-as-data (`confidence_config`, versioned).
- Data model, RBAC, and the governance API surface.

### Phase 1 — Readiness Engine (commit `643f70556`)
Turns `schedule_advanced`'s binary ready/not-ready into a deterministic **Ready / At-risk / Blocked** classification per look-ahead activity, persisted as `ReadinessResult` snapshots.

- **`readiness_engine.py`** — pure classifier (no I/O, no clock). `classify_activity` / `evaluate_look_ahead` apply a hardcoded truth table over raw constraints + best-effort CPM float. Each verdict carries a `binding_constraint_ref`, traceable `drivers[]` (P4), a `float_burn` delta vs the prior snapshot, and a uniform E5.3 confidence. `run_digest` hashes the canonical inputs into a deterministic `evaluation_run_id` so re-runs are idempotent (E1.1-AC6).
- **Correctness catch:** `cannot_clear → BLOCKED` is handled here on raw rows, because `schedule_advanced.constraint_ready_state` treats `cannot_clear` as *not open* and would call a permanently-blocked activity "ready". Open-blocker subset is exactly `{open, in_progress, escalated}`.
- **`service.evaluate_readiness`** — derives the look-ahead's project for the IDOR check (foreign/missing look-ahead → 404), pulls constraints from `schedule_advanced`, resolves best-effort CPM float (one swappable `_resolve_float` against `oe_schedule_activity`), runs the engine under the project's confidence policy, and snapshots one idempotent run. `list_readiness` returns the latest run.
- **API:** `POST …/projects/{id}/look-aheads/{la}/readiness/evaluate` (gated `.watch`) and `GET …/projects/{id}/readiness` (gated `.read`). New permission `schedule_intelligence.watch = EDITOR`.

The `task_ref ↔ schedule-activity` float join is intentionally best-effort for the MVP: unresolved float degrades confidence (never silently), and `_resolve_float` is the single swap-point when a richer mapping lands.

### Tests
- **20 unit** (`test_oe_schedule_intelligence_readiness_engine.py`) — truth table, determinism, `cannot_clear→BLOCKED`, binding selection, confidence degradation.
- **7 integration** (`test_oe_schedule_intelligence_readiness_db.py`) — persist, GET latest, idempotent re-run, foreign/missing look-ahead 404, best-effort float join + float-burn across runs.

All 27 new tests pass (plus the 22 Phase 0 tests) when run scoped. Note: the whole-tree `make module-test` collection currently hits a pre-existing embedded-PostgreSQL teardown race that errors the integration tests (Phase 0 tests included) — unrelated to this change; scoped runs are green.

_No migration:_ `readiness_result` already ships in the module's v0001 draft; dev materialises tables via boot-time `create_all`.
