### PR TITLE
probe: prove the gate lane build step can go red (throwaway, do not merge)

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,3 +1,5 @@
+import { thisModuleDoesNotExist } from './ci-build-gate-redness-probe-missing-module';
+void thisModuleDoesNotExist;
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider, MutationCache, QueryCache } from '@tanstack/react-query';


### PR DESCRIPTION
Throwaway probe. The frontend job of CI (PostgreSQL) gained a vite build step in 6985772ad and nothing had yet shown it able to fail. This branch carries one unresolvable import in frontend/src/main.tsx so the build step has to refuse it.

Reading it for: the build step failing rather than install or the existence check, the named test step still running instead of going skipped, and the two tests/pwa files failing with no build output to inspect.

Every other lane on this PR is red by construction. Closing and deleting the branch as soon as the run is read.